### PR TITLE
monologueスキル: VOX_ACTOR_WORKSPACE未指定時のデフォルト出力先を追加 #177

### DIFF
--- a/plugins/vox-actor-plugin/.claude-plugin/plugin.json
+++ b/plugins/vox-actor-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-actor-plugin",
   "description": "vox-actorを利用するためのプラグイン",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "canpok1"
   }

--- a/plugins/vox-actor-plugin/skills/monologue/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/monologue/SKILL.md
@@ -68,8 +68,8 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 通知の実行に使用する `${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh` は以下の前提条件を必要とする:
 
-- **環境変数 `VOX_ACTOR_WORKSPACE`**: 必須。通知ファイルの出力先ディレクトリを指定する。未設定の場合、スクリプトはエラー終了する
-- **通知ディレクトリ**: `${VOX_ACTOR_WORKSPACE}/` に通知ファイルを書き出す。ディレクトリが存在しない場合はスクリプトが自動作成する
+- **環境変数 `VOX_ACTOR_WORKSPACE`**: 通知ファイルの出力先ディレクトリを指定する。未設定の場合はgitリポジトリ直下の `.tmp/notify` がデフォルト出力先として使用される。gitリポジトリ外かつ未設定の場合はエラー終了する
+- **通知ディレクトリ**: 出力先ディレクトリ（`${VOX_ACTOR_WORKSPACE}` またはデフォルトの `<gitリポジトリ直下>/.tmp/notify`）に通知ファイルを書き出す。ディレクトリが存在しない場合はスクリプトが自動作成する
 - **通知ファイル形式**: `notify_{ミリ秒タイムスタンプ}.json` として作成される。JSON形式（`{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`）で出力される。外部の通知監視プロセスがこのファイルを検知してユーザーに通知する
 
 ## キャラクター設定ファイルについて

--- a/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
+++ b/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 if [ -z "$VOX_ACTOR_WORKSPACE" ]; then
-  echo "[ERROR] 環境変数 'VOX_ACTOR_WORKSPACE' が設定されていません。"
-  exit 1
+  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  if [ -z "$GIT_COMMON_DIR" ]; then
+    echo "[ERROR] 環境変数 'VOX_ACTOR_WORKSPACE' が設定されておらず、gitリポジトリ外のためデフォルト出力先を決定できません。"
+    exit 1
+  fi
+  VOX_ACTOR_WORKSPACE="$(dirname "$GIT_COMMON_DIR")/.tmp/notify"
 fi
 
 PROBABILITY="$1"


### PR DESCRIPTION
## Summary

- `monologue.sh` で環境変数 `VOX_ACTOR_WORKSPACE` が未設定の場合、`git rev-parse --git-common-dir` からリポジトリルートを特定して `<gitリポジトリ直下>/.tmp/notify` をデフォルト出力先として使用するよう変更
- gitリポジトリ外で実行された場合は従来通りエラー終了
- SKILL.md の前提条件の記述を新仕様に合わせて更新
- vox-actor-plugin のバージョンを 0.0.1 → 0.0.2 に更新

## 動作確認

- [x] `VOX_ACTOR_WORKSPACE` 未設定 + gitリポジトリ内 → `<リポジトリ直下>/.tmp/notify` に通知ファイル生成を確認
- [x] `VOX_ACTOR_WORKSPACE` 未設定 + gitリポジトリ外 → エラー終了を確認
- [x] `shellcheck` パス

Closes #177

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)