### PR TITLE
バージョンタグ自動作成ワークフローの構築

### DIFF
--- a/.github/workflows/version-tagging.yml
+++ b/.github/workflows/version-tagging.yml
@@ -1,0 +1,49 @@
+name: version-tagging
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  create-version-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.create-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create and push version tag
+        run: ./scripts/create-version-tag.sh
+
+      - name: Get created tag
+        id: create-tag
+        run: echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+
+  # タグ作成後にリリースを実行
+  # GITHUB_TOKENでプッシュされたタグは他のワークフローをトリガーしないため
+  # version-tagging内で直接リリース処理を行う
+  release:
+    needs: create-version-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.create-version-tag.outputs.tag }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/create-version-tag.sh
+++ b/scripts/create-version-tag.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# mainブランチにバージョンタグを付与するスクリプト
+# 最新のリリースバージョンのパッチバージョンを1つ進めたタグを作成する
+#
+# 使用方法:
+#   ./scripts/create-version-tag.sh           # 実際にタグを作成してプッシュ
+#   ./scripts/create-version-tag.sh --dry-run # ドライランモード（タグ作成・プッシュをスキップ）
+
+set -euo pipefail
+
+DRY_RUN=false
+
+# 引数の解析
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            echo "不明なオプション: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# 最新のバージョンタグを取得（セマンティックバージョニング形式、プレリリースタグを除外）
+# pipefail環境でのSIGPIPE問題を回避するため、grepの結果を一度変数に格納
+ALL_TAGS=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; })
+LATEST_TAG=$(echo "$ALL_TAGS" | head -n 1)
+
+if [[ -z "$LATEST_TAG" ]]; then
+    echo "最新のタグが見つかりません。初期バージョン v0.0.1 を使用します。"
+    NEW_VERSION="v0.0.1"
+else
+    echo "最新のタグ: $LATEST_TAG"
+
+    # バージョン番号を解析（vプレフィックスを除去）
+    IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST_TAG#v}"
+
+    # パッチバージョンをインクリメント
+    NEW_PATCH=$((PATCH + 1))
+    NEW_VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}"
+fi
+
+echo "新しいバージョン: $NEW_VERSION"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[ドライラン] タグの作成とプッシュをスキップします。"
+else
+    # タグを作成
+    git tag "$NEW_VERSION"
+    echo "タグ $NEW_VERSION を作成しました。"
+
+    # タグをプッシュ
+    git push origin "$NEW_VERSION"
+    echo "タグ $NEW_VERSION をプッシュしました。"
+fi

