### PR TITLE
auto-monologue-pluginのフック呼び出しを必須化しバージョンを0.0.3に更新

### DIFF
--- a/plugins/auto-monologue-plugin/.claude-plugin/plugin.json
+++ b/plugins/auto-monologue-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-monologue-plugin",
   "description": "独り言を自動的に生成するためのプラグイン",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": {
     "name": "canpok1"
   }

--- a/plugins/auto-monologue-plugin/scripts/monologue-pre-skill.sh
+++ b/plugins/auto-monologue-plugin/scripts/monologue-pre-skill.sh
@@ -6,6 +6,6 @@ cat > /dev/null
 jq -n '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",
-    additionalContext: "現在の作業が以下のいずれかのタイミングに該当する場合、/vox-actor-plugin:monologue スキルを呼び出してキャラクターの独り言を通知してください。\n- 作業開始時・終了時\n- ステップの開始時・終了時\n- 想定外のことが起こった時\n- ユーザー確認が必要な時\n- 新しい発見があったとき\n\n該当しない場合は無視してください。"
+    additionalContext: "これから実行しようとしているスキルの状況に合わせて、/vox-actor-plugin:monologue スキルを必ず呼び出してキャラクターの独り言を通知してください。呼び出しをスキップしてはいけません。"
   }
 }'


### PR DESCRIPTION
## Summary
- PreToolUseフックの `additionalContext` を条件判定なしで必ず `/vox-actor-plugin:monologue` スキルを呼び出す表現に変更
- auto-monologue-plugin のバージョンを 0.0.2 → 0.0.3 に更新

## Test plan
- [ ] Skill実行時にmonologueスキルが常に呼び出されることを確認
- [ ] plugin.jsonのバージョン表記が0.0.3になっていることを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)