### PR TITLE
/reviewスキルにアーキテクチャ観点のレビューを追加 #161

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -1,0 +1,110 @@
+---
+name: architecture-reviewer
+description: 変更差分に対してクリーンアーキテクチャのレイヤー責務ルール違反をチェックするエージェント。
+tools: Read, Glob, Grep, Bash(ls *), Bash(git *)
+model: sonnet
+---
+
+# アーキテクチャレビューエージェント
+
+変更差分を取得し、`docs/architecture/layer-rules.md` に定義されたレイヤー責務ルールに基づいて、ロジックの配置・責務境界に関する違反をチェックする。自動修正は行わず、指摘のみを報告する。
+
+## 前提
+
+- 依存方向の静的チェックは `depcheck.yml` により import 文レベルで行われている
+- 本エージェントはその補完として、import 文だけでは検出できない「ロジック配置の意味的な違反」を検出する
+
+## 対象ファイル
+
+- `cmd/` 配下の `*.go`
+- `internal/app/` 配下の `*.go`
+- `internal/domain/` 配下の `*.go`
+- `internal/infra/` 配下の `*.go`
+
+※ `*_test.go` および `mock_*.go` / `*_mock.go` は対象外
+
+## チェック観点
+
+### 1. ドメインロジックの配置
+
+ビジネスルール（エンティティのフィールド操作、値の検証・変換、不変条件の保証）がドメイン層に存在するか。infra / app / cmd 層にドメインロジックが漏れていないかを確認する。
+
+代表的な違反兆候:
+
+- infra 層でエンティティのフィールドを条件分岐で書き換えている
+- infra 層で「範囲外の値を丸める」「デフォルト値を補完する」などの処理がある
+- cmd 層でファイル種別やリクエスト内容によるビジネス分岐がある
+- app 層のユースケース内にドメインルール（例: エンティティの不変条件）のチェックが散在している
+
+### 2. 依存方向（import 文ベースの補完確認）
+
+`depcheck.yml` の検証を補完するため、変更ファイルの import 文を確認する:
+
+- `domain → app` / `domain → infra` / `domain → cmd` の import がないか
+- `app → infra` / `app → cmd` の import がないか
+- `infra → cmd` の import がないか
+
+違反を検出した場合は `depcheck.yml` での検出漏れの可能性があるため、その旨も併記する。
+
+### 3. インターフェース（ポート）の肥大化
+
+`internal/app/port.go` などの app 層のポート定義に、infra の関心事が漏れていないかを確認する。
+
+代表的な違反兆候:
+
+- インターフェースのシグネチャに `retryCount`、`timeoutMs`、`httpClient` などの infra 固有の引数が含まれる
+- インターフェースが返す型が infra 固有の構造体である（例: `*http.Response`）
+- インターフェースのメソッド名が実装技術を示唆している（例: `SendHTTPRequest` ではなく `Synthesize` であるべき）
+
+## ワークフロー
+
+1. `docs/architecture/layer-rules.md` を Read で読み込む
+2. `git diff --name-only` で変更ファイルを取得する
+   - PR レビュー時: `git diff --name-only origin/main...HEAD`
+   - ローカル作業中: `git diff --name-only HEAD`
+   - 変更ファイルがない場合はその旨を報告して終了
+3. 変更ファイルのうち `cmd/`、`internal/` 配下の `*.go`（テスト・モックを除く）を対象として、`git diff` で実際の差分を取得する
+4. 各チェック観点について、変更箇所がルールに違反していないかを判定する
+   - 必要に応じて関連ファイル（例: `internal/app/port.go`、`internal/domain/entity/*.go`）を Read して文脈を確認する
+5. 結果を出力する（自動修正はしない）
+
+## 出力形式
+
+### 問題なしの場合
+
+```
+アーキテクチャレビュー: 問題なし
+
+チェック対象: N ファイル（変更差分）
+- cmd/xxx.go
+- internal/app/yyy.go
+...
+```
+
+### 問題ありの場合
+
+ファイルパス・行番号・違反内容・該当するチェック観点・改善案をリスト形式で報告する。
+
+```
+アーキテクチャレビュー: 要修正（M 件）
+
+## 1. ドメインロジックが infra 層に漏れている
+
+- ファイル: internal/infra/voicevox_client.go:42
+- 違反内容: `req.SpeedScale` の範囲補正ロジックが infra 層に存在する
+- 該当ルール: 観点 1（ドメインロジックの配置）
+- 改善案: `entity.SynthesisRequest.Normalize()` のようなドメイン層のメソッドに移動する
+
+## 2. app 層のポートに infra の関心事が漏れている
+
+- ファイル: internal/app/port.go:15
+- 違反内容: `Synthesize` メソッドの引数に `retryCount int` が含まれる
+- 該当ルール: 観点 3（インターフェースの肥大化）
+- 改善案: リトライ戦略は infra 層（`RetryableVoicevoxClient`）の内部に閉じる
+```
+
+## 注意事項
+
+- 自動修正は行わない。指摘のみを報告し、修正は人間（またはメインエージェント）の判断に委ねる
+- 違反かどうかの判断が曖昧な場合は、断定せず「疑わしい箇所」として報告する
+- `docs/architecture/layer-rules.md` が存在しない場合は、その旨を報告して終了する

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,18 +1,28 @@
 ---
 name: review
