### PR TITLE
homebrewへのリリース用設定を追加

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -37,3 +37,4 @@ jobs:
           args: ${{ inputs.goreleaser-args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,7 +67,7 @@ homebrew_casks:
   - repository:
       owner: canpok1
       name: homebrew-tap
-      token: {{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     hooks:
       post:
         install: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,3 +62,15 @@ release:
     ---
 
     Released by [GoReleaser](https://github.com/goreleaser/goreleaser).
+
+homebrew_casks:
+  - repository:
+      owner: canpok1
+      name: homebrew-tap
+      token: {{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/{{ .ProjectName }}"]
+          end


### PR DESCRIPTION
## Summary
- GoReleaserの設定にHomebrew Caskの設定を追加し、リリース時にhomebrew-tapリポジトリへ自動でCask定義を配信できるようにした
- GitHub Actionsワークフローに`HOMEBREW_TAP_GITHUB_TOKEN`環境変数を追加

## Test plan
- [ ] GoReleaserのドライランで設定が正しくパースされることを確認
- [ ] `HOMEBREW_TAP_GITHUB_TOKEN`シークレットがリポジトリに設定されていることを確認
- [ ] リリース実行時にhomebrew-tapリポジトリにCask定義がpushされることを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)