--- a/scripts/create-version-tag_test.sh
+++ b/scripts/create-version-tag_test.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# create-version-tag.sh のテスト
+# --dry-run モードを使ってテストする
+#
+# テストリスト:
+# DONE: タグが存在しない場合、v0.0.1 を新しいバージョンとする
+# DONE: v0.0.1 が存在する場合、v0.0.2 を新しいバージョンとする
+# DONE: v1.2.3 が存在する場合、v1.2.4 を新しいバージョンとする
+# DONE: プレリリースタグ（v1.0.0-rc1）が存在する場合、無視される
+# DONE: 複数タグが存在する場合、最新のものからインクリメントする
+# DONE: --dry-run モードではタグの作成・プッシュをスキップする
+# DONE: 不明なオプションが渡された場合、エラー終了する
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_UNDER_TEST="${SCRIPT_DIR}/create-version-tag.sh"
+
+# テスト用の一時ディレクトリ
+TEST_DIR=""
+
+# テスト結果カウンタ
+PASSED=0
+FAILED=0
+
+# セットアップ: テスト用のgitリポジトリを作成
+setup() {
+    TEST_DIR=$(mktemp -d)
+    cd "$TEST_DIR"
+    git init --initial-branch=main
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    # 最低1つのコミットが必要
+    echo "initial" > README.md
+    git add README.md
+    git commit -m "Initial commit"
+}
+
+# クリーンアップ
+teardown() {
+    cd /
+    rm -rf "$TEST_DIR"
+}
+
+# アサーション: 出力に文字列が含まれるか
+assert_output_contains() {
+    local expected="$1"
+    local actual="$2"
+    if echo "$actual" | grep -qF "$expected"; then
+        return 0
+    else
+        echo "  FAIL: 出力に '$expected' が含まれていません"
+        echo "  実際の出力: $actual"
+        return 1
+    fi
+}
+
+# アサーション: 終了コードの確認
+assert_exit_code() {
+    local expected="$1"
+    local actual="$2"
+    if [[ "$actual" -eq "$expected" ]]; then
+        return 0
+    else
+        echo "  FAIL: 終了コードが $expected ではなく $actual です"
+        return 1
+    fi
+}
+
+# テスト実行ヘルパー
+run_test() {
+    local test_name="$1"
+    local test_func="$2"
+
+    echo "--- $test_name"
+    setup
+    if $test_func; then
+        echo "  PASS"
+        PASSED=$((PASSED + 1))
+    else
+        echo "  FAIL"
+        FAILED=$((FAILED + 1))
+    fi
+    teardown
+}
+
+# ====================
+# テストケース
+# ====================
+
+echo "=== create-version-tag.sh テスト ==="
+
+# テスト1: タグが存在しない場合、v0.0.1 を新しいバージョンとする
+test_no_existing_tags() {
+    local output
+    output=$("$SCRIPT_UNDER_TEST" --dry-run 2>&1)
+    assert_output_contains "新しいバージョン: v0.0.1" "$output"
+}
+run_test "タグが存在しない場合、v0.0.1を新しいバージョンとする" test_no_existing_tags
+
+# テスト2: v0.0.1 が存在する場合、v0.0.2 を新しいバージョンとする
+test_increment_patch_from_001() {
+    git tag v0.0.1
+    local output
+    output=$("$SCRIPT_UNDER_TEST" --dry-run 2>&1)
+    assert_output_contains "新しいバージョン: v0.0.2" "$output"
+}
+run_test "v0.0.1が存在する場合、v0.0.2を新しいバージョンとする" test_increment_patch_from_001
+
+# テスト3: v1.2.3 が存在する場合、v1.2.4 を新しいバージョンとする
+test_increment_patch_from_123() {
+    git tag v1.2.3
+    local output
+    output=$("$SCRIPT_UNDER_TEST" --dry-run 2>&1)
+    assert_output_contains "新しいバージョン: v1.2.4" "$output"
+}
+run_test "v1.2.3が存在する場合、v1.2.4を新しいバージョンとする" test_increment_patch_from_123
+
+# テスト4: プレリリースタグが存在する場合、無視される
+test_ignore_prerelease_tags() {
+    git tag v1.0.0-rc1
+    local output
+    output=$("$SCRIPT_UNDER_TEST" --dry-run 2>&1)
+    # プレリリースタグしかないので、v0.0.1 になるはず
+    assert_output_contains "新しいバージョン: v0.0.1" "$output"
+}
+run_test "プレリリースタグが存在する場合、無視される" test_ignore_prerelease_tags
+
+# テスト5: 複数タグが存在する場合、最新のものからインクリメントする
+test_multiple_tags_uses_latest() {
+    git tag v0.1.0
+    git tag v0.2.0
+    git tag v0.1.5
+    local output
+    output=$("$SCRIPT_UNDER_TEST" --dry-run 2>&1)
+    # v0.2.0 が最新なので、v0.2.1 になるはず
+    assert_output_contains "新しいバージョン: v0.2.1" "$output"
+}
+run_test "複数タグが存在する場合、最新のものからインクリメントする" test_multiple_tags_uses_latest
+
+# テスト6: --dry-run モードではタグの作成・プッシュをスキップする
+test_dry_run_skips_tag_creation() {
+    local output
+    output=$("$SCRIPT_UNDER_TEST" --dry-run 2>&1)
+    assert_output_contains "[ドライラン] タグの作成とプッシュをスキップします。" "$output"
+    # タグが作成されていないことを確認
+    local tag_count
+    tag_count=$(git tag -l | wc -l)
+    if [[ "$tag_count" -ne 0 ]]; then
+        echo "  FAIL: ドライランモードでタグが作成されています（タグ数: $tag_count）"
+        return 1
+    fi
+}
+run_test "--dry-runモードではタグの作成・プッシュをスキップする" test_dry_run_skips_tag_creation
+
+# テスト7: 不明なオプションが渡された場合、エラー終了する
+test_unknown_option_exits_with_error() {
+    local output
+    local exit_code=0
+    output=$("$SCRIPT_UNDER_TEST" --unknown 2>&1) || exit_code=$?
+    assert_exit_code 1 "$exit_code" && assert_output_contains "不明なオプション: --unknown" "$output"
+}
+run_test "不明なオプションが渡された場合、エラー終了する" test_unknown_option_exits_with_error
+
+# テスト結果のサマリー
+print_summary() {
+    echo ""
+    echo "=== テスト結果 ==="
+    echo "PASSED: $PASSED"
+    echo "FAILED: $FAILED"
+    if [[ "$FAILED" -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+trap print_summary EXIT


### PR DESCRIPTION
## Summary

- workflow_dispatchでセマンティックバージョニングに基づくタグを自動生成し、GoReleaserリリースを起動するワークフローを追加
- パッチバージョン自動インクリメントスクリプト（`scripts/create-version-tag.sh`）を追加
- テスト7ケース（`scripts/create-version-tag_test.sh`）を追加

## 成果物

| ファイル | 説明 |
|---------|------|
| `.github/workflows/version-tagging.yml` | workflow_dispatch → タグ生成 → リリース |
| `scripts/create-version-tag.sh` | パッチバージョン自動インクリメント |
| `scripts/create-version-tag_test.sh` | テスト7ケース |

## 仕様

- タグが存在しない場合は `v0.0.1` から開始
- 既存タグがある場合はパッチバージョンをインクリメント（例: `v1.2.3` → `v1.2.4`）
- プレリリースタグ（`v1.0.0-rc1` など）は無視
- GITHUB_TOKENでプッシュされたタグは他のワークフローをトリガーしないため、version-tagging内で直接リリースジョブも実行

## Test plan

- [x] テスト7ケースすべてパス確認済み
- [ ] workflow_dispatchでタグが作成されることを確認

Closes #7

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)