-description: コード品質レビューとドキュメント整合性チェックを統合的に実施するスキル。/simplify でコード品質をレビューし、ドキュメント検証サブエージェントでドキュメントの最新性を検証する。
+description: コード品質レビュー、ドキュメント整合性チェック、アーキテクチャ妥当性チェックを統合的に実施するスキル。/simplify でコード品質をレビューし、2つのサブエージェント（doc-validator・architecture-reviewer）でドキュメント最新性とレイヤー責務の妥当性を検証する。
 context: fork
 agent: general-purpose
 allowed-tools: Skill, Agent, Bash, Read, Grep, Glob, Write, Edit
 user-invocable: true
 ---
 
-自己レビュー（コード品質 + ドキュメント整合性チェック）を行います。
+自己レビュー（コード品質 + ドキュメント整合性 + アーキテクチャ妥当性）を行います。
 
 ## 手順
 
 1. `/simplify` スキルを呼び出して、変更コードの再利用性・品質・効率のレビューと改善を行う
-2. `doc-validator` サブエージェントを呼び出して、ドキュメントの整合性をチェックする
-   - `context: fork` + `agent: doc-validator` で呼び出す
-   - 問題が見つかった場合はドキュメントを修正する
+2. 以下の2つを同時並行で実行する
+   - `doc-validator` サブエージェントを呼び出して、ドキュメントの整合性をチェックする
+     - `context: fork` + `agent: doc-validator` で呼び出す
+     - 問題が見つかった場合はドキュメントを修正する
+   - `architecture-reviewer` サブエージェントを呼び出して、レイヤー責務ルール（`docs/architecture/layer-rules.md`）に基づくアーキテクチャの妥当性をチェックする
+     - `context: fork` + `agent: architecture-reviewer` で呼び出す
+     - 指摘のみで自動修正はしない。報告された違反はメインエージェントが内容を精査し、必要に応じて修正する
 3. 修正があった場合はコミットする
+
+## 同時並行の根拠
+
+- `/simplify` はコードを修正するため、サブエージェントのレビューと競合しうる。そのため `/simplify` を先に実行し、その後にサブエージェント 2 つを並行で実行する
+- `doc-validator` はドキュメントの修正、`architecture-reviewer` はコードの指摘のみ（修正なし）で、対象が異なり競合しない
+- `/simplify` のコード修正が先に完了しているため、サブエージェントは修正後のコードを正しくレビューできる

