### PR TITLE
watchモードで処理済みファイルと同名の再配置を再検知する #68

### DIFF
--- a/internal/infra/dir_watcher.go
+++ b/internal/infra/dir_watcher.go
@@ -49,6 +49,17 @@ func (w *PollingDirWatcher) Watch(ctx context.Context, dir string) (<-chan strin
 				continue
 			}
 
+			// seenマップからディレクトリに存在しなくなったファイルを削除
+			currentFiles := make(map[string]bool, len(files))
+			for _, f := range files {
+				currentFiles[f] = true
+			}
+			for f := range seen {
+				if !currentFiles[f] {
+					delete(seen, f)
+				}
+			}
+
 			for _, f := range files {
 				if seen[f] {
 					continue

--- a/internal/infra/dir_watcher_test.go
+++ b/internal/infra/dir_watcher_test.go
@@ -136,6 +136,55 @@ func TestPollingDirWatcher_DoesNotDuplicateFiles(t *testing.T) {
 	}
 }
 
+func TestPollingDirWatcher_RedetectsFileAfterRemovalAndReplacement(t *testing.T) {
+	dir := t.TempDir()
+
+	watcher := infra.NewPollingDirWatcher(50 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// ファイルを作成
+	filePath := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(filePath, []byte("first"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fileCh, _ := watcher.Watch(ctx, dir)
+
+	// 1回目の検出
+	select {
+	case f := <-fileCh:
+		if filepath.Base(f) != "test.txt" {
+			t.Fatalf("expected test.txt, got %s", filepath.Base(f))
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for first detection")
+	}
+
+	// ファイルを削除（done/への移動をシミュレート）
+	if err := os.Remove(filePath); err != nil {
+		t.Fatal(err)
+	}
+
+	// ポーリングが削除を検知するのを待つ
+	time.Sleep(150 * time.Millisecond)
+
+	// 同名ファイルを再配置
+	if err := os.WriteFile(filePath, []byte("second"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2回目の検出（再配置されたファイルが検知されるべき）
+	select {
+	case f := <-fileCh:
+		if filepath.Base(f) != "test.txt" {
+			t.Fatalf("expected test.txt on re-detection, got %s", filepath.Base(f))
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for re-detection of replaced file")
+	}
+}
+
 func TestPollingDirWatcher_StopsOnContextCancel(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- watchモードの`seen`マップからディレクトリに存在しなくなったファイルのエントリを削除するように修正
- ポーリングのたびに現在のファイル一覧と`seen`マップを比較し、消えたファイルを`seen`から除外
- ファイル削除→同名ファイル再配置の再検知を確認するテストを追加

Closes #68

## Test plan

- [x] 既存テスト全てPASS（`go test -v -race ./internal/infra/`）
- [x] 新規テスト `TestPollingDirWatcher_RedetectsFileAfterRemovalAndReplacement` がPASS
- [x] `golangci-lint run` で指摘なし
- [x] `gofmt -l .` で出力なし

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ファイルが削除された後に同じ名前で再作成された場合、ファイル監視機能が正しく検出するように改善しました。

* **Tests**
  * ファイル削除・再作成後の再検出シナリオに関するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->