### PR TITLE
fix-prスキル: CodeRabbitのapprove漏れ時にapprove依頼コメントを投稿する #107

### DIFF
--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -38,8 +38,47 @@ PR $ARGUMENTS に対して、CI待機・レビュー対応・マージを行い�
 |---|---|---|
 | `0` | マージ完了 | 完了。ユーザーに結果を報告 |
 | `1` | コンフリクト要解消 | AIがコンフリクトを解消 → コミット・プッシュ → フロー先頭（ステップ1）に戻る |
-| `2` | 未解決レビュー/CHANGES_REQUESTEDが原因 | `/pr-comments` スキルでレビューコメントを取得し対応 → コミット・プッシュ → フロー先頭（ステップ1）に戻る（※ステップ1のwait-coderabbit.shがCHANGES_REQUESTED検知時に `@coderabbitai resolve` を自動投稿する） |
+| `2` | 未解決レビュー/CHANGES_REQUESTEDが原因 | ステップ3aへ進む |
 | `3` | その他エラー | AIがstderrのエラー内容を分析・対応を試行 → 解決ならフロー先頭（ステップ1）に戻る → 解決不可ならユーザーに通知して中断 |
+
+### ステップ3a: CodeRabbitのapprove漏れチェック（exit 2の場合）
+
+exit 2の場合、レビューコメント対応の**前に**、CodeRabbitがレビュー完了済みなのにapproveし忘れていないかをチェックする。
+
+#### 情報収集
+
+以下のコマンドでCodeRabbitのレビュー状態を取得する:
+
+```bash
+# CodeRabbitの最新レビュー状態を取得
+gh pr view --repo <REPO> <PR番号> --json reviews --jq '[.reviews[] | select(.author.login=="coderabbitai")] | last'
+
+# CodeRabbitのレビューコメント（サマリー）を取得
+gh pr view --repo <REPO> <PR番号> --json comments --jq '[.comments[] | select(.author.login=="coderabbitai")] | last | .body'
+```
+
+#### AI判断
+
+取得した情報をもとに、以下の基準で判断する:
+
+- **approve漏れと判断する条件**（以下をすべて満たす場合）:
+  - CodeRabbitのレビューが存在するが、状態が `APPROVED` ではない
+  - レビューコメントの内容から、指摘事項がない（または全て解決済み）と読み取れる
+  - 実質的にレビュー完了しているにもかかわらず、approveアクションだけが行われていない
+
+- **approve漏れではないと判断する条件**（以下のいずれかに該当する場合）:
+  - 未解決の指摘事項が残っている
+  - レビュー状態が `CHANGES_REQUESTED` で、実際に対応すべき変更要求がある
+  - レビューがまだ進行中である
+
+#### アクション
+
+- **approve漏れの場合**: PRに `@coderabbitai approve` コメントを投稿 → フロー先頭（ステップ1）に戻る
+- **approve漏れではない場合**: ステップ3bへ進む
+
+### ステップ3b: レビューコメント対応（exit 2の場合）
+
+`/pr-comments` スキルでレビューコメントを取得し対応 → コミット・プッシュ → フロー先頭（ステップ1）に戻る（※ステップ1のwait-coderabbit.shがCHANGES_REQUESTED検知時に `@coderabbitai resolve` を自動投稿する）
 
 ## 注意事項
 


### PR DESCRIPTION
## Summary

- fix-prスキルのexit 2分岐にCodeRabbitのapprove漏れチェック（ステップ3a）を追加
- レビュー完了済みかつ未approveの場合、`@coderabbitai approve`コメントを自動投稿するフローを導入
- 従来のレビューコメント対応フローはステップ3bとして維持

## Test plan

- [ ] fix-prスキル実行時にexit 2が発生した場合、ステップ3aのapprove漏れチェックが実行されることを確認
- [ ] approve漏れと判断された場合に`@coderabbitai approve`コメントが投稿されることを確認
- [ ] approve漏れではない場合にステップ3bのレビューコメント対応フローに進むことを確認

Closes #107

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CodeRabbit レビューの承認状態を自動チェックする機能を追加
  * レビューコメント対応プロセスを強化

* **ドキュメンテーション**
  * PR 修正ワークフローの詳細な手順説明と実行例を拡充

<!-- end of auto-generated comment: release notes by coderabbit.ai -->