### PR TITLE
monologueスキル: vox-actorコマンド利用可能時はdirectモードで通知 #181

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,25 +227,28 @@ vox-actor act --verbose script.txt
 
 ### claude codeなどのLLMの作業状況を音声で通知する
 
-LLMの作業状況を指定ディレクトリにテキストファイルとして出力し、vox-actorの監視モードで読み上げることで、作業の進捗を音声で把握できます。
+LLMの作業状況を音声で通知できます。通知方式は実行環境に応じて2種類あります。
+
+- **`direct` モード**: `vox-actor say` をその場で直接呼び出す方式。監視プロセスの常駐が不要で、ファイルI/Oやポーリング遅延も発生しない。`vox-actor` コマンドが `PATH` 上に存在する環境で利用できる
+- **`file` モード**: テキストファイルを指定ディレクトリに書き出し、別プロセスで起動した `vox-actor watch` が読み上げる方式。`vox-actor` コマンドがない端末からでも（共有ディレクトリ経由で）利用できる
+
+どちらを使うかは `VOX_ACTOR_MONOLOGUE_MODE` 環境変数で明示するか、未設定時は `vox-actor` コマンドの有無で自動判定されます（あり → `direct`、なし → `file`）。
 
 claude code向けプラグインを同梱しているので、claude codeでは簡単に導入できます。同梱プラグインは以下の2種類です。
 
 - `vox-actor-plugin`: 独り言スキル（`/vox-actor-plugin:monologue`）を提供するプラグイン
 - `auto-monologue-plugin`: Stop hookでClaudeに独り言スキルの活用を促すプラグイン（`vox-actor-plugin` と併用することで、作業の区切りで独り言が自動生成されるようになる）
 
-1. 環境変数を設定する。
+#### セットアップ（`direct` モード）
+
+1. 環境変数を設定する（エラーログ出力先の指定。任意）。
    ```
-   # テキストファイルの出力先ディレクトリを指定
    export VOX_ACTOR_WORKSPACE=/path/to/directory
+   # VOICEVOXエンジンのURLがデフォルトでない場合のみ
+   export VOX_ENGINE_URL=http://localhost:50021
    ```
 
-2. vox-actorを監視モードで起動する。
-   ```
-   vox-actor watch $VOX_ACTOR_WORKSPACE
-   ```
-
-3. claude codeにプラグインを導入する。
+2. claude codeにプラグインを導入する。
    ```
    # claude code上で実行
    /plugin marketplace add canpok1/vox-actor
@@ -254,12 +257,33 @@ claude code向けプラグインを同梱しているので、claude codeでは�
    /plugin install auto-monologue-plugin@vox-actor-marketplace
    ```
 
-4. 独り言スキル（monologue）を実行する。
+3. 独り言スキル（monologue）を実行する。
    ```
    # claude code上で実行
    /vox-actor-plugin:monologue
    ```
    `auto-monologue-plugin` を導入している場合は、作業の区切りで自動的に独り言が生成される。
+
+`vox-actor say` の失敗は `$VOX_ACTOR_WORKSPACE/monologue-errors.log` に追記されるので、`tail -f` で確認できます（ログは末尾200行でローテーション）。複数セッションから並列に呼ばれても許容されます（エンジンへのリクエストや音声再生が重なる場合があります）。逐次再生したい場合は後述の `file` モードに切り替えてください。
+
+#### セットアップ（`file` モード）
+
+`vox-actor` コマンドが手元にない環境や、監視プロセスで逐次再生したい場合に使います。
+
+1. 環境変数を設定する。
+   ```
+   # テキストファイルの出力先ディレクトリを指定
+   export VOX_ACTOR_WORKSPACE=/path/to/directory
+   # モードを明示する場合（vox-actorコマンドがある環境で file モードを強制したい場合）
+   export VOX_ACTOR_MONOLOGUE_MODE=file
+   ```
+
+2. vox-actorを監視モードで起動する。
+   ```
+   vox-actor watch $VOX_ACTOR_WORKSPACE
+   ```
+
+3. claude codeにプラグインを導入し、独り言スキルを実行する（`direct` モードと同じ手順）。
 
 
 ## 開発

--- a/plugins/vox-actor-plugin/.claude-plugin/plugin.json
+++ b/plugins/vox-actor-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-actor-plugin",
   "description": "vox-actorを利用するためのプラグイン",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": {
     "name": "canpok1"
   }

--- a/plugins/vox-actor-plugin/skills/monologue/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/monologue/SKILL.md
@@ -68,9 +68,28 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 通知の実行に使用する `${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh` は以下の前提条件を必要とする:
 
-- **環境変数 `VOX_ACTOR_WORKSPACE`**: 通知ファイルの出力先ディレクトリを指定する。未設定の場合はgitリポジトリ直下の `.tmp/notify` がデフォルト出力先として使用される。gitリポジトリ外かつ未設定の場合はエラー終了する
-- **通知ディレクトリ**: 出力先ディレクトリ（`${VOX_ACTOR_WORKSPACE}` またはデフォルトの `<gitリポジトリ直下>/.tmp/notify`）に通知ファイルを書き出す。ディレクトリが存在しない場合はスクリプトが自動作成する
-- **通知ファイル形式**: `notify_{ミリ秒タイムスタンプ}.json` として作成される。JSON形式（`{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`）で出力される。外部の通知監視プロセスがこのファイルを検知してユーザーに通知する
+- **環境変数 `VOX_ACTOR_WORKSPACE`**: 通知ファイルやエラーログの出力先ディレクトリを指定する。未設定の場合はgitリポジトリ直下の `.tmp/notify` がデフォルト出力先として使用される。gitリポジトリ外かつ未設定の場合はエラー終了する
+- **出力先ディレクトリ**: `${VOX_ACTOR_WORKSPACE}` またはデフォルトの `<gitリポジトリ直下>/.tmp/notify`。ディレクトリが存在しない場合はスクリプトが自動作成する
+
+### 通知モード
+
+通知方式は以下のルールで自動切替する:
+
+1. 環境変数 `VOX_ACTOR_MONOLOGUE_MODE` が設定されていればそれに従う（`direct` または `file`）
+2. 未設定なら `vox-actor` コマンドの有無で判定する（あり → `direct`、なし → `file`）
+
+#### `direct` モード
+
+`vox-actor say --speaker <スピーカーID> --speed <話速> "<セリフ>"` をバックグラウンドで起動し、スクリプトは即座に戻る。
+
+- VOICEVOXエンジンのURLは `vox-actor` 側の環境変数 `VOX_ENGINE_URL` で解決する（非デフォルトポート時はユーザーが設定）
+- 監視プロセス（`vox-actor watch`）の常駐は不要
+- 複数セッションから並列に呼ばれても許容する（エンジンへの並列リクエストと音声再生の重なりは発生するがエラーにはならない）。逐次再生が必要な場合は `VOX_ACTOR_MONOLOGUE_MODE=file` + 監視プロセス構成に切り替えれば対応可能
+- `vox-actor say` 失敗時もスクリプト本体はエラー終了せず、標準出力/標準エラーの内容を `${VOX_ACTOR_WORKSPACE}/monologue-errors.log` にタイムスタンプ付きで追記する。ログは末尾200行でローテーションされる。失敗検知は `tail -f ${VOX_ACTOR_WORKSPACE}/monologue-errors.log` で行える
+
+#### `file` モード
+
+`${VOX_ACTOR_WORKSPACE}` に通知ファイルを書き出す。ファイル名は `notify_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）がこのファイルを検知して読み上げる
 
 ## キャラクター設定ファイルについて
 

--- a/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
+++ b/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
@@ -48,12 +48,51 @@ if ! [[ "$SPEED_SCALE" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
   exit 1
 fi
 
-# 乱数判定: ROLL <= PROBABILITY なら通知する
 ROLL=$((RANDOM % 100 + 1))
 if [ "$ROLL" -gt "$PROBABILITY" ]; then
   exit 0
 fi
 
+MODE="${VOX_ACTOR_MONOLOGUE_MODE:-}"
+if [ -z "$MODE" ]; then
+  if command -v vox-actor >/dev/null 2>&1; then
+    MODE="direct"
+  else
+    MODE="file"
+  fi
+fi
+
 mkdir -p "$VOX_ACTOR_WORKSPACE"
-jq -cn --argjson speaker "$SPEAKER" --arg text "$TEXT" --argjson speedScale "$SPEED_SCALE" \
-  '{speaker: $speaker, text: $text, speedScale: $speedScale}' > "${VOX_ACTOR_WORKSPACE}/notify_$(($(date +%s%N)/1000000)).json"
+
+case "$MODE" in
+  direct)
+    ERROR_LOG="${VOX_ACTOR_WORKSPACE}/monologue-errors.log"
+    MAX_LOG_LINES=200
+    (
+      OUTPUT=$(vox-actor say --speaker "$SPEAKER" --speed "$SPEED_SCALE" "$TEXT" 2>&1)
+      STATUS=$?
+      if [ "$STATUS" -ne 0 ]; then
+        TS=$(date '+%Y-%m-%d %H:%M:%S')
+        {
+          echo "[$TS] exit=$STATUS speaker=$SPEAKER speed=$SPEED_SCALE text=$TEXT"
+          printf '%s\n' "$OUTPUT" | sed 's/^/  /'
+        } >> "$ERROR_LOG"
+        LINES=$(wc -l < "$ERROR_LOG")
+        if [ "$LINES" -gt "$MAX_LOG_LINES" ]; then
+          TMP_LOG=$(mktemp "${ERROR_LOG}.XXXXXX")
+          tail -n "$MAX_LOG_LINES" "$ERROR_LOG" > "$TMP_LOG"
+          mv "$TMP_LOG" "$ERROR_LOG"
+        fi
+      fi
+    ) </dev/null >/dev/null 2>&1 &
+    disown 2>/dev/null
+    ;;
+  file)
+    jq -cn --argjson speaker "$SPEAKER" --arg text "$TEXT" --argjson speedScale "$SPEED_SCALE" \
+      '{speaker: $speaker, text: $text, speedScale: $speedScale}' > "${VOX_ACTOR_WORKSPACE}/notify_$(($(date +%s%N)/1000000)).json"
+    ;;
+  *)
+    echo "[ERROR] VOX_ACTOR_MONOLOGUE_MODE は 'direct' または 'file' で指定してください: '$MODE'"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- `plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh` に `direct` モードを追加。`vox-actor` コマンドが `PATH` 上にあれば `vox-actor say` をバックグラウンド起動して通知する
- 環境変数 `VOX_ACTOR_MONOLOGUE_MODE` で `direct` / `file` を強制切替可能。未設定なら `command -v vox-actor` で自動判定
- `direct` モード失敗時は `${VOX_ACTOR_WORKSPACE}/monologue-errors.log` にタイムスタンプ付きで追記し、末尾200行でローテーション。スクリプト本体はエラー終了しない
- `SKILL.md` / `README.md` を両モード・エラーログ確認方法・並列実行時の挙動を含めて更新
- `plugins/vox-actor-plugin/.claude-plugin/plugin.json` の `version` を `0.0.2` → `0.0.3`

## 受け入れ条件の対応

- [x] `vox-actor` コマンドの有無に応じて `direct` / `file` モードが自動判定される
- [x] `VOX_ACTOR_MONOLOGUE_MODE` で両モードを強制できる
- [x] `direct` モードでは `vox-actor say` がバックグラウンド実行され、スクリプトは即座に戻る
- [x] `direct` モードで `VOX_ENGINE_URL` の指定が `vox-actor` 側を通じて反映される
- [x] `vox-actor say` 失敗時、スクリプト本体はエラー終了せず `monologue-errors.log` にタイムスタンプ付きで追記される
- [x] ログファイルが一定行数（200行）を超えないようローテーションされる
- [x] 既存の引数バリデーションが両モードで機能する
- [x] 乱数判定でスキップされるケースで `vox-actor say` が起動されない
- [x] `SKILL.md` と `README.md` が更新される
- [x] `plugin.json` の `version` を `0.0.3` に更新
- [x] `shellcheck` 指摘なし

## Test plan

- [x] `shellcheck plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh` で指摘がないこと
- [x] 引数バリデーション（確率/話者ID/話速/モード）の各エラーケース確認
- [x] `vox-actor` 未インストール環境での自動判定 → `file` モード動作
- [x] ダミーコマンドで `direct` モード自動判定 → `vox-actor say` 呼び出し確認
- [x] `VOX_ACTOR_MONOLOGUE_MODE=file` / `direct` の強制切替確認
- [x] `direct` モード失敗時のエラーログ追記・200行ローテーション
- [x] バックグラウンド起動でスクリプトが即座（約2ms）に戻ること
- [x] 乱数スキップ時は `vox-actor` が起動しないこと（30/30件確認）

Closes #181

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)