### PR TITLE
AudioQueryのパラメータ上書きロジックをドメイン層に移動する #160

### DIFF
--- a/internal/app/act_usecase.go
+++ b/internal/app/act_usecase.go
@@ -110,7 +110,8 @@ func (u *ActUsecase) Run(ctx context.Context, params ActParams) error {
 		}
 		u.logger.Debug("query created", "path", script.Path)
 
-		wavData, err := u.client.Synthesize(ctx, query, speakerID, speed, pitch, intonation)
+		q := query.WithOverrides(speed, pitch, intonation)
+		wavData, err := u.client.Synthesize(ctx, &q, speakerID)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil

--- a/internal/app/act_usecase_test.go
+++ b/internal/app/act_usecase_test.go
@@ -49,10 +49,8 @@ type mockVoicevoxClient struct {
 }
 
 type synthesizeCallArgs struct {
-	speakerID  int
-	speed      *float64
-	pitch      *float64
-	intonation *float64
+	query     *entity.AudioQuery
+	speakerID int
 }
 
 func (m *mockVoicevoxClient) HealthCheck(_ context.Context) error {
@@ -65,9 +63,9 @@ func (m *mockVoicevoxClient) CreateQuery(_ context.Context, _ string, speakerID 
 	return m.query, m.createQueryErr
 }
 
-func (m *mockVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, speakerID int, speed, pitch, intonation *float64) ([]byte, error) {
+func (m *mockVoicevoxClient) Synthesize(_ context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error) {
 	m.synthesizeCalls++
-	m.synthesizeArgs = append(m.synthesizeArgs, synthesizeCallArgs{speakerID: speakerID, speed: speed, pitch: pitch, intonation: intonation})
+	m.synthesizeArgs = append(m.synthesizeArgs, synthesizeCallArgs{query: query, speakerID: speakerID})
 	return m.wavData, m.synthesizeErr
 }
 
@@ -235,14 +233,15 @@ func TestActUsecase_Run_WithOptions(t *testing.T) {
 		t.Fatalf("expected 1 Synthesize call, got: %d", len(client.synthesizeArgs))
 	}
 	args := client.synthesizeArgs[0]
-	if args.speed == nil || *args.speed != 1.5 {
-		t.Errorf("expected speed 1.5, got: %v", args.speed)
+	// WithOverridesにより、queryのフィールドが上書きされている
+	if args.query.SpeedScale != 1.5 {
+		t.Errorf("expected SpeedScale 1.5, got: %f", args.query.SpeedScale)
 	}
-	if args.pitch == nil || *args.pitch != 0.5 {
-		t.Errorf("expected pitch 0.5, got: %v", args.pitch)
+	if args.query.PitchScale != 0.5 {
+		t.Errorf("expected PitchScale 0.5, got: %f", args.query.PitchScale)
 	}
-	if args.intonation == nil || *args.intonation != 1.2 {
-		t.Errorf("expected intonation 1.2, got: %v", args.intonation)
+	if args.query.IntonationScale != 1.2 {
+		t.Errorf("expected IntonationScale 1.2, got: %f", args.query.IntonationScale)
 	}
 }
 
@@ -443,7 +442,7 @@ func (m *cancellingVoicevoxClient) CreateQuery(_ context.Context, _ string, _ in
 	return m.query, nil
 }
 
-func (m *cancellingVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int, _, _, _ *float64) ([]byte, error) {
+func (m *cancellingVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
 	return m.wavData, nil
 }
 
@@ -736,14 +735,15 @@ func TestActUsecase_Run_ScriptEmotionParams(t *testing.T) {
 		t.Fatalf("expected 1 Synthesize call, got %d", len(client.synthesizeArgs))
 	}
 	args := client.synthesizeArgs[0]
-	if args.speed == nil || *args.speed != 1.5 {
-		t.Errorf("expected speed 1.5, got %v", args.speed)
+	// WithOverridesにより、queryのフィールドが上書きされている
+	if args.query.SpeedScale != 1.5 {
+		t.Errorf("expected SpeedScale 1.5, got %f", args.query.SpeedScale)
 	}
-	if args.pitch == nil || *args.pitch != 0.1 {
-		t.Errorf("expected pitch 0.1, got %v", args.pitch)
+	if args.query.PitchScale != 0.1 {
+		t.Errorf("expected PitchScale 0.1, got %f", args.query.PitchScale)
 	}
-	if args.intonation == nil || *args.intonation != 1.8 {
-		t.Errorf("expected intonation 1.8, got %v", args.intonation)
+	if args.query.IntonationScale != 1.8 {
+		t.Errorf("expected IntonationScale 1.8, got %f", args.query.IntonationScale)
 	}
 }
 
@@ -783,8 +783,8 @@ func TestActUsecase_Run_ScriptParamsOverrideGlobal(t *testing.T) {
 	}
 	args := client.synthesizeArgs[0]
 	// スクリプト単位のSpeedScale(0.5)がグローバル(2.0)より優先される
-	if args.speed == nil || *args.speed != 0.5 {
-		t.Errorf("expected speed 0.5 (script override), got %v", args.speed)
+	if args.query.SpeedScale != 0.5 {
+		t.Errorf("expected SpeedScale 0.5 (script override), got %f", args.query.SpeedScale)
 	}
 }
 
@@ -818,8 +818,8 @@ func TestActUsecase_Run_ScriptNoParams_UsesGlobal(t *testing.T) {
 	}
 	args := client.synthesizeArgs[0]
 	// スクリプトにSpeedScaleがないのでグローバル(2.0)が使われる
-	if args.speed == nil || *args.speed != 2.0 {
-		t.Errorf("expected speed 2.0 (global), got %v", args.speed)
+	if args.query.SpeedScale != 2.0 {
+		t.Errorf("expected SpeedScale 2.0 (global), got %f", args.query.SpeedScale)
 	}
 }
 
@@ -870,16 +870,16 @@ func TestActUsecase_Run_MultipleScriptsWithDifferentParams(t *testing.T) {
 	if len(client.synthesizeArgs) != 3 {
 		t.Fatalf("expected 3 Synthesize calls, got %d", len(client.synthesizeArgs))
 	}
-	// a.json: speed=0.8
-	if client.synthesizeArgs[0].speed == nil || *client.synthesizeArgs[0].speed != 0.8 {
-		t.Errorf("expected first speed 0.8, got %v", client.synthesizeArgs[0].speed)
+	// a.json: speed=0.8（WithOverridesでqueryに適用済み）
+	if client.synthesizeArgs[0].query.SpeedScale != 0.8 {
+		t.Errorf("expected first SpeedScale 0.8, got %f", client.synthesizeArgs[0].query.SpeedScale)
 	}
-	// b.txt: speed=nil (no script or global)
-	if client.synthesizeArgs[1].speed != nil {
-		t.Errorf("expected second speed nil, got %v", *client.synthesizeArgs[1].speed)
+	// b.txt: speed未指定（デフォルトのquery値=0.0のまま）
+	if client.synthesizeArgs[1].query.SpeedScale != 0.0 {
+		t.Errorf("expected second SpeedScale 0.0 (default), got %f", client.synthesizeArgs[1].query.SpeedScale)
 	}
 	// c.json: speed=1.5
-	if client.synthesizeArgs[2].speed == nil || *client.synthesizeArgs[2].speed != 1.5 {
-		t.Errorf("expected third speed 1.5, got %v", client.synthesizeArgs[2].speed)
+	if client.synthesizeArgs[2].query.SpeedScale != 1.5 {
+		t.Errorf("expected third SpeedScale 1.5, got %f", client.synthesizeArgs[2].query.SpeedScale)
 	}
 }

--- a/internal/app/port.go
+++ b/internal/app/port.go
@@ -38,6 +38,5 @@ type VoicevoxClient interface {
 	CreateQuery(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error)
 
 	// Synthesize は音声合成を実行し、WAV形式のバイト列を返す。
-	// speed, pitch, intonation が指定された場合、AudioQueryの対応フィールドを上書きする。
-	Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int, speed, pitch, intonation *float64) ([]byte, error)
+	Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error)
 }

--- a/internal/app/say_usecase.go
+++ b/internal/app/say_usecase.go
@@ -69,7 +69,8 @@ func (u *SayUsecase) Run(ctx context.Context, params SayParams) error {
 	}
 	u.logger.Debug("query created")
 
-	wavData, err := u.client.Synthesize(ctx, query, params.SpeakerID, params.Speed, params.Pitch, params.Intonation)
+	q := query.WithOverrides(params.Speed, params.Pitch, params.Intonation)
+	wavData, err := u.client.Synthesize(ctx, &q, params.SpeakerID)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil

--- a/internal/app/say_usecase_test.go
+++ b/internal/app/say_usecase_test.go
@@ -80,14 +80,15 @@ func TestSayUsecase_Run_WithParams(t *testing.T) {
 	if args.speakerID != 5 {
 		t.Errorf("expected speakerID 5, got: %d", args.speakerID)
 	}
-	if args.speed == nil || *args.speed != 1.5 {
-		t.Errorf("expected speed 1.5, got: %v", args.speed)
+	// WithOverridesにより、Synthesizeに渡されるqueryのフィールドが上書きされている
+	if args.query.SpeedScale != 1.5 {
+		t.Errorf("expected SpeedScale 1.5, got: %f", args.query.SpeedScale)
 	}
-	if args.pitch == nil || *args.pitch != 0.5 {
-		t.Errorf("expected pitch 0.5, got: %v", args.pitch)
+	if args.query.PitchScale != 0.5 {
+		t.Errorf("expected PitchScale 0.5, got: %f", args.query.PitchScale)
 	}
-	if args.intonation == nil || *args.intonation != 1.2 {
-		t.Errorf("expected intonation 1.2, got: %v", args.intonation)
+	if args.query.IntonationScale != 1.2 {
+		t.Errorf("expected IntonationScale 1.2, got: %f", args.query.IntonationScale)
 	}
 }
 

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -129,7 +129,8 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params ActP
 		}
 		u.logger.Debug("query created", "path", script.Path)
 
-		wavData, err := u.client.Synthesize(ctx, query, speakerID, speed, pitch, intonation)
+		q := query.WithOverrides(speed, pitch, intonation)
+		wavData, err := u.client.Synthesize(ctx, &q, speakerID)
 		if err != nil {
 			u.logger.Error("synthesize error (skipping script)", "path", script.Path, "error", err)
 			continue

--- a/internal/app/watch_usecase_test.go
+++ b/internal/app/watch_usecase_test.go
@@ -364,9 +364,9 @@ func TestWatchUsecase_Run_ScriptParamsOverrideGlobal(t *testing.T) {
 	if args.speakerID != 7 {
 		t.Errorf("expected Synthesize speakerID 7, got %d", args.speakerID)
 	}
-	// スクリプト単位のSpeed(0.5)がグローバル(2.0)より優先される
-	if args.speed == nil || *args.speed != 0.5 {
-		t.Errorf("expected speed 0.5 (script override), got %v", args.speed)
+	// スクリプト単位のSpeed(0.5)がグローバル(2.0)より優先される（WithOverridesでqueryに適用済み）
+	if args.query.SpeedScale != 0.5 {
+		t.Errorf("expected SpeedScale 0.5 (script override), got %f", args.query.SpeedScale)
 	}
 }
 
@@ -404,9 +404,9 @@ func TestWatchUsecase_Run_ScriptNoParams_UsesGlobal(t *testing.T) {
 		t.Fatalf("expected 1 Synthesize call, got %d", len(client.synthesizeArgs))
 	}
 	args := client.synthesizeArgs[0]
-	// スクリプトにSpeedScaleがないのでグローバル(2.0)が使われる
-	if args.speed == nil || *args.speed != 2.0 {
-		t.Errorf("expected speed 2.0 (global), got %v", args.speed)
+	// スクリプトにSpeedScaleがないのでグローバル(2.0)が使われる（WithOverridesでqueryに適用済み）
+	if args.query.SpeedScale != 2.0 {
+		t.Errorf("expected SpeedScale 2.0 (global), got %f", args.query.SpeedScale)
 	}
 	// SpeakerIDもデフォルト(3)が使われる
 	if args.speakerID != 3 {

--- a/internal/domain/entity/audio_query.go
+++ b/internal/domain/entity/audio_query.go
@@ -24,6 +24,21 @@ type AccentPhrase struct {
 	IsInterrogative bool   `json:"is_interrogative"`
 }
 
+// WithOverrides は指定されたパラメータでAudioQueryのフィールドを上書きした新しいAudioQueryを返す。
+// nilのパラメータは上書きしない。値レシーバのため元のAudioQueryは変更されない。
+func (q AudioQuery) WithOverrides(speed, pitch, intonation *float64) AudioQuery {
+	if speed != nil {
+		q.SpeedScale = *speed
+	}
+	if pitch != nil {
+		q.PitchScale = *pitch
+	}
+	if intonation != nil {
+		q.IntonationScale = *intonation
+	}
+	return q
+}
+
 // Mora はモーラ（音節）を表す。
 type Mora struct {
 	Text            string   `json:"text"`

--- a/internal/domain/entity/audio_query_test.go
+++ b/internal/domain/entity/audio_query_test.go
@@ -6,13 +6,6 @@ import (
 	"github.com/canpok1/vox-actor/internal/domain/entity"
 )
 
-// AudioQuery.WithOverrides テストリスト
-// DONE: 正常系: 全パラメータnilの場合、元のAudioQueryと同じ値を返す
-// DONE: 正常系: speedのみ指定した場合、SpeedScaleだけ上書きされる
-// DONE: 正常系: pitchのみ指定した場合、PitchScaleだけ上書きされる
-// DONE: 正常系: intonationのみ指定した場合、IntonationScaleだけ上書きされる
-// DONE: 正常系: 全パラメータ指定した場合、全て上書きされる
-// DONE: 正常系: 元のAudioQueryが変更されない（値レシーバによるコピー）
 
 func TestAudioQuery_WithOverrides_AllNil(t *testing.T) {
 	q := entity.AudioQuery{

--- a/internal/domain/entity/audio_query_test.go
+++ b/internal/domain/entity/audio_query_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/canpok1/vox-actor/internal/domain/entity"
 )
 
-
 func TestAudioQuery_WithOverrides_AllNil(t *testing.T) {
 	q := entity.AudioQuery{
 		SpeedScale:      1.0,

--- a/internal/domain/entity/audio_query_test.go
+++ b/internal/domain/entity/audio_query_test.go
@@ -1,0 +1,150 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+// AudioQuery.WithOverrides テストリスト
+// DONE: 正常系: 全パラメータnilの場合、元のAudioQueryと同じ値を返す
+// DONE: 正常系: speedのみ指定した場合、SpeedScaleだけ上書きされる
+// DONE: 正常系: pitchのみ指定した場合、PitchScaleだけ上書きされる
+// DONE: 正常系: intonationのみ指定した場合、IntonationScaleだけ上書きされる
+// DONE: 正常系: 全パラメータ指定した場合、全て上書きされる
+// DONE: 正常系: 元のAudioQueryが変更されない（値レシーバによるコピー）
+
+func TestAudioQuery_WithOverrides_AllNil(t *testing.T) {
+	q := entity.AudioQuery{
+		SpeedScale:      1.0,
+		PitchScale:      0.0,
+		IntonationScale: 1.0,
+	}
+
+	result := q.WithOverrides(nil, nil, nil)
+
+	if result.SpeedScale != 1.0 {
+		t.Errorf("expected SpeedScale 1.0, got %f", result.SpeedScale)
+	}
+	if result.PitchScale != 0.0 {
+		t.Errorf("expected PitchScale 0.0, got %f", result.PitchScale)
+	}
+	if result.IntonationScale != 1.0 {
+		t.Errorf("expected IntonationScale 1.0, got %f", result.IntonationScale)
+	}
+}
+
+func TestAudioQuery_WithOverrides_SpeedOnly(t *testing.T) {
+	q := entity.AudioQuery{
+		SpeedScale:      1.0,
+		PitchScale:      0.0,
+		IntonationScale: 1.0,
+	}
+
+	speed := 1.5
+	result := q.WithOverrides(&speed, nil, nil)
+
+	if result.SpeedScale != 1.5 {
+		t.Errorf("expected SpeedScale 1.5, got %f", result.SpeedScale)
+	}
+	if result.PitchScale != 0.0 {
+		t.Errorf("expected PitchScale 0.0, got %f", result.PitchScale)
+	}
+	if result.IntonationScale != 1.0 {
+		t.Errorf("expected IntonationScale 1.0, got %f", result.IntonationScale)
+	}
+}
+
+func TestAudioQuery_WithOverrides_PitchOnly(t *testing.T) {
+	q := entity.AudioQuery{
+		SpeedScale:      1.0,
+		PitchScale:      0.0,
+		IntonationScale: 1.0,
+	}
+
+	pitch := 0.5
+	result := q.WithOverrides(nil, &pitch, nil)
+
+	if result.SpeedScale != 1.0 {
+		t.Errorf("expected SpeedScale 1.0, got %f", result.SpeedScale)
+	}
+	if result.PitchScale != 0.5 {
+		t.Errorf("expected PitchScale 0.5, got %f", result.PitchScale)
+	}
+	if result.IntonationScale != 1.0 {
+		t.Errorf("expected IntonationScale 1.0, got %f", result.IntonationScale)
+	}
+}
+
+func TestAudioQuery_WithOverrides_IntonationOnly(t *testing.T) {
+	q := entity.AudioQuery{
+		SpeedScale:      1.0,
+		PitchScale:      0.0,
+		IntonationScale: 1.0,
+	}
+
+	intonation := 2.0
+	result := q.WithOverrides(nil, nil, &intonation)
+
+	if result.SpeedScale != 1.0 {
+		t.Errorf("expected SpeedScale 1.0, got %f", result.SpeedScale)
+	}
+	if result.PitchScale != 0.0 {
+		t.Errorf("expected PitchScale 0.0, got %f", result.PitchScale)
+	}
+	if result.IntonationScale != 2.0 {
+		t.Errorf("expected IntonationScale 2.0, got %f", result.IntonationScale)
+	}
+}
+
+func TestAudioQuery_WithOverrides_AllParams(t *testing.T) {
+	q := entity.AudioQuery{
+		SpeedScale:      1.0,
+		PitchScale:      0.0,
+		IntonationScale: 1.0,
+		VolumeScale:     1.0,
+	}
+
+	speed := 1.5
+	pitch := 0.5
+	intonation := 2.0
+	result := q.WithOverrides(&speed, &pitch, &intonation)
+
+	if result.SpeedScale != 1.5 {
+		t.Errorf("expected SpeedScale 1.5, got %f", result.SpeedScale)
+	}
+	if result.PitchScale != 0.5 {
+		t.Errorf("expected PitchScale 0.5, got %f", result.PitchScale)
+	}
+	if result.IntonationScale != 2.0 {
+		t.Errorf("expected IntonationScale 2.0, got %f", result.IntonationScale)
+	}
+	// 上書きしていないフィールドは元の値のまま
+	if result.VolumeScale != 1.0 {
+		t.Errorf("expected VolumeScale 1.0, got %f", result.VolumeScale)
+	}
+}
+
+func TestAudioQuery_WithOverrides_DoesNotModifyOriginal(t *testing.T) {
+	q := entity.AudioQuery{
+		SpeedScale:      1.0,
+		PitchScale:      0.0,
+		IntonationScale: 1.0,
+	}
+
+	speed := 1.5
+	pitch := 0.5
+	intonation := 2.0
+	_ = q.WithOverrides(&speed, &pitch, &intonation)
+
+	// 元のAudioQueryが変更されていないことを確認
+	if q.SpeedScale != 1.0 {
+		t.Errorf("original SpeedScale should not be modified, got %f", q.SpeedScale)
+	}
+	if q.PitchScale != 0.0 {
+		t.Errorf("original PitchScale should not be modified, got %f", q.PitchScale)
+	}
+	if q.IntonationScale != 1.0 {
+		t.Errorf("original IntonationScale should not be modified, got %f", q.IntonationScale)
+	}
+}

--- a/internal/infra/retryable_voicevox_client.go
+++ b/internal/infra/retryable_voicevox_client.go
@@ -155,11 +155,11 @@ func (c *RetryableVoicevoxClient) CreateQuery(ctx context.Context, text string, 
 }
 
 // Synthesize は音声合成を実行し、WAV形式のバイト列を返す。失敗時は指数バックオフでリトライを行う。
-func (c *RetryableVoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int, speed, pitch, intonation *float64) ([]byte, error) {
+func (c *RetryableVoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error) {
 	var result []byte
 	err := c.retryWithBackoff(ctx, func() error {
 		var err error
-		result, err = c.inner.Synthesize(ctx, query, speakerID, speed, pitch, intonation)
+		result, err = c.inner.Synthesize(ctx, query, speakerID)
 		return err
 	})
 	return result, err

--- a/internal/infra/retryable_voicevox_client_test.go
+++ b/internal/infra/retryable_voicevox_client_test.go
@@ -23,7 +23,7 @@ func (e *mockNetError) Temporary() bool { return true }
 type mockVoicevoxClient struct {
 	healthCheckFunc func(ctx context.Context) error
 	createQueryFunc func(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error)
-	synthesizeFunc  func(ctx context.Context, query *entity.AudioQuery, speakerID int, speed, pitch, intonation *float64) ([]byte, error)
+	synthesizeFunc  func(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error)
 	callCounts      map[string]int
 }
 
@@ -49,10 +49,10 @@ func (m *mockVoicevoxClient) CreateQuery(ctx context.Context, text string, speak
 	return &entity.AudioQuery{}, nil
 }
 
-func (m *mockVoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int, speed, pitch, intonation *float64) ([]byte, error) {
+func (m *mockVoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error) {
 	m.callCounts["Synthesize"]++
 	if m.synthesizeFunc != nil {
-		return m.synthesizeFunc(ctx, query, speakerID, speed, pitch, intonation)
+		return m.synthesizeFunc(ctx, query, speakerID)
 	}
 	return []byte("wav"), nil
 }
@@ -146,7 +146,7 @@ func TestRetryableVoicevoxClient_CreateQuery_Success(t *testing.T) {
 func TestRetryableVoicevoxClient_Synthesize_Success(t *testing.T) {
 	mock := newMockVoicevoxClient()
 	expectedWAV := []byte("wav data")
-	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int, _, _, _ *float64) ([]byte, error) {
+	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
 		return expectedWAV, nil
 	}
 
@@ -154,7 +154,7 @@ func TestRetryableVoicevoxClient_Synthesize_Success(t *testing.T) {
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
 	query := &entity.AudioQuery{SpeedScale: 1.0}
-	wav, err := client.Synthesize(context.Background(), query, 1, nil, nil, nil)
+	wav, err := client.Synthesize(context.Background(), query, 1)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -171,7 +171,7 @@ func TestRetryableVoicevoxClient_Synthesize_RetrySuccess(t *testing.T) {
 	mock := newMockVoicevoxClient()
 	callCount := 0
 	expectedWAV := []byte("wav data")
-	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int, _, _, _ *float64) ([]byte, error) {
+	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
 		callCount++
 		if callCount == 1 {
 			return nil, &mockNetError{msg: "connection refused"}
@@ -183,7 +183,7 @@ func TestRetryableVoicevoxClient_Synthesize_RetrySuccess(t *testing.T) {
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
 	query := &entity.AudioQuery{SpeedScale: 1.0}
-	wav, err := client.Synthesize(context.Background(), query, 1, nil, nil, nil)
+	wav, err := client.Synthesize(context.Background(), query, 1)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -221,7 +221,7 @@ func TestRetryableVoicevoxClient_CreateQuery_MaxRetriesExceeded(t *testing.T) {
 // リトライ上限超過: Synthesizeが最大3回リトライしても失敗する場合エラーを返す
 func TestRetryableVoicevoxClient_Synthesize_MaxRetriesExceeded(t *testing.T) {
 	mock := newMockVoicevoxClient()
-	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int, _, _, _ *float64) ([]byte, error) {
+	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
 		return nil, &mockNetError{msg: "connection refused"}
 	}
 
@@ -229,7 +229,7 @@ func TestRetryableVoicevoxClient_Synthesize_MaxRetriesExceeded(t *testing.T) {
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
 	query := &entity.AudioQuery{SpeedScale: 1.0}
-	wav, err := client.Synthesize(context.Background(), query, 1, nil, nil, nil)
+	wav, err := client.Synthesize(context.Background(), query, 1)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -330,7 +330,7 @@ func TestRetryableVoicevoxClient_CreateQuery_NonRetryableError(t *testing.T) {
 // 非リトライエラー: Synthesizeで非net.Errorはリトライせず即座にエラーを返す
 func TestRetryableVoicevoxClient_Synthesize_NonRetryableError(t *testing.T) {
 	mock := newMockVoicevoxClient()
-	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int, _, _, _ *float64) ([]byte, error) {
+	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
 		return nil, errors.New("synthesis failed: status 500")
 	}
 
@@ -338,7 +338,7 @@ func TestRetryableVoicevoxClient_Synthesize_NonRetryableError(t *testing.T) {
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
 	query := &entity.AudioQuery{SpeedScale: 1.0}
-	_, err := client.Synthesize(context.Background(), query, 1, nil, nil, nil)
+	_, err := client.Synthesize(context.Background(), query, 1)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/infra/voicevox_client.go
+++ b/internal/infra/voicevox_client.go
@@ -111,21 +111,8 @@ func (c *VoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID
 }
 
 // Synthesize は音声合成を実行し、WAV形式のバイト列を返す。
-// speed, pitch, intonation が非nilの場合、AudioQueryの対応フィールドを上書きする。
-func (c *VoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int, speed, pitch, intonation *float64) ([]byte, error) {
-	// AudioQueryのコピーを作成し、指定されたパラメータを上書き
-	q := *query
-	if speed != nil {
-		q.SpeedScale = *speed
-	}
-	if pitch != nil {
-		q.PitchScale = *pitch
-	}
-	if intonation != nil {
-		q.IntonationScale = *intonation
-	}
-
-	jsonBody, err := json.Marshal(q)
+func (c *VoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error) {
+	jsonBody, err := json.Marshal(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal audio query: %w", err)
 	}

--- a/internal/infra/voicevox_client_test.go
+++ b/internal/infra/voicevox_client_test.go
@@ -192,7 +192,7 @@ func TestSynthesize_Success(t *testing.T) {
 	}
 
 	client := infra.NewVoicevoxClient(server.URL)
-	wav, err := client.Synthesize(context.Background(), query, 1, nil, nil, nil)
+	wav, err := client.Synthesize(context.Background(), query, 1)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -201,7 +201,7 @@ func TestSynthesize_Success(t *testing.T) {
 	}
 }
 
-func TestSynthesize_OverrideParams(t *testing.T) {
+func TestSynthesize_PassesThroughQueryDirectly(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -212,7 +212,7 @@ func TestSynthesize_OverrideParams(t *testing.T) {
 			t.Fatalf("failed to unmarshal request body: %v", err)
 		}
 
-		// 上書きされた値を検証
+		// queryがそのまま渡されることを検証（パラメータ上書きはドメイン層の責務）
 		if q.SpeedScale != 1.5 {
 			t.Errorf("expected speedScale 1.5, got %f", q.SpeedScale)
 		}
@@ -222,37 +222,25 @@ func TestSynthesize_OverrideParams(t *testing.T) {
 		if q.IntonationScale != 2.0 {
 			t.Errorf("expected intonationScale 2.0, got %f", q.IntonationScale)
 		}
-		// 上書きしていないフィールドは元の値のまま
-		if q.VolumeScale != 1.0 {
-			t.Errorf("expected volumeScale 1.0, got %f", q.VolumeScale)
-		}
 
 		w.Header().Set("Content-Type", "audio/wav")
 		w.Write([]byte("wav"))
 	}))
 	defer server.Close()
 
+	// 既にWithOverridesで上書き済みのqueryを渡す想定
 	query := &entity.AudioQuery{
-		SpeedScale:         1.0,
-		PitchScale:         0.0,
-		IntonationScale:    1.0,
+		SpeedScale:         1.5,
+		PitchScale:         0.5,
+		IntonationScale:    2.0,
 		VolumeScale:        1.0,
 		OutputSamplingRate: 24000,
 	}
 
-	speed := 1.5
-	pitch := 0.5
-	intonation := 2.0
-
 	client := infra.NewVoicevoxClient(server.URL)
-	_, err := client.Synthesize(context.Background(), query, 1, &speed, &pitch, &intonation)
+	_, err := client.Synthesize(context.Background(), query, 1)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
-	}
-
-	// 元のqueryが変更されていないことを確認
-	if query.SpeedScale != 1.0 {
-		t.Errorf("original query should not be modified, speedScale: %f", query.SpeedScale)
 	}
 }
 
@@ -325,7 +313,7 @@ func TestSynthesize_Non200(t *testing.T) {
 	}
 
 	client := infra.NewVoicevoxClient(server.URL)
-	wav, err := client.Synthesize(context.Background(), query, 1, nil, nil, nil)
+	wav, err := client.Synthesize(context.Background(), query, 1)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}


### PR DESCRIPTION
## Summary

- `AudioQuery` に `WithOverrides` メソッドを追加し、音声パラメータ（speed, pitch, intonation）の上書きロジックをドメイン層に移動
- `VoicevoxClient.Synthesize` インターフェースから `speed, pitch, intonation` 引数を削除してシグネチャを簡素化
- ユースケース層（say/act/watch）で `WithOverrides` を呼び出すように変更し、infra層からドメインロジックを分離

## Test plan

- [x] `WithOverrides` の単体テスト（個別パラメータ、全パラメータ、nil全指定、元オブジェクト非変更）
- [x] 全既存テストがパス（`go test ./...`）
- [x] `golangci-lint run` で指摘なし
- [x] `gofmt` でフォーマット済み

Closes #160

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)