--- a/docs/architecture/layer-rules.md
+++ b/docs/architecture/layer-rules.md
@@ -1,0 +1,114 @@
+# レイヤー構成と責務ルール
+
+このドキュメントは vox-actor のクリーンアーキテクチャにおけるレイヤー構成と、各層の責務・依存方向のルールを定義する。人間のレビュー基準であると同時に、`architecture-reviewer` サブエージェントの判断基準としても参照される。
+
+## レイヤー構成
+
+```
+main.go (DI)
+  └→ cmd/                CLI層: cobra コマンド定義、フラグ解析
+       └→ internal/app/       アプリケーション層: ユースケース、ポート（インターフェース）定義
+            └→ internal/domain/  ドメイン層: エンティティ、ビジネスルール（外部依存なし）
+
+internal/infra/  インフラ層: ポートの具象実装（app 層のインターフェースを実装）
+```
+
+## 依存方向
+
+- 許可される依存: `cmd → app → domain`、`infra → app → domain`
+- 禁止される依存: 上記以外のすべての方向
+  - 特に以下は禁止
+    - `domain → app`、`domain → infra`、`domain → cmd`
+    - `app → infra`、`app → cmd`
+    - `infra → cmd`
+
+依存方向の静的チェックは `depcheck.yml` によって import 文レベルで検証されている。`architecture-reviewer` は、その補完として import 文だけでは検出できない「ロジック配置の意味的な違反」を検出する。
+
+## 各層の責務ルール
+
+| 層 | 置くべきもの | 置いてはいけないもの |
+|---|---|---|
+| domain | エンティティ、ビジネスルール、値の変換・検証ロジック、ドメインが満たすべき不変条件 | 外部依存（HTTP、ファイル I/O、DB、ログ出力など）、フレームワーク依存 |
+| app | ユースケースのオーケストレーション、ポート（インターフェース）定義、複数ポートの協調制御 | 具象実装への直接依存、HTTP リクエスト・ファイル操作などの副作用を持つ処理の直接記述 |
+| infra | ポートの具象実装（HTTP 通信、ファイル操作、外部プロセス起動、リトライ・タイムアウト等） | ビジネスルール、ドメインエンティティのフィールドを条件分岐で書き換えるような処理 |
+| cmd | CLI 引数・フラグの解析、依存の組み立て（DI）、シグナルハンドリング、標準入出力との橋渡し | ビジネスルール、直接的な外部通信、ユースケースの条件分岐 |
+
+## よくある違反パターン
+
+以下は過去の手動レビュー（例: #160）で発見された違反パターンや、クリーンアーキテクチャで典型的に発生する問題である。
+
+### 1. ドメインロジックが infra 層に漏れている
+
+**違反例:**
+
+```go
+// internal/infra/voicevox_client.go
+func (c *VoicevoxClient) Synthesize(req *entity.SynthesisRequest) ([]byte, error) {
+    // ❌ エンティティのフィールドを条件付きで書き換えている（ドメインロジック）
+    if req.SpeedScale < 0.5 {
+        req.SpeedScale = 0.5
+    }
+    if req.SpeedScale > 2.0 {
+        req.SpeedScale = 2.0
+    }
+    // ... HTTP 通信 ...
+}
+```
+
+**あるべき姿:** エンティティのメソッド（例: `SynthesisRequest.Normalize()` や `NewSynthesisRequest()` のコンストラクタ内）としてドメイン層に配置する。
+
+### 2. app 層のインターフェースに infra の関心事が漏れている
+
+**違反例:**
+
+```go
+// internal/app/port.go
+type VoicevoxClient interface {
+    // ❌ retryCount は infra の関心事（リトライ戦略）
+    Synthesize(ctx context.Context, req *entity.SynthesisRequest, retryCount int) ([]byte, error)
+}
+```
+
+**あるべき姿:** リトライ回数は infra 層の実装内部に閉じ込める（例: `RetryableVoicevoxClient` のコンストラクタで受け取る）。
+
+### 3. cmd 層にビジネスロジックの条件分岐がある
+
+**違反例:**
+
+```go
+// cmd/act.go
+func runAct(cmd *cobra.Command, args []string) error {
+    // ❌ ファイル拡張子による処理分岐はビジネスルール
+    if strings.HasSuffix(args[0], ".json") {
+        // JSON 用の処理
+    } else if strings.HasSuffix(args[0], ".yaml") {
+        // YAML 用の処理
+    }
+}
+```
+
+**あるべき姿:** ユースケース（app 層）またはドメイン層に処理分岐を移す。cmd 層は「どのユースケースを呼び出すか」の組み立てに専念する。
+
+### 4. app 層から infra の具象型を直接 import している
+
+**違反例:**
+
+```go
+// internal/app/say_usecase.go
+import "github.com/canpok1/vox-actor/internal/infra"  // ❌ 具象パッケージへの依存
+
+func (u *SayUsecase) Execute(...) error {
+    client := infra.NewVoicevoxClient(...)  // ❌
+}
+```
+
+**あるべき姿:** app 層はインターフェース（ポート）に依存し、具象は main.go / cmd 層で組み立てて注入する。
+
+## アーキテクチャチェックの棲み分け
+
+| 検証手段 | 対象 | 粒度 |
+|---|---|---|
+| `depcheck.yml` | import 文の方向 | 静的・機械的 |
+| `architecture-reviewer` | ロジックの配置・責務境界 | 意味的・コンテキスト依存 |
+
+両者は補完関係にあり、どちらかだけでは不十分である。


