### PR TITLE
PlayAndWaitのcontext対応でオーディオデバイス不在時のハングを修正 #81

### DIFF
--- a/internal/infra/beep_player.go
+++ b/internal/infra/beep_player.go
@@ -19,7 +19,8 @@ type speakerBackend interface {
 	// Init はスピーカーを初期化する。
 	Init(sampleRate beep.SampleRate, bufferSize int) error
 	// PlayAndWait はStreamerを再生し、完了まで待機する。
-	PlayAndWait(s beep.Streamer)
+	// contextがキャンセルされた場合は再生を中断しエラーを返す。
+	PlayAndWait(ctx context.Context, s beep.Streamer) error
 }
 
 // BeepPlayer はgopxl/beepライブラリを使用してWAVバイト列を再生する。
@@ -77,7 +78,5 @@ func (p *BeepPlayer) Play(ctx context.Context, wavData []byte) error {
 	default:
 	}
 
-	p.backend.PlayAndWait(streamer)
-
-	return nil
+	return p.backend.PlayAndWait(ctx, streamer)
 }

--- a/internal/infra/beep_player_test.go
+++ b/internal/infra/beep_player_test.go
@@ -9,10 +9,16 @@ package infra
 // DONE: 異常系: backendがnilの場合、NewBeepPlayerがエラーを返す
 // DONE: 正常系: 有効なWAVデータでInit/PlayAndWaitが呼ばれること
 // DONE: 異常系: キャンセル済みcontextで即時エラーを返すこと
+//
+// PlayAndWait context対応 (#81)
+// DONE: 正常系: PlayAndWaitにcontextが渡され、正常完了時にnilが返ること
+// DONE: 異常系: PlayAndWait中にcontextがキャンセルされた場合、context.Canceledが返ること
+// DONE: 異常系: PlayAndWaitがエラーを返した場合、Play()がそのエラーを返すこと
 
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"testing"
 
 	"github.com/canpok1/vox-actor/internal/app"
@@ -23,6 +29,8 @@ import (
 type mockSpeakerBackend struct {
 	initCalled bool
 	playCalled bool
+	playErr    error
+	playCtx    context.Context
 }
 
 func (m *mockSpeakerBackend) Init(_ beep.SampleRate, _ int) error {
@@ -30,8 +38,10 @@ func (m *mockSpeakerBackend) Init(_ beep.SampleRate, _ int) error {
 	return nil
 }
 
-func (m *mockSpeakerBackend) PlayAndWait(_ beep.Streamer) {
+func (m *mockSpeakerBackend) PlayAndWait(ctx context.Context, _ beep.Streamer) error {
 	m.playCalled = true
+	m.playCtx = ctx
+	return m.playErr
 }
 
 func TestBeepPlayer_ImplementsAudioPlayer(t *testing.T) {
@@ -130,6 +140,63 @@ func TestBeepPlayer_Play_CancelledContext(t *testing.T) {
 	}
 	if err != context.Canceled {
 		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+}
+
+func TestBeepPlayer_Play_PlayAndWaitReceivesContext(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSpeakerBackend{}
+	player, err := NewBeepPlayer(mock)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ctx := context.Background()
+	wavData := createMinimalWAV(t)
+	err = player.Play(ctx, wavData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mock.playCtx != ctx {
+		t.Error("expected PlayAndWait to receive the same context passed to Play")
+	}
+}
+
+func TestBeepPlayer_Play_PlayAndWaitCancelledDuringPlay(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSpeakerBackend{playErr: context.Canceled}
+	player, err := NewBeepPlayer(mock)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wavData := createMinimalWAV(t)
+	err = player.Play(context.Background(), wavData)
+	if err == nil {
+		t.Fatal("expected error when PlayAndWait returns context.Canceled, got nil")
+	}
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+}
+
+func TestBeepPlayer_Play_PlayAndWaitReturnsError(t *testing.T) {
+	t.Parallel()
+
+	playErr := fmt.Errorf("audio device not available")
+	mock := &mockSpeakerBackend{playErr: playErr}
+	player, err := NewBeepPlayer(mock)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wavData := createMinimalWAV(t)
+	err = player.Play(context.Background(), wavData)
+	if err == nil {
+		t.Fatal("expected error when PlayAndWait fails, got nil")
 	}
 }
 

--- a/internal/infra/speaker_backend.go
+++ b/internal/infra/speaker_backend.go
@@ -1,6 +1,9 @@
 package infra
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/gopxl/beep/v2"
 	"github.com/gopxl/beep/v2/speaker"
 )
@@ -17,10 +20,15 @@ func (r *realSpeakerBackend) Init(sampleRate beep.SampleRate, bufferSize int) er
 	return speaker.Init(sampleRate, bufferSize)
 }
 
-func (r *realSpeakerBackend) PlayAndWait(s beep.Streamer) {
+func (r *realSpeakerBackend) PlayAndWait(ctx context.Context, s beep.Streamer) error {
 	done := make(chan struct{})
 	speaker.Play(beep.Seq(s, beep.Callback(func() {
 		close(done)
 	})))
-	<-done
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("playback cancelled: %w", ctx.Err())
+	}
 }


### PR DESCRIPTION
## Summary

- `speakerBackend.PlayAndWait` に `context.Context` 引数と `error` 戻り値を追加
- `realSpeakerBackend.PlayAndWait` で `select` により `ctx.Done()` と再生完了チャネルを同時に監視し、コンテキストキャンセル時に即座に返却
- `BeepPlayer.Play` から `PlayAndWait` に `ctx` を伝播し、戻り値の `error` をそのまま返却
- テストケース3件追加（context伝播、キャンセル時エラー、エラー伝播）

## 変更ファイル

- `internal/infra/beep_player.go` — インターフェース変更、Play メソッドの簡素化
- `internal/infra/speaker_backend.go` — context 対応の select 実装
- `internal/infra/beep_player_test.go` — 新規テスト3件追加

## Test plan

- [x] `go test -v -race ./...` 全テスト PASS
- [x] `golangci-lint run` 指摘なし

Closes #81

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * オーディオ再生操作のキャンセル機能をサポート
  * 再生エラーのハンドリングを強化し、エラー情報をより正確に伝播
  * 音声再生システムの信頼性と制御性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->