### PR TITLE
JSONL朗読劇モード（.jsonl）の実装 #62

### DIFF
--- a/internal/infra/file_reader.go
+++ b/internal/infra/file_reader.go
@@ -26,13 +26,27 @@ var supportedExts = map[string]bool{
 	".jsonl": true,
 }
 
-// jsonScript は .json ファイルの台本データを表す。
+// jsonScript は .json / .jsonl ファイルの台本データを表す。
 type jsonScript struct {
 	Text            *string  `json:"text"`
 	Speaker         *int     `json:"speaker"`
 	SpeedScale      *float64 `json:"speedScale"`
 	PitchScale      *float64 `json:"pitchScale"`
 	IntonationScale *float64 `json:"intonationScale"`
+}
+
+// toScript は jsonScript を entity.Script に変換する。
+func (js *jsonScript) toScript(path string) entity.Script {
+	text := *js.Text
+	return entity.Script{
+		Path:            path,
+		Text:            text,
+		IsEmpty:         len(text) == 0,
+		SpeakerID:       js.Speaker,
+		SpeedScale:      js.SpeedScale,
+		PitchScale:      js.PitchScale,
+		IntonationScale: js.IntonationScale,
+	}
 }
 
 // FileReader はファイルシステムから台本を読み込む。
@@ -123,18 +137,7 @@ func (r *FileReader) readJSONFile(path string) ([]entity.Script, error) {
 		return nil, fmt.Errorf("missing required field 'text' in %s", path)
 	}
 
-	text := *js.Text
-	return []entity.Script{
-		{
-			Path:            path,
-			Text:            text,
-			IsEmpty:         len(text) == 0,
-			SpeakerID:       js.Speaker,
-			SpeedScale:      js.SpeedScale,
-			PitchScale:      js.PitchScale,
-			IntonationScale: js.IntonationScale,
-		},
-	}, nil
+	return []entity.Script{js.toScript(path)}, nil
 }
 
 func (r *FileReader) readJSONLFile(path string) ([]entity.Script, error) {
@@ -160,22 +163,21 @@ func (r *FileReader) readJSONLFile(path string) ([]entity.Script, error) {
 			slog.Warn("invalid JSON line (skipping)", "path", path, "line", lineNum, "error", err)
 			continue
 		}
+		if err := dec.Decode(&struct{}{}); err != io.EOF {
+			slog.Warn("trailing data in JSON line (skipping)", "path", path, "line", lineNum)
+			continue
+		}
 
 		if js.Text == nil {
 			slog.Warn("missing required field 'text' (skipping)", "path", path, "line", lineNum)
 			continue
 		}
 
-		text := *js.Text
-		scripts = append(scripts, entity.Script{
-			Path:            path,
-			Text:            text,
-			IsEmpty:         len(text) == 0,
-			SpeakerID:       js.Speaker,
-			SpeedScale:      js.SpeedScale,
-			PitchScale:      js.PitchScale,
-			IntonationScale: js.IntonationScale,
-		})
+		scripts = append(scripts, js.toScript(path))
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", path, err)
 	}
 
 	if scripts == nil {

--- a/internal/infra/file_reader_test.go
+++ b/internal/infra/file_reader_test.go
@@ -20,6 +20,18 @@ package infra_test
 // DONE: 異常系: .jsonファイルが不正なJSONの場合、エラーを返す
 // DONE: 異常系: .jsonファイルにtextフィールドがない場合、エラーを返す
 // DONE: 異常系: .jsonファイルに未知フィールドがある場合、エラーを返す
+//
+// JSONL朗読劇モード:
+// DONE: 正常系: .jsonlファイルを行ごとに解析し複数のScriptを返す
+// DONE: 正常系: .jsonlファイルでtextのみ指定した場合、任意パラメータはnilのScriptを返す
+// DONE: 正常系: .jsonlファイルで全パラメータ指定した場合、全て反映されたScriptを返す
+// DONE: 正常系: .jsonlファイルの空行はスキップされる
+// DONE: 正常系: ディレクトリ読み込み時に.jsonlファイルも対象になる
+// DONE: 正常系: .jsonlファイルが1行のみでも正しく解析される
+// DONE: 異常系: 不正なJSON行はスキップされる
+// DONE: 異常系: textフィールドがない行はスキップされる
+// DONE: 異常系: 全行が不正な場合は空スライスを返す
+// DONE: 異常系: trailing dataがある行はスキップされる
 
 import (
 	"os"
@@ -690,6 +702,36 @@ func TestFileReader_Read_JSONLFile_MissingTextSkipped(t *testing.T) {
 
 	if len(scripts) != 2 {
 		t.Fatalf("expected 2 scripts (missing text skipped), got %d", len(scripts))
+	}
+
+	if scripts[0].Text != "valid" {
+		t.Errorf("expected text %q, got %q", "valid", scripts[0].Text)
+	}
+	if scripts[1].Text != "also valid" {
+		t.Errorf("expected text %q, got %q", "also valid", scripts[1].Text)
+	}
+}
+
+func TestFileReader_Read_JSONLFile_TrailingDataSkipped(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "script.jsonl")
+	content := `{"text": "valid"}
+{"text": "ok"} garbage
+{"text": "also valid"}`
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := infra.NewFileReader()
+	scripts, err := reader.Read(filePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(scripts) != 2 {
+		t.Fatalf("expected 2 scripts (trailing data line skipped), got %d", len(scripts))
 	}
 
 	if scripts[0].Text != "valid" {


### PR DESCRIPTION
## Summary
- `file_reader.go` に `readJSONLFile` メソッドを追加し、`.jsonl` ファイルを行ごとにJSONとして解析して複数の `entity.Script` を返す
- `supportedExts` に `.jsonl` を追加し、ディレクトリ読み込み時にも対象に含める
- 不正なJSON行や `text` フィールドが欠落した行は `slog.Warn` でログ出力してスキップ

## Test plan
- [x] 複数行のJSONLファイルが正しく複数Scriptに解析される
- [x] textのみ指定の行はオプショナルパラメータがnil
- [x] 全パラメータ指定の行は全て反映される
- [x] 空行はスキップされる
- [x] ディレクトリ読み込み時に `.jsonl` も対象になる
- [x] 1行だけのJSONLも正しく処理される
- [x] 不正なJSON行はスキップされる
- [x] textフィールドがない行はスキップされる
- [x] 全行が不正な場合、空スライスを返す
- [x] `go test -v -race ./...` PASS
- [x] `golangci-lint run` 0 issues

Closes #62

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * JSON Lines (.jsonl) ファイル形式のサポートを追加しました。新しいファイル形式により、行ごとのデータ処理に対応しています。
  * 複数ファイル形式の処理精度を向上させ、無効なデータのスキップと適切なエラーログを実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->