### PR TITLE
CI/CDパイプラインの構築

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: build
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Setup
+      run: make setup
+
+    - name: Verify Go Formatting
+      run: |
+        make fmt
+        git diff --exit-code
+
+    - name: Lint
+      run: make lint
+
+    - name: Depcheck
+      run: make depcheck
+
+    - name: Test
+      run: make test
+
+    - name: Build
+      run: make build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,25 @@
+name: e2e
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+
+    - name: E2E Test
+      run: make test-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v7
+      with:
+        distribution: goreleaser
+        version: "~> v2"
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - -s -w -X github.com/canpok1/vox-actor/cmd.version={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ lint:
 depcheck:
 	go vet -vettool=$$(which depcheck) ./...
 
+test-e2e:
+	go test -tags=e2e ./test/e2e/...
+
 all: build
 
-.PHONY: all setup build clean test fmt lint depcheck
+.PHONY: all setup build clean test test-e2e fmt lint depcheck

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,10 +4,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version = "dev"
+
 func makeRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "vox-actor",
-		Short: "AIエージェント構築フレームワークのCLIツール",
+		Use:     "vox-actor",
+		Short:   "AIエージェント構築フレームワークのCLIツール",
+		Version: version,
 	}
 	cmd.SilenceUsage = true
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -34,6 +34,36 @@ func TestHelp_ContainsCommandName(t *testing.T) {
 	}
 }
 
+func TestVersion_DefaultIsDev(t *testing.T) {
+	if version != "dev" {
+		t.Errorf("expected default version to be 'dev', got: %s", version)
+	}
+}
+
+func TestRootCmd_HasVersion(t *testing.T) {
+	rootCmd := makeRootCmd()
+	if rootCmd.Version != version {
+		t.Errorf("expected Version to be '%s', got: '%s'", version, rootCmd.Version)
+	}
+}
+
+func TestVersion_Flag(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"--version"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Execute() with --version returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, version) {
+		t.Errorf("expected version output to contain '%s', got: %s", version, output)
+	}
+}
+
 func TestHelp_ShowsHelpOutput(t *testing.T) {
 	rootCmd := makeRootCmd()
 	buf := new(bytes.Buffer)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,40 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+var binaryPath string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "vox-actor-e2e-*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	binaryPath = filepath.Join(dir, "vox-actor")
+	cmd := exec.Command("go", "build", "-o", binaryPath, "github.com/canpok1/vox-actor")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		panic("failed to build binary: " + err.Error())
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestCLIVersion(t *testing.T) {
+	cmd := exec.Command(binaryPath, "--version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run CLI: %v\n%s", err, out)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected version output, got empty")
+	}
+}


### PR DESCRIPTION
## Summary

- GitHub ActionsとGoReleaserを組み合わせたCI/CDパイプラインを構築
- build/release/e2eの3つのワークフローを追加
- cmd/root.goにversion変数を追加し、GoReleaserのldflagsでバージョン埋め込みに対応

## 成果物

- `.github/workflows/build.yml` - push時: fmt → lint → depcheck → test → build
- `.github/workflows/release.yml` - タグpush時: GoReleaserリリース
- `.github/workflows/e2e.yml` - PR時 + main push時: E2Eテスト
- `.goreleaser.yaml` - linux/windows/darwin向けビルド、ldflagsでバージョン埋め込み
- `test/e2e/e2e_test.go` - E2Eテストスケルトン
- `Makefile` - test-e2eターゲット追加
- `cmd/root.go` - version変数追加

## Test plan

- [ ] GitHub上でCIが通ることを確認
- [ ] `make test` でユニットテストが通ること
- [ ] `make test-e2e` でE2Eテストが通ること

Closes #6

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * CLIでバージョン表示機能を追加しました。

* **Chores**
  * CI/CDパイプラインを構築し、自動テストと自動リリース処理を実装しました。
  * ビルド設定とリリース設定を追加しました。

* **Tests**
  * エンドツーエンドテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->