### PR TITLE
スクリプトのjq出力後にechoを追加して連続実行時の視認性を改善 #122

### DIFF
--- a/.claude/scripts/assign-issues.sh
+++ b/.claude/scripts/assign-issues.sh
@@ -28,6 +28,7 @@ if "${USE_PRINT_MODE}"; then
     -p "/assign-issues" \
     --output-format stream-json --verbose --include-partial-messages | \
     jq -rj 'if .type == "stream_event" and .event.delta.type? == "text_delta" then .event.delta.text elif .type == "result" then .result else empty end'
+  echo
 else
   claude --dangerously-skip-permissions "/assign-issues"
 fi

--- a/.claude/scripts/solve-issue.sh
+++ b/.claude/scripts/solve-issue.sh
@@ -39,6 +39,7 @@ if "${USE_PRINT_MODE}"; then
     -p "/solve-issue ${ISSUE_NUMBER}" \
     --output-format stream-json --verbose --include-partial-messages | \
     jq -rj 'if .type == "stream_event" and .event.delta.type? == "text_delta" then .event.delta.text elif .type == "result" then .result else empty end'
+  echo
 else
   claude --worktree "issue-${ISSUE_NUMBER}" --dangerously-skip-permissions "/solve-issue ${ISSUE_NUMBER}"
 fi


### PR DESCRIPTION
## Summary

- `assign-issues.sh` の `claude | jq` パイプライン後に `echo` を追加し、連続実行時の出力区切りを改善
- `solve-issue.sh` の `claude | jq` パイプライン後に `echo` を追加し、同様に視認性を改善

Closes #122

## Test plan

- [ ] `assign-issues.sh -p` を連続実行し、出力間に空行が入ることを確認
- [ ] `solve-issue.sh -p` を連続実行し、出力間に空行が入ることを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 出力フォーマットを改善し、スクリプトの終了時に適切な改行が含まれるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->