### PR TITLE
docs: README構成整理 - LLM連携をメイン用途として前面化 #183

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,161 @@
 # vox-actor
 
-テキストファイルやテキストをVOICEVOXエンジンで音声合成し、読み上げるCLIツールです。
+**LLMの作業を"声"で届ける、VOICEVOX読み上げCLI**
 
-## クイックスタート
+## ✨ 特徴
+
+- **LLM向けに設計** — claude code連携プラグインを同梱。`vox-actor` が `PATH` 上にあれば監視プロセス不要で即座に読み上げ
+- **多彩な入力** — 直接テキスト／テキストファイル／JSON台本／ディレクトリ監視に対応
+- **感情制御** — キャラクター・話速・音高・抑揚をセリフ単位で調整可能
+
+## 🚀 クイックスタート（LLM連携フロー）
+
+claude code で作業の区切りごとに独り言を読み上げさせる最短手順です。`vox-actor` コマンドが `PATH` 上にある環境では `direct` モードで動作し、`vox-actor watch` の常駐や `VOX_ACTOR_WORKSPACE` の設定は不要です。
 
 1. **VOICEVOXエンジンを起動する**
 
    - インストーラー版: [公式サイト](https://voicevox.hiroshiba.jp/)からダウンロードしてインストール後、アプリを起動する
    - Docker版: `docker run --rm -p 50021:50021 voicevox/voicevox_engine:latest`
 
-2. **vox-actorをインストールする**
+2. **vox-actorをインストールする（Homebrew）**
+
+   ```bash
+   brew tap canpok1/tap
+   brew install --cask vox-actor
+   ```
+
+   Homebrew以外のインストール方法は[インストール方法](#-インストール方法)を参照してください。
+
+3. **claude codeにプラグインを導入する**
+
+   ```
+   # claude code上で実行
+   /plugin marketplace add canpok1/vox-actor
+   /plugin install vox-actor-plugin@vox-actor-marketplace
+   # 自動で独り言を生成したい場合は auto-monologue-plugin も導入
+   /plugin install auto-monologue-plugin@vox-actor-marketplace
+   ```
+
+4. **作業の区切りで自動的に独り言が読み上げられる**
+
+   `auto-monologue-plugin` を導入していれば、claude code の作業の区切りごとに自動で独り言が生成・読み上げされます。手動で呼び出す場合は `/vox-actor-plugin:monologue` を実行します。
+
+> **💡 リモート環境で使う場合や複数セッションの音声を逐次再生したい場合**
+> `direct` モードは同時呼び出し時に音声が並列再生されます。ホストとclaude code実行環境が分かれている場合や、逐次再生したい場合は[🔀 高度な利用（リモート環境・監視モード）](#-高度な利用リモート環境監視モード)を参照してください。
+
+## 🛠 その他の使い方
+
+LLM連携を使わず、CLIとして単体で使う場合の例です。
+
+### テキストの直接読み上げ
+
+```bash
+vox-actor say "こんにちは"
+```
+
+キャラクターや音声パラメータを指定する場合:
+
+```bash
+vox-actor say --speaker 3 --speed 1.2 "こんにちは"
+```
+
+### テキストファイルの読み上げ
+
+```bash
+vox-actor act script.txt
+```
+
+話速・音高・抑揚を調整する場合:
+
+```bash
+vox-actor act --speed 1.2 --pitch 0.1 --intonation 1.5 script.txt
+```
+
+### JSON台本モード（感情制御パラメータ付き）
+
+`.json` ファイルを使うと、セリフごとにキャラクターや感情パラメータを指定できます。
+
+```json
+{
+  "text": "こんにちは",
+  "speaker": 3,
+  "speedScale": 1.2,
+  "pitchScale": 0.1,
+  "intonationScale": 1.5
+}
+```
+
+```bash
+vox-actor act script.json
+```
+
+`text` のみ必須で、他のパラメータは省略可能です。省略した場合はCLIオプションのデフォルト値が使われます。
+
+ディレクトリを指定した場合、`.txt` と `.json` の両方が辞書順で読み上げられます。
+
+### バージョン確認
+
+```bash
+vox-actor --version
+```
+
+## 📖 コマンドリファレンス
+
+オプションの優先順位: **CLIフラグ > 環境変数 > デフォルト値**
+
+### `say` サブコマンド
+
+テキストを直接引数で渡して読み上げる。
+
+| オプション | 環境変数 | デフォルト値 | 説明 |
+|---|---|---|---|
+| `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
+| `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
+| `--speed` | — | `1.0` | 話速 |
+| `--pitch` | — | `0.0` | 音高 |
+| `--intonation` | — | `1.0` | 抑揚 |
+| `--verbose` | — | `false` | 詳細ログを出力 |
+
+### `act` サブコマンド
+
+テキストファイル／JSON台本／ディレクトリを読み上げる。
+
+| オプション | 環境変数 | デフォルト値 | 説明 |
+|---|---|---|---|
+| `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
+| `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
+| `--speed` | — | `1.0` | 話速 |
+| `--pitch` | — | `0.0` | 音高 |
+| `--intonation` | — | `1.0` | 抑揚 |
+| `--watch` | — | `false` | ディレクトリ監視モードを有効化（後方互換。[高度な利用](#-高度な利用リモート環境監視モード)参照） |
+| `--watch-delete` | — | `false` | ディレクトリ監視モード（処理済みファイルを削除。後方互換） |
+| `--verbose` | — | `false` | 詳細ログを出力 |
+
+### `watch` サブコマンド
+
+1つ以上のディレクトリを並列監視し、配置されたファイルを検知順に逐次再生する。
+
+| オプション | 環境変数 | デフォルト値 | 説明 |
+|---|---|---|---|
+| `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
+| `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
+| `--speed` | — | `1.0` | 話速 |
+| `--pitch` | — | `0.0` | 音高 |
+| `--intonation` | — | `1.0` | 抑揚 |
+| `--delete` | — | `false` | 処理済みファイルを削除（未指定時は各ディレクトリの `done/` に移動） |
+| `--verbose` | — | `false` | 詳細ログを出力 |
+
+## 📦 インストール方法
+
+お好みの方法でインストールできます。
+
+- **Homebrew（macOS/Linux）**
+   ```bash
+   brew tap canpok1/tap
+   brew install --cask vox-actor
+   ```
+
+- **バイナリダウンロード**
 
    [GitHub Releases](https://github.com/canpok1/vox-actor/releases)からビルド済みバイナリをダウンロードして配置します。
 
@@ -30,135 +176,75 @@
    sudo mv vox-actor /usr/local/bin/
    ```
 
-3. **テキストを読み上げる**
-
-   ```bash
-   vox-actor say "こんにちは"
-   ```
-
-4. **ディレクトリを監視して自動読み上げする**
-
-   ```bash
-   vox-actor watch /path/to/watch-dir
-   ```
-
-   複数ディレクトリを同時に監視する場合は、スペース区切りでパスを追加できます。
-
-   ```bash
-   vox-actor watch /path/to/dir-a /path/to/dir-b
-   ```
-
-   別のターミナルからテキストファイルを配置すると、自動的に読み上げられます。
-
-   ```bash
-   echo "こんばんは" > /path/to/watch-dir/sample.txt
-   ```
-
-## 前提条件
-
-- Go 1.26.1 以上（ソースからビルドする場合）
-- [VOICEVOX エンジン](https://voicevox.hiroshiba.jp/)が起動していること（デフォルト: `http://localhost:50021`）
-  - インストーラー版: [公式サイト](https://voicevox.hiroshiba.jp/)からダウンロードしてインストール後、アプリを起動する
-  - Docker版: `docker run --rm -p 50021:50021 voicevox/voicevox_engine:latest`
-
-## インストール
-
-- バイナリをダウンロードする場合
-   - [GitHub Releases](https://github.com/canpok1/vox-actor/releases)からビルド済みバイナリをダウンロードして配置してください。
-
-- Homebrewを使う場合（macOS/Linux）:
-   ```bash
-   brew tap canpok1/tap
-   brew install --cask vox-actor
-   ```
-
-- Goの`install`コマンドを使う場合
+- **`go install` を使う**
    ```bash
    go install github.com/canpok1/vox-actor@latest
    ```
 
-- ソースからビルドする場合
+- **ソースからビルド**
    ```bash
    git clone https://github.com/canpok1/vox-actor.git
    cd vox-actor
    make build
    ```
 
-## バージョン確認
+## 🧩 前提条件
 
-```bash
-vox-actor --version
-```
+- [VOICEVOXエンジン](https://voicevox.hiroshiba.jp/) が起動していること（デフォルト: `http://localhost:50021`）
+  - インストーラー版: [公式サイト](https://voicevox.hiroshiba.jp/)からダウンロードしてインストール後、アプリを起動する
+  - Docker版: `docker run --rm -p 50021:50021 voicevox/voicevox_engine:latest`
+- Go 1.26.1 以上（ソースからビルドする場合のみ）
 
-## 使い方
+## 🔀 高度な利用（リモート環境・監視モード）
 
-### テキストの直接読み上げ
+以下のようなケースでは、`watch` コマンドを常駐させる `file` モードでの利用が適しています。
 
-```bash
-vox-actor say "こんにちは"
-```
+- claude code がコンテナ／リモート環境で動作し、`vox-actor` コマンドはホスト側にしか存在しない
+- 複数セッションから同時に呼ばれても音声を逐次再生したい（`direct` モードは並列再生になる）
 
-キャラクターや音声パラメータを指定する場合:
+### `direct` モードと `file` モードの違い
 
-```bash
-vox-actor say --speaker 3 --speed 1.2 "こんにちは"
-```
+| 観点 | `direct` モード | `file` モード |
+|---|---|---|
+| 読み上げ方式 | `vox-actor say` をその場で直接呼び出す | テキスト等をファイルに書き出し、別プロセスの `vox-actor watch` が読み上げる |
+| 監視プロセス | 不要 | `vox-actor watch` の常駐が必要 |
+| `VOX_ACTOR_WORKSPACE` | 任意（エラーログ出力先として使用） | 必須（ファイル受け渡し用ディレクトリ） |
+| 同時呼び出し時 | 並列再生 | 検知順に逐次再生 |
+| 前提 | `vox-actor` コマンドが `PATH` 上にある | claude code 側と `vox-actor watch` 側で `VOX_ACTOR_WORKSPACE` を共有 |
 
-### テキストファイルの読み上げ
+モードは `VOX_ACTOR_MONOLOGUE_MODE` 環境変数で明示するか、未設定時は `vox-actor` コマンドの有無で自動判定されます（あり → `direct`、なし → `file`）。
 
-```bash
-vox-actor act script.txt
-```
+### `file` モードのセットアップ
 
-VOICEVOXエンジンのURLやキャラクターを指定する場合:
+1. **ホスト側で監視プロセスを常駐させる**
+   ```bash
+   # テキストファイルの受け渡し先ディレクトリを指定
+   export VOX_ACTOR_WORKSPACE=/path/to/shared/directory
+   vox-actor watch "$VOX_ACTOR_WORKSPACE"
+   ```
 
-```bash
-vox-actor act --engine-url http://localhost:50021 --speaker 3 script.txt
-```
+2. **claude code 側で `file` モードを明示し、共有ディレクトリを指定する**
+   ```bash
+   export VOX_ACTOR_WORKSPACE=/path/to/shared/directory
+   # vox-actorコマンドがある環境で file モードを強制したい場合は以下も指定
+   export VOX_ACTOR_MONOLOGUE_MODE=file
+   ```
 
-話速・音高・抑揚を調整する場合:
+3. **claude code にプラグインを導入する**（[クイックスタート](#-クイックスタートllm連携フロー)と同じ手順）
 
-```bash
-vox-actor act --speed 1.2 --pitch 0.1 --intonation 1.5 script.txt
-```
+### ディレクトリ監視モードの詳細（`watch` コマンド）
 
-### JSON台本モード（感情制御パラメータ付き）
-
-`.json` ファイルを使うと、セリフごとにキャラクターや感情パラメータを指定できます:
-
-```json
-{
-  "text": "こんにちは",
-  "speaker": 3,
-  "speedScale": 1.2,
-  "pitchScale": 0.1,
-  "intonationScale": 1.5
-}
-```
-
-```bash
-vox-actor act script.json
-```
-
-`text` のみ必須で、他のパラメータは省略可能です。省略した場合はCLIオプションのデフォルト値が使われます。
-
-ディレクトリを指定した場合、`.txt` と `.json` の両方が辞書順で読み上げられます。
-
-### ディレクトリ監視モード
-
-ディレクトリを監視し、ファイルが配置されると自動的に読み上げます。処理済みファイルは各監視ディレクトリ内の `done/` サブディレクトリに移動されます。
+`vox-actor watch` は、配置されたテキストファイルや JSON 台本を自動で読み上げます。処理済みファイルは各監視ディレクトリ直下の `done/` サブディレクトリに移動されます（例: `./dir-a/foo.txt` → `./dir-a/done/foo.txt`）。
 
 ```bash
 vox-actor watch /path/to/watch-dir
 ```
 
-複数ディレクトリを同時に監視する場合:
+複数ディレクトリを同時に監視する場合はスペース区切りで指定します。各ディレクトリは並列で監視され、検知したファイルは検知順に1件ずつ再生されます。
 
 ```bash
 vox-actor watch /path/to/dir-a /path/to/dir-b
 ```
-
-各ディレクトリは並列で監視され、検知したファイルは検知順に1件ずつ再生されます。処理済みファイルは各ディレクトリ直下の `done/` に移動されます（例: `./dir-a/foo.txt` → `./dir-a/done/foo.txt`）。
 
 処理済みファイルを `done/` に移動する代わりに削除する場合:
 
@@ -166,7 +252,13 @@ vox-actor watch /path/to/dir-a /path/to/dir-b
 vox-actor watch --delete /path/to/watch-dir
 ```
 
-#### `act --watch` / `act --watch-delete`（後方互換）
+別のターミナルからファイルを配置すると、自動的に読み上げられます。
+
+```bash
+echo "こんばんは" > /path/to/watch-dir/sample.txt
+```
+
+### `act --watch` / `act --watch-delete`（後方互換）
 
 従来どおり `act` コマンドでも単一ディレクトリの監視が可能です。
 
@@ -177,116 +269,13 @@ vox-actor act --watch-delete /path/to/watch-dir
 
 `--watch` と `--watch-delete` は同時に指定できません。複数ディレクトリを同時に監視したい場合は `watch` コマンドを使ってください。
 
-詳細ログを出力する場合:
+### エラーログ
 
-```bash
-vox-actor act --verbose script.txt
-```
+`direct` モードでの `vox-actor say` 失敗は `$VOX_ACTOR_WORKSPACE/monologue-errors.log` に追記されます（ログは末尾200行でローテーション）。`tail -f` で確認できます。
 
-## オプション一覧
+## 👩‍💻 開発者向け情報
 
-### `act` サブコマンド
-
-| オプション | 環境変数 | デフォルト値 | 説明 |
-|---|---|---|---|
-| `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
-| `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
-| `--speed` | — | `1.0` | 話速 |
-| `--pitch` | — | `0.0` | 音高 |
-| `--intonation` | — | `1.0` | 抑揚 |
-| `--watch` | — | `false` | ディレクトリ監視モードを有効化 |
-| `--watch-delete` | — | `false` | ディレクトリ監視モード（処理済みファイルを削除） |
-| `--verbose` | — | `false` | 詳細ログを出力 |
-
-### `watch` サブコマンド
-
-| オプション | 環境変数 | デフォルト値 | 説明 |
-|---|---|---|---|
-| `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
-| `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
-| `--speed` | — | `1.0` | 話速 |
-| `--pitch` | — | `0.0` | 音高 |
-| `--intonation` | — | `1.0` | 抑揚 |
-| `--delete` | — | `false` | 処理済みファイルを削除（未指定時は各ディレクトリの `done/` に移動） |
-| `--verbose` | — | `false` | 詳細ログを出力 |
-
-### `say` サブコマンド
-
-| オプション | 環境変数 | デフォルト値 | 説明 |
-|---|---|---|---|
-| `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
-| `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
-| `--speed` | — | `1.0` | 話速 |
-| `--pitch` | — | `0.0` | 音高 |
-| `--intonation` | — | `1.0` | 抑揚 |
-| `--verbose` | — | `false` | 詳細ログを出力 |
-
-オプションの優先順位: **CLIフラグ > 環境変数 > デフォルト値**
-
-## 活用方法
-
-### claude codeなどのLLMの作業状況を音声で通知する
-
-LLMの作業状況を音声で通知できます。通知方式は実行環境に応じて2種類あります。
-
-- **`direct` モード**: `vox-actor say` をその場で直接呼び出す方式。監視プロセスの常駐が不要で、ファイルI/Oやポーリング遅延も発生しない。`vox-actor` コマンドが `PATH` 上に存在する環境で利用できる
-- **`file` モード**: テキストファイルを指定ディレクトリに書き出し、別プロセスで起動した `vox-actor watch` が読み上げる方式。`vox-actor` コマンドがない端末からでも（共有ディレクトリ経由で）利用できる
-
-どちらを使うかは `VOX_ACTOR_MONOLOGUE_MODE` 環境変数で明示するか、未設定時は `vox-actor` コマンドの有無で自動判定されます（あり → `direct`、なし → `file`）。
-
-claude code向けプラグインを同梱しているので、claude codeでは簡単に導入できます。同梱プラグインは以下の2種類です。
-
-- `vox-actor-plugin`: 独り言スキル（`/vox-actor-plugin:monologue`）を提供するプラグイン
-- `auto-monologue-plugin`: Stop hookでClaudeに独り言スキルの活用を促すプラグイン（`vox-actor-plugin` と併用することで、作業の区切りで独り言が自動生成されるようになる）
-
-#### セットアップ（`direct` モード）
-
-1. 環境変数を設定する（エラーログ出力先の指定。任意）。
-   ```
-   export VOX_ACTOR_WORKSPACE=/path/to/directory
-   # VOICEVOXエンジンのURLがデフォルトでない場合のみ
-   export VOX_ENGINE_URL=http://localhost:50021
-   ```
-
-2. claude codeにプラグインを導入する。
-   ```
-   # claude code上で実行
-   /plugin marketplace add canpok1/vox-actor
-   /plugin install vox-actor-plugin@vox-actor-marketplace
-   # 自動で独り言を生成したい場合は auto-monologue-plugin も導入する
-   /plugin install auto-monologue-plugin@vox-actor-marketplace
-   ```
-
-3. 独り言スキル（monologue）を実行する。
-   ```
-   # claude code上で実行
-   /vox-actor-plugin:monologue
-   ```
-   `auto-monologue-plugin` を導入している場合は、作業の区切りで自動的に独り言が生成される。
-
-`vox-actor say` の失敗は `$VOX_ACTOR_WORKSPACE/monologue-errors.log` に追記されるので、`tail -f` で確認できます（ログは末尾200行でローテーション）。複数セッションから並列に呼ばれても許容されます（エンジンへのリクエストや音声再生が重なる場合があります）。逐次再生したい場合は後述の `file` モードに切り替えてください。
-
-#### セットアップ（`file` モード）
-
-`vox-actor` コマンドが手元にない環境や、監視プロセスで逐次再生したい場合に使います。
-
-1. 環境変数を設定する。
-   ```
-   # テキストファイルの出力先ディレクトリを指定
-   export VOX_ACTOR_WORKSPACE=/path/to/directory
-   # モードを明示する場合（vox-actorコマンドがある環境で file モードを強制したい場合）
-   export VOX_ACTOR_MONOLOGUE_MODE=file
-   ```
-
-2. vox-actorを監視モードで起動する。
-   ```
-   vox-actor watch $VOX_ACTOR_WORKSPACE
-   ```
-
-3. claude codeにプラグインを導入し、独り言スキルを実行する（`direct` モードと同じ手順）。
-
-
-## 開発
+本リポジトリへのコントリビューター向けの情報です。
 
 ```bash
 # セットアップ（linter等のインストール）


### PR DESCRIPTION
## Summary

Issue #183 に沿って `README.md` を再構成しました。新規利用者が「何のツールか／どう使い始めるか」を最短経路で掴めるように、LLM連携（claude code連携プラグイン）をメイン用途として前面に出し、CLI単体利用・開発者向け情報を明示的に分離しています。

### 主な変更

| 観点 | 変更後 |
|---|---|
| 特徴 | LLM連携を筆頭にした3点訴求を追加 |
| クイックスタート | `direct` モード前提の4ステップに簡素化（`watch` 常駐・`VOX_ACTOR_WORKSPACE` 設定は不要） |
| クイックスタートのインストール手順 | Homebrew（`brew install --cask vox-actor`）に集約 |
| コマンドリファレンス | `say` → `act` → `watch` の順に再配置 |
| 高度な利用（新設） | `file` モード手順、`direct`/`file` モード比較表、`watch` 詳細、`act --watch` 後方互換を集約 |
| 開発者向け情報 | `make` コマンド等を「開発者向け情報」として明示分離 |
| `VOX_ACTOR_MONOLOGUE_MODE` | 新設の比較表・`file` モードのセットアップ手順で説明 |

Issue #181 でマージ済みの `direct` モード（`vox-actor` コマンドが `PATH` 上にあれば監視プロセスなしで読み上げ）を前提としています。

## 受け入れ条件の充足

- [x] 新構成の章立てで `README.md` が整理されている
- [x] タイトル直下にタグラインと特徴3点が配置され、LLM連携が筆頭特徴として記載されている
- [x] クイックスタートが `direct` モード前提の4ステップになっており、`vox-actor watch` / `VOX_ACTOR_WORKSPACE` への依存がない
- [x] クイックスタートのインストール手順が Homebrew (`brew install --cask vox-actor`) に集約されている
- [x] 「高度な利用」章に `file` モード手順、`watch` コマンド詳細、`act --watch` 後方互換が集約されている
- [x] 開発者向け情報が「開発者向け情報」として明示的に分離されている
- [x] `VOX_ACTOR_MONOLOGUE_MODE` の説明が README に含まれている（Issue #181 との整合）

## Test plan

- [ ] GitHub 上でレンダリングされた README を確認（見出しのアンカーリンク・絵文字・テーブル表示）
- [ ] クイックスタートの4ステップが最新の `direct` モード挙動と一致していることを確認
- [ ] `say` / `act` / `watch` のオプション表が実装と一致していることを確認（本PR作成前に cmd/ 配下で検証済み）

Closes #183

---
🤖 Generated with [Claude Code](https://claude.ai/code)