### PR TITLE
README.mdのクイックスタートをバイナリダウンロード手順に変更し、ディレクトリ監視の手順を拡充する #148

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,17 @@
 
    ```bash
    # Linux (x86_64) の場合
-   curl -Lo vox-actor.tar.gz https://github.com/canpok1/vox-actor/releases/latest/download/vox-actor_Linux_x86_64.tar.gz
+   curl -fLo vox-actor.tar.gz https://github.com/canpok1/vox-actor/releases/latest/download/vox-actor_Linux_x86_64.tar.gz
    tar xzf vox-actor.tar.gz
    sudo mv vox-actor /usr/local/bin/
 
    # macOS (Apple Silicon) の場合
-   curl -Lo vox-actor.tar.gz https://github.com/canpok1/vox-actor/releases/latest/download/vox-actor_Darwin_arm64.tar.gz
+   curl -fLo vox-actor.tar.gz https://github.com/canpok1/vox-actor/releases/latest/download/vox-actor_Darwin_arm64.tar.gz
+   tar xzf vox-actor.tar.gz
+   sudo mv vox-actor /usr/local/bin/
+
+   # macOS (Intel) の場合
+   curl -fLo vox-actor.tar.gz https://github.com/canpok1/vox-actor/releases/latest/download/vox-actor_Darwin_x86_64.tar.gz
    tar xzf vox-actor.tar.gz
    sudo mv vox-actor /usr/local/bin/
    ```


### PR DESCRIPTION
## Summary

- クイックスタートのステップ2を `go install` からGitHub Releasesのビルド済みバイナリダウンロード手順に変更
- クイックスタートのステップ4にファイル配置による自動読み上げ確認手順を追加
- インストールセクションの `go install` および前提条件の Go バージョン記載はそのまま維持

Closes #148

## Test plan

- [ ] README.mdのクイックスタート手順が正しく表示されることを確認
- [ ] バイナリダウンロードURLが正しいことを確認（`/releases/latest/download/` パスが有効）
- [ ] ディレクトリ監視手順のサンプルコマンドが正しいことを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * インストール手順を更新し、GitHub Releasesから事前構築バイナリを取得する方法を追加しました
  * クロスターミナル操作についての説明を追加しました
  * インストール/読み上げフローの実装例を拡充しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->