### PR TITLE
solve-issue: 対応済みIssueを自動クローズする #102

### DIFF
--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -77,7 +77,9 @@ GitHub Issue $ARGUMENTS を対応します。
   - ブランチ名検索（第一手段）: `gh pr list --repo {owner}/{repo} --head "worktree-issue-{番号}" --state all`
   - テキスト検索（フォールバック）: `gh pr list --repo {owner}/{repo} --search "#{番号}" --state all`
   - 両方の結果を合わせて、以下の優先順位で判断する:
-    1. **merged状態のPRが存在する場合**: 既に対応済みのため、Issueをクローズし（`gh issue close`）、対応済みPRへのリンクをコメントとして残した上で、処理をスキップして完了する（ステップ9の振り返りのみ実施する）
+    1. **merged状態のPRが存在する場合**: 既に対応済みのため、以下の手順でIssueをクローズし、処理をスキップして完了する（ステップ9の振り返りのみ実施する）
+       - merged PRの情報を取得: `gh pr list --repo {owner}/{repo} --search "#{番号}" --state merged --json number,url --jq '.[0]'`
+       - Issueをコメント付きでクローズ: `gh issue close {番号} --repo {owner}/{repo} --comment "対応済みPR #{PR番号} が既にマージされているためクローズします。\n\nPR: {PR URL}"`
     2. **open状態のPRが存在する場合**: 新しいPRを作成せず、既存PRに対してステップ7（fix-pr）を継続する
        - 複数のopen PRがある場合は、最新のものを対象とする
        - PR番号の取得例: `gh pr list --repo {owner}/{repo} --head "worktree-issue-{番号}" --state open --json number --jq '.[0].number'`


### PR DESCRIPTION
## Summary

- solve-issueスキルのステップ5で、merged PRが検出された場合にIssueを自動クローズする処理を追加
- `gh issue close` でクローズし、対応済みPRへのリンクをコメントとして残す記述に変更
- ステップ番号の参照をステップ8→ステップ9に修正（テーブル定義との整合性）

Closes #102

## Test plan

- [ ] SKILL.mdの変更内容が正しいことを確認
- [ ] ステップ番号の参照が正しいことを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * マージされたプルリクエストに対応する際の処理フローが改善されました。関連する課題が自動的にクローズされ、対応するプルリクエストへのリンクが追加されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->