### PR TITLE
actサブコマンドのUsage表示から冗長な[options]を削除

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -16,7 +16,7 @@ type ActDeps struct {
 
 func makeActCmd(deps *ActDeps) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "act [options] <path>",
+		Use:   "act <path>",
 		Short: "テキストファイルを読み上げる",
 		Long:  "テキストファイルを読み込み、VOICEVOXエンジンで音声合成して再生する。",
 		Args: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- `act`サブコマンドのヘルプ表示で `[options]` と `[flags]` が重複していた問題を修正
- cobraが自動付与する `[flags]` のみを使用するよう `Use` フィールドを変更
- 修正前: `vox-actor act [options] <path> [flags]`
- 修正後: `vox-actor act <path> [flags]`

## Test plan
- [x] `go run main.go act --help` で表示が `vox-actor act <path> [flags]` となることを確認済み

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * act コマンドのヘルプテキストを簡潔に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->