### PR TITLE
標準出力のログを人間が読みやすい形式にする #165

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -8,7 +8,9 @@ import (
 	"syscall"
 
 	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/infra/logging"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // ActDeps はactコマンドの依存を保持する。
@@ -86,7 +88,11 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 	if verbose {
 		logLevel = slog.LevelDebug
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
+	noColor := !term.IsTerminal(int(os.Stderr.Fd())) || os.Getenv("NO_COLOR") != ""
+	logger := slog.New(logging.NewHumanHandler(os.Stderr, &logging.HumanHandlerOptions{
+		Level:   logLevel,
+		NoColor: noColor,
+	}))
 
 	client := deps.ClientFactory(engineURL)
 	if client == nil {

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -8,7 +8,9 @@ import (
 	"syscall"
 
 	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/infra/logging"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // SayDeps はsayコマンドの依存を保持する。
@@ -58,7 +60,11 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 	if verbose {
 		logLevel = slog.LevelDebug
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
+	noColor := !term.IsTerminal(int(os.Stderr.Fd())) || os.Getenv("NO_COLOR") != ""
+	logger := slog.New(logging.NewHumanHandler(os.Stderr, &logging.HumanHandlerOptions{
+		Level:   logLevel,
+		NoColor: noColor,
+	}))
 
 	client := deps.ClientFactory(engineURL)
 	if client == nil {

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/sys v0.25.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/term v0.42.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -17,4 +17,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
+golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/app/act_usecase_test.go
+++ b/internal/app/act_usecase_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canpok1/vox-actor/internal/app"
 	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/canpok1/vox-actor/internal/infra/logging"
 )
 
 // act_usecase テストリスト
@@ -474,7 +475,7 @@ func TestActUsecase_Run_LogsProcessingStatus(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
 	params := app.ActParams{
@@ -507,7 +508,7 @@ func TestActUsecase_Run_VerboseLogsDebugInfo(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelDebug, NoColor: true}))
 
 	speed := 1.5
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
@@ -567,7 +568,7 @@ func TestActUsecase_Run_SynthesisCompletedLoggedAtInfoLevel(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
 	params := app.ActParams{Path: "test.txt", SpeakerID: 3}
@@ -600,7 +601,7 @@ func TestActUsecase_Run_LogsProgressCounter(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
 	params := app.ActParams{Path: "scripts/", SpeakerID: 3}

--- a/internal/app/watch_usecase_test.go
+++ b/internal/app/watch_usecase_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/canpok1/vox-actor/internal/app"
 	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/canpok1/vox-actor/internal/infra/logging"
 )
 
 // --- WatchUsecase用モック ---
@@ -507,7 +508,7 @@ func TestWatchUsecase_Run_DeleteMode_LogsFileDeleted(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithDeleteMode(), app.WithWatchLogger(logger))
 	params := app.ActParams{Path: "/tmp/watch", SpeakerID: 3}
@@ -550,7 +551,7 @@ func TestWatchUsecase_Run_FileMovedToDoneLoggedAtInfoLevel(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
 	params := app.ActParams{Path: "/tmp/watch", SpeakerID: 3}
@@ -583,7 +584,7 @@ func TestWatchUsecase_Run_SynthesisCompletedLoggedAtInfoLevel(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
 	params := app.ActParams{Path: "/tmp/watch", SpeakerID: 3}
@@ -616,7 +617,7 @@ func TestWatchUsecase_Run_LogsProcessingStatus(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
 	params := app.ActParams{
@@ -656,7 +657,7 @@ func TestWatchUsecase_Run_WatcherError_LoggedViaLogger(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, customWatcher, app.WithWatchLogger(logger))
 	params := app.ActParams{

--- a/internal/infra/logging/handler.go
+++ b/internal/infra/logging/handler.go
@@ -1,0 +1,142 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+)
+
+// HumanHandlerOptions は HumanHandler の設定オプション。
+type HumanHandlerOptions struct {
+	Level   slog.Level
+	NoColor bool
+}
+
+// HumanHandler は人間が読みやすい形式でログを出力する slog.Handler 実装。
+type HumanHandler struct {
+	w       io.Writer
+	opts    HumanHandlerOptions
+	attrs   []slog.Attr
+	groups  []string
+	mu      *sync.Mutex
+}
+
+// NewHumanHandler は新しい HumanHandler を生成する。
+func NewHumanHandler(w io.Writer, opts *HumanHandlerOptions) *HumanHandler {
+	o := HumanHandlerOptions{
+		Level: slog.LevelInfo,
+	}
+	if opts != nil {
+		o = *opts
+	}
+	return &HumanHandler{
+		w:    w,
+		opts: o,
+		mu:   &sync.Mutex{},
+	}
+}
+
+// Enabled は指定レベルのログを出力するかどうかを返す。
+func (h *HumanHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.opts.Level
+}
+
+// Handle はログレコードをフォーマットして出力する。
+func (h *HumanHandler) Handle(_ context.Context, r slog.Record) error {
+	// 記号
+	prefix := levelPrefix(r.Level)
+
+	// 日時
+	timeStr := r.Time.Format("2006-01-02 15:04:05")
+
+	// 属性の収集
+	var attrs []slog.Attr
+	attrs = append(attrs, h.attrs...)
+	r.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a)
+		return true
+	})
+
+	// 属性文字列の構築
+	attrStr := ""
+	if len(attrs) > 0 {
+		attrStr = " ("
+		for i, a := range attrs {
+			if i > 0 {
+				attrStr += ", "
+			}
+			attrStr += fmt.Sprintf("%s=%v", a.Key, a.Value)
+		}
+		attrStr += ")"
+	}
+
+	line := fmt.Sprintf("%s[%s] %s%s\n", prefix, timeStr, r.Message, attrStr)
+
+	// 色付け
+	if !h.opts.NoColor {
+		line = colorize(r.Level, line)
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, err := io.WriteString(h.w, line)
+	return err
+}
+
+// WithAttrs は属性を追加した新しいハンドラを返す。
+func (h *HumanHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newAttrs := make([]slog.Attr, len(h.attrs), len(h.attrs)+len(attrs))
+	copy(newAttrs, h.attrs)
+	newAttrs = append(newAttrs, attrs...)
+	return &HumanHandler{
+		w:      h.w,
+		opts:   h.opts,
+		attrs:  newAttrs,
+		groups: h.groups,
+		mu:     h.mu,
+	}
+}
+
+// WithGroup はグループを追加した新しいハンドラを返す。
+func (h *HumanHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	newGroups := make([]string, len(h.groups), len(h.groups)+1)
+	copy(newGroups, h.groups)
+	newGroups = append(newGroups, name)
+	return &HumanHandler{
+		w:      h.w,
+		opts:   h.opts,
+		attrs:  h.attrs,
+		groups: newGroups,
+		mu:     h.mu,
+	}
+}
+
+func levelPrefix(level slog.Level) string {
+	switch {
+	case level >= slog.LevelError:
+		return "x "
+	case level >= slog.LevelWarn:
+		return "! "
+	default:
+		return "  "
+	}
+}
+
+func colorize(level slog.Level, line string) string {
+	switch {
+	case level >= slog.LevelError:
+		return "\033[31m" + line + "\033[0m"
+	case level >= slog.LevelWarn:
+		return "\033[33m" + line + "\033[0m"
+	case level >= slog.LevelInfo:
+		return line
+	default:
+		// Debug: gray
+		return "\033[90m" + line + "\033[0m"
+	}
+}

--- a/internal/infra/logging/handler.go
+++ b/internal/infra/logging/handler.go
@@ -16,11 +16,11 @@ type HumanHandlerOptions struct {
 
 // HumanHandler は人間が読みやすい形式でログを出力する slog.Handler 実装。
 type HumanHandler struct {
-	w       io.Writer
-	opts    HumanHandlerOptions
-	attrs   []slog.Attr
-	groups  []string
-	mu      *sync.Mutex
+	w      io.Writer
+	opts   HumanHandlerOptions
+	attrs  []slog.Attr
+	groups []string
+	mu     *sync.Mutex
 }
 
 // NewHumanHandler は新しい HumanHandler を生成する。

--- a/internal/infra/logging/handler.go
+++ b/internal/infra/logging/handler.go
@@ -45,13 +45,9 @@ func (h *HumanHandler) Enabled(_ context.Context, level slog.Level) bool {
 
 // Handle はログレコードをフォーマットして出力する。
 func (h *HumanHandler) Handle(_ context.Context, r slog.Record) error {
-	// 記号
 	prefix := levelPrefix(r.Level)
-
-	// 日時
 	timeStr := r.Time.Format("2006-01-02 15:04:05")
 
-	// 属性の収集
 	var attrs []slog.Attr
 	attrs = append(attrs, h.attrs...)
 	r.Attrs(func(a slog.Attr) bool {
@@ -59,7 +55,6 @@ func (h *HumanHandler) Handle(_ context.Context, r slog.Record) error {
 		return true
 	})
 
-	// 属性文字列の構築
 	attrStr := ""
 	if len(attrs) > 0 {
 		attrStr = " ("
@@ -74,7 +69,6 @@ func (h *HumanHandler) Handle(_ context.Context, r slog.Record) error {
 
 	line := fmt.Sprintf("%s[%s] %s%s\n", prefix, timeStr, r.Message, attrStr)
 
-	// 色付け
 	if !h.opts.NoColor {
 		line = colorize(r.Level, line)
 	}

--- a/internal/infra/logging/handler_test.go
+++ b/internal/infra/logging/handler_test.go
@@ -13,8 +13,8 @@ import (
 func TestHumanHandler_Handle_InfoMessageOnly(t *testing.T) {
 	var buf bytes.Buffer
 	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
-		Level:    slog.LevelInfo,
-		NoColor:  true,
+		Level:   slog.LevelInfo,
+		NoColor: true,
 	})
 	logger := slog.New(h)
 

--- a/internal/infra/logging/handler_test.go
+++ b/internal/infra/logging/handler_test.go
@@ -1,0 +1,259 @@
+package logging_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/infra/logging"
+)
+
+func TestHumanHandler_Handle_InfoMessageOnly(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:    slog.LevelInfo,
+		NoColor:  true,
+	})
+	logger := slog.New(h)
+
+	logger.Info("hello world")
+
+	output := buf.String()
+	// 先頭は空白2文字（Info記号）
+	if !strings.HasPrefix(output, "  [") {
+		t.Errorf("expected prefix '  [', got: %q", output)
+	}
+	// メッセージが含まれる
+	if !strings.Contains(output, "hello world") {
+		t.Errorf("expected output to contain 'hello world', got: %q", output)
+	}
+	// 属性なしなので括弧がない
+	if strings.Contains(output, "(") {
+		t.Errorf("expected no attributes section, got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_InfoWithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+	})
+	logger := slog.New(h)
+
+	logger.Info("scripts loaded", "path", "/tmp/test.txt", "count", 5)
+
+	output := buf.String()
+	if !strings.Contains(output, "scripts loaded (path=/tmp/test.txt, count=5)") {
+		t.Errorf("expected formatted attrs, got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_WarnPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelWarn,
+		NoColor: true,
+	})
+	logger := slog.New(h)
+
+	logger.Warn("something wrong")
+
+	output := buf.String()
+	if !strings.HasPrefix(output, "! [") {
+		t.Errorf("expected Warn prefix '! [', got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_ErrorPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelError,
+		NoColor: true,
+	})
+	logger := slog.New(h)
+
+	logger.Error("fatal error")
+
+	output := buf.String()
+	if !strings.HasPrefix(output, "x [") {
+		t.Errorf("expected Error prefix 'x [', got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_DebugPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelDebug,
+		NoColor: true,
+	})
+	logger := slog.New(h)
+
+	logger.Debug("debug info")
+
+	output := buf.String()
+	if !strings.HasPrefix(output, "  [") {
+		t.Errorf("expected Debug prefix '  [', got: %q", output)
+	}
+	if !strings.Contains(output, "debug info") {
+		t.Errorf("expected output to contain 'debug info', got: %q", output)
+	}
+}
+
+func TestHumanHandler_Enabled_RespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+	})
+
+	if h.Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("expected Debug to be disabled when level is Info")
+	}
+	if !h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("expected Info to be enabled when level is Info")
+	}
+	if !h.Enabled(context.Background(), slog.LevelWarn) {
+		t.Error("expected Warn to be enabled when level is Info")
+	}
+}
+
+func TestHumanHandler_Handle_DateTimeFormat(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+	})
+	logger := slog.New(h)
+
+	logger.Info("test")
+
+	output := buf.String()
+	// 日時フォーマット: [YYYY-MM-DD HH:MM:SS]
+	// 正規表現的に確認: "  [2026-04-11 " のようなパターン
+	if !strings.Contains(output, "[20") {
+		t.Errorf("expected datetime in output, got: %q", output)
+	}
+	if strings.Contains(output, "+") {
+		t.Errorf("expected no timezone offset in output, got: %q", output)
+	}
+}
+
+func TestHumanHandler_WithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+	})
+	logger := slog.New(h).With("component", "test")
+
+	logger.Info("hello")
+
+	output := buf.String()
+	if !strings.Contains(output, "component=test") {
+		t.Errorf("expected WithAttrs to include 'component=test', got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_ColorDisabledByNoColor(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelWarn,
+		NoColor: true,
+	})
+	logger := slog.New(h)
+
+	logger.Warn("warning")
+
+	output := buf.String()
+	// ANSI escape sequence should not be present
+	if strings.Contains(output, "\033[") {
+		t.Errorf("expected no ANSI escape when NoColor=true, got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_ColorEnabledForWarn(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelWarn,
+		NoColor: false,
+	})
+	logger := slog.New(h)
+
+	logger.Warn("warning")
+
+	output := buf.String()
+	// Yellow ANSI escape
+	if !strings.Contains(output, "\033[33m") {
+		t.Errorf("expected yellow ANSI escape for Warn, got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_ColorEnabledForError(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelError,
+		NoColor: false,
+	})
+	logger := slog.New(h)
+
+	logger.Error("error msg")
+
+	output := buf.String()
+	// Red ANSI escape
+	if !strings.Contains(output, "\033[31m") {
+		t.Errorf("expected red ANSI escape for Error, got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_ColorEnabledForDebug(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelDebug,
+		NoColor: false,
+	})
+	logger := slog.New(h)
+
+	logger.Debug("debug msg")
+
+	output := buf.String()
+	// Gray ANSI escape (\033[90m)
+	if !strings.Contains(output, "\033[90m") {
+		t.Errorf("expected gray ANSI escape for Debug, got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_ColorEnabledForInfo(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: false,
+	})
+	logger := slog.New(h)
+
+	logger.Info("info msg")
+
+	output := buf.String()
+	// Info should have no color (no ANSI escape)
+	if strings.Contains(output, "\033[") {
+		t.Errorf("expected no ANSI escape for Info, got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_NewlineTerminated(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+	})
+	logger := slog.New(h)
+
+	logger.Info("test")
+
+	output := buf.String()
+	if !strings.HasSuffix(output, "\n") {
+		t.Errorf("expected output to end with newline, got: %q", output)
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/infra/logging/` に自前の `slog.Handler`（`HumanHandler`）を実装
- ログ出力を `{記号} [{日時}] {メッセージ} (key=value, ...)` 形式に統一
- レベルに応じた色付け（Debug:グレー / Info:色なし / Warn:黄 / Error:赤）
- TTY判定（`golang.org/x/term`）と `NO_COLOR` 環境変数による色付け制御
- `cmd/act.go` / `cmd/say.go` のロガー初期化を新ハンドラに変更
- 既存テストを新ハンドラ（`HumanHandler`）を使うように更新

Closes #165

## Test plan

- [x] `internal/infra/logging/` の新規テスト14件がすべてPASS
- [x] 既存テスト（`act_usecase_test.go`, `watch_usecase_test.go`）が新ハンドラで全件PASS
- [x] `go test ./...` で全パッケージのテストがPASS
- [x] `golangci-lint run` で指摘ゼロ
- [ ] 実際に `act` / `say` を手元で動かし、出力が従来より読みやすくなっていることを確認する

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)