### PR TITLE
create-issueとsolve-issueからcontext: forkを削除 #89

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: create-issue
 description: ユーザーが `/create-issue` で手動実行した場合のみ使用。ユーザーとの会話で仕様を整理し、GitHub Issueを作成する。実装は行わない。
-context: fork
 agent: general-purpose
 allowed-tools: Bash(gh issue create *), Read, Grep, Glob, WebSearch, WebFetch, AskUserQuestion
 disable-model-invocation: false

--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: solve-issue
 description: ユーザーが `/solve-issue` で手動実行した場合のみ使用。GitHub Issueの対応を行うスキル。実装、自己レビュー、PR作成、マージ、振り返りまで一連の流れを一気に行う。
-context: fork
 agent: general-purpose
 allowed-tools: Skill, Agent, Bash, Read, Grep, Glob, Write, Edit
 disable-model-invocation: true


### PR DESCRIPTION
## Summary

- `create-issue` スキルのSKILL.mdからfrontmatterの `context: fork` 行を削除
- `solve-issue` スキルのSKILL.mdからfrontmatterの `context: fork` 行を削除
- ユーザー対話型スキルはメインコンテキストで実行する方が適切なため

## Test plan

- [ ] `create-issue` スキルが `/create-issue` で正常に起動することを確認
- [ ] `solve-issue` スキルが `/solve-issue` で正常に起動することを確認
- [ ] 他のスキル（assign-issues, fix-pr, review, tdd）の `context: fork` が維持されていることを確認

Closes #89

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * スキル設定ファイルから不要なフィールドを削除し、構成を簡潔化しました。機能的な変更はなく、メンテナンスの改善です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->