### PR DESCRIPTION
## 概要

`/review` スキルに、クリーンアーキテクチャのレイヤー責務ルールに基づくアーキテクチャ観点のレビューを追加します。これにより「ドメインロジックが infra 層に漏れている」といったレイヤー間の責務配置に関する問題（#160 で手動発見されたような問題）を自動的に指摘できるようにします。

Closes #161

## 変更内容

### 1. レイヤー責務ルールのドキュメントを新規作成

`docs/architecture/layer-rules.md`

- レイヤー構成図と依存方向（`cmd → app → domain`、`infra → app → domain`）
- 各層（domain / app / infra / cmd）の責務テーブル
- よくある違反パターン4種（コード例付き）
- `depcheck.yml`（静的）と `architecture-reviewer`（意味的）の棲み分け

人間向けドキュメントとサブエージェントの判断基準を兼ねるため `docs/` 配下に配置しています。

### 2. `architecture-reviewer` サブエージェントを新規作成

`.claude/agents/architecture-reviewer.md`

既存の `doc-validator.md` と同形式で、以下の3観点で変更差分をチェックします:

1. **ドメインロジックの配置** — ビジネスルールが infra / app / cmd 層に漏れていないか
2. **依存方向の補完確認** — `depcheck.yml` の検出漏れを補完する意味での import 文確認
3. **インターフェース（ポート）の肥大化** — app 層のポートに infra の関心事が漏れていないか

指摘のみで自動修正はしません。

### 3. `/review` スキルの手順を更新

`.claude/skills/review/SKILL.md`

- `/simplify` → その後に `doc-validator` と `architecture-reviewer` を並行実行する手順に変更
- description にアーキテクチャ妥当性チェックの文言を追加
- 並列実行の根拠セクションを追加（`/simplify` のコード修正と競合しないよう順序を担保）

## やらないこと（Issue 記載通り）

- `depcheck.yml` の変更（既存の静的チェックはそのまま維持）
- アーキテクチャレビューによる自動修正（指摘のみ）
- `.claude/rules/` へのルール配置（人間も参照するため `docs/` 配下に配置）

## テスト計画

- [ ] `/review` スキルを実行し、`/simplify` → 2 サブエージェント並行の流れが動作することを確認
- [ ] `architecture-reviewer` が `docs/architecture/layer-rules.md` を正しく参照し、3観点でチェックすることを確認
- [ ] 問題なしの場合・問題ありの場合の出力形式が期待通りであることを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)