### PR TITLE
READMEにHomebrew手順追加＆ヘルプメッセージの説明文を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@
 - バイナリをダウンロードする場合
    - [GitHub Releases](https://github.com/canpok1/vox-actor/releases)からビルド済みバイナリをダウンロードして配置してください。
 
+- Homebrewを使う場合（macOS/Linux）:
+   ```bash
+   brew tap canpok1/tap
+   brew install --cask vox-actor
+   ```
+
 - Goの`install`コマンドを使う場合
    ```bash
    go install github.com/canpok1/vox-actor@latest

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ type Deps struct {
 func makeRootCmd(deps ...*Deps) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "vox-actor",
-		Short:   "AIエージェント構築フレームワークのCLIツール",
+		Short:   "テキストをVOICEVOXエンジンで音声合成し読み上げるCLIツール",
 		Version: version,
 	}
 	cmd.SilenceUsage = true


### PR DESCRIPTION
## Summary
- READMEにHomebrewでのインストール手順（`brew tap` / `brew install --cask`）を追加
- ルートコマンドのShort説明を実態に合わせて修正（「AIエージェント構築フレームワークのCLIツール」→「テキストをVOICEVOXエンジンで音声合成し読み上げるCLIツール」）

## Test plan
- [ ] `go build` でビルドが通ること
- [ ] `vox-actor --help` で修正後の説明文が表示されること
- [ ] READMEのHomebrew手順が正しく表示されること

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)