### PR TITLE
refactor: watchモードのINFOログを整理する #185

### DIFF
--- a/internal/app/log_text.go
+++ b/internal/app/log_text.go
@@ -1,0 +1,25 @@
+package app
+
+import "strings"
+
+// logTextMaxRunes はログ出力時にtextを切り詰めるrune数の上限。
+const logTextMaxRunes = 15
+
+// truncateAndEscapeText はログ表示用に text を整形する。
+// rune数が logTextMaxRunes を超える場合は先頭をその長さで切り詰め末尾に "..." を付与し、
+// 残った文字列に含まれる改行(\n, \r)を可視化のためバックスラッシュ表記へ置換する。
+func truncateAndEscapeText(text string) string {
+	runes := []rune(text)
+	truncated := false
+	if len(runes) > logTextMaxRunes {
+		runes = runes[:logTextMaxRunes]
+		truncated = true
+	}
+	s := string(runes)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	if truncated {
+		s += "..."
+	}
+	return s
+}

--- a/internal/app/log_text_test.go
+++ b/internal/app/log_text_test.go
@@ -1,0 +1,61 @@
+package app
+
+import "testing"
+
+func TestTruncateAndEscapeText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "短いテキストはそのまま返す",
+			in:   "短いセリフ",
+			want: "短いセリフ",
+		},
+		{
+			name: "ちょうど15文字は省略記号を付けない",
+			in:   "あいうえおかきくけこさしすせそ",
+			want: "あいうえおかきくけこさしすせそ",
+		},
+		{
+			name: "16文字は先頭15文字に切り詰めて省略記号を付ける",
+			in:   "あいうえおかきくけこさしすせそた",
+			want: "あいうえおかきくけこさしすせそ...",
+		},
+		{
+			name: "空文字はそのまま空",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "LFはエスケープされる",
+			in:   "abc\ndef",
+			want: `abc\ndef`,
+		},
+		{
+			name: "CRもエスケープされる",
+			in:   "abc\rdef",
+			want: `abc\rdef`,
+		},
+		{
+			name: "CRLFは両方エスケープされる",
+			in:   "abc\r\ndef",
+			want: `abc\r\ndef`,
+		},
+		{
+			name: "改行を含む長文はrune15文字で切ってからエスケープ",
+			in:   "あいうえおかきくけこさし\nすせそたちつ",
+			want: `あいうえおかきくけこさし\nすせ...`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := truncateAndEscapeText(c.in)
+			if got != c.want {
+				t.Errorf("truncateAndEscapeText(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"path/filepath"
 	"sync"
@@ -170,13 +171,13 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 			if delErr := u.mover.Delete(path); delErr != nil {
 				u.logger.Error("delete error", "path", path, "error", delErr)
 			} else {
-				u.logger.Info("file deleted", "path", path)
+				u.logger.Debug("file deleted", "path", path)
 			}
 		} else {
 			if moveErr := u.mover.MoveToDone(path); moveErr != nil {
 				u.logger.Error("move error", "path", path, "error", moveErr)
 			} else {
-				u.logger.Info("file moved to done", "path", path)
+				u.logger.Debug("file moved to done", "path", path)
 			}
 		}
 	}()
@@ -187,13 +188,22 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 		return
 	}
 
+	total := 0
+	for _, s := range scripts {
+		if !s.IsEmpty {
+			total++
+		}
+	}
+
+	current := 0
 	for _, script := range scripts {
 		if script.IsEmpty {
 			u.logger.Debug("skipping empty script", "path", script.Path)
 			continue
 		}
 
-		u.logger.Info("processing script", "path", script.Path)
+		current++
+		u.logger.Debug("processing script", "path", script.Path)
 
 		// セリフ単位パラメータがあればグローバルパラメータより優先する
 		speakerID := script.ResolveSpeakerID(params.SpeakerID)
@@ -214,12 +224,12 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 			u.logger.Error("synthesize error (skipping script)", "path", script.Path, "error", err)
 			continue
 		}
-		u.logger.Info("synthesis completed", "path", script.Path, "wavSize", len(wavData))
+		u.logger.Debug("synthesis completed", "path", script.Path, "wavSize", len(wavData))
 
 		if err := u.player.Play(ctx, wavData); err != nil {
 			u.logger.Error("play error (skipping script)", "path", script.Path, "error", err)
 			continue
 		}
-		u.logger.Info("playback completed", "path", script.Path)
+		u.logger.Info(fmt.Sprintf("[%d/%d] playback completed", current, total), "text", truncateAndEscapeText(script.Text))
 	}
 }

--- a/internal/app/watch_usecase_test.go
+++ b/internal/app/watch_usecase_test.go
@@ -491,7 +491,7 @@ func TestWatchUsecase_Run_DefaultMode_MovesToDoneNotDelete(t *testing.T) {
 	}
 }
 
-func TestWatchUsecase_Run_DeleteMode_LogsFileDeleted(t *testing.T) {
+func TestWatchUsecase_Run_DeleteMode_FileDeletedSuppressedAtInfoLevel(t *testing.T) {
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
@@ -519,8 +519,41 @@ func TestWatchUsecase_Run_DeleteMode_LogsFileDeleted(t *testing.T) {
 	}
 
 	output := buf.String()
+	if strings.Contains(output, "file deleted") {
+		t.Errorf("expected 'file deleted' NOT in INFO log (demoted to DEBUG), got: %s", output)
+	}
+}
+
+func TestWatchUsecase_Run_DeleteMode_FileDeletedAppearsAtDebugLevel(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{
+		files: []string{"/tmp/watch/a.txt"},
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelDebug, NoColor: true}))
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithDeleteMode(), app.WithWatchLogger(logger))
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+
+	err := uc.Run(context.Background(), params)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	output := buf.String()
 	if !strings.Contains(output, "file deleted") {
-		t.Errorf("expected log to contain 'file deleted', got: %s", output)
+		t.Errorf("expected log to contain 'file deleted' at Debug level, got: %s", output)
 	}
 }
 
@@ -534,7 +567,7 @@ func (w *blockingDirWatcher) Watch(_ context.Context, _ string) (<-chan string, 
 	return w.fileCh, w.errCh
 }
 
-func TestWatchUsecase_Run_FileMovedToDoneLoggedAtInfoLevel(t *testing.T) {
+func TestWatchUsecase_Run_FileMovedToDoneSuppressedAtInfoLevel(t *testing.T) {
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
@@ -562,12 +595,12 @@ func TestWatchUsecase_Run_FileMovedToDoneLoggedAtInfoLevel(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "file moved to done") {
-		t.Errorf("expected log to contain 'file moved to done' at Info level, got: %s", output)
+	if strings.Contains(output, "file moved to done") {
+		t.Errorf("expected 'file moved to done' NOT in INFO log (demoted to DEBUG), got: %s", output)
 	}
 }
 
-func TestWatchUsecase_Run_SynthesisCompletedLoggedAtInfoLevel(t *testing.T) {
+func TestWatchUsecase_Run_SynthesisCompletedSuppressedAtInfoLevel(t *testing.T) {
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
@@ -595,8 +628,115 @@ func TestWatchUsecase_Run_SynthesisCompletedLoggedAtInfoLevel(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "synthesis completed") {
-		t.Errorf("expected log to contain 'synthesis completed' at Info level, got: %s", output)
+	for _, msg := range []string{"processing script", "synthesis completed", "query created"} {
+		if strings.Contains(output, msg) {
+			t.Errorf("expected %q NOT in INFO log (demoted to DEBUG), got: %s", msg, output)
+		}
+	}
+}
+
+func TestWatchUsecase_Run_PlaybackCompletedAtInfoIncludesProgressAndText(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{
+		files: []string{"/tmp/watch/a.txt"},
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "[1/1] playback completed") {
+		t.Errorf("expected log to contain '[1/1] playback completed', got: %s", output)
+	}
+	if !strings.Contains(output, "text=おはよう") {
+		t.Errorf("expected log to contain 'text=おはよう', got: %s", output)
+	}
+}
+
+func TestWatchUsecase_Run_PlaybackCompletedTruncatesLongTextAndEscapesNewlines(t *testing.T) {
+	longText := "あいうえおかきくけこさし\nすせそたちつ"
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: longText, IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{
+		files: []string{"/tmp/watch/a.txt"},
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	output := buf.String()
+	want := `text=あいうえおかきくけこさし\nすせ...`
+	if !strings.Contains(output, want) {
+		t.Errorf("expected log to contain %q, got: %s", want, output)
+	}
+}
+
+func TestWatchUsecase_Run_PlaybackCompletedSkipsEmptyAndNumeratesContiguously(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "1.txt", Text: "first", IsEmpty: false},
+			{Path: "2.txt", Text: "", IsEmpty: true},
+			{Path: "3.txt", Text: "third", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{
+		files: []string{"/tmp/watch/a.txt"},
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	output := buf.String()
+	for _, expected := range []string{"[1/2] playback completed", "[2/2] playback completed"} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("expected log to contain %q, got: %s", expected, output)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`watch` コマンド / `act --watch` / `act --watch-delete`（= `WatchUsecase`）のINFOログを削減し、1ファイル1セリフ成功時に出力される行数を減らす。セリフ内容も1行に含めて可視性を保つ。

### 変更内容

- INFO残し
  - `file detected` (path)
  - `[N/M] playback completed` (text=...) — 新規
- DEBUG降格
  - `processing script`
  - `synthesis completed`
  - `query created`
  - `file moved to done`
  - `file deleted`
- ERROR / WARN は変更なし

### `[N/M]` の仕様

- **N**: 非空スクリプトの連番（空スクリプトをスキップしても詰めて表示）
- **M**: 非空スクリプトの総数（事前カウント、`act_usecase.go` と同じ流儀）

### text の加工

`internal/app/log_text.go` に `truncateAndEscapeText` ヘルパーを追加。

- rune（文字）数で先頭15文字に切り詰め
- 切り詰めた場合は末尾に `...` を付与（≤15文字なら付けない）
- `\n` / `\r` は文字列 `\\n` / `\\r` へ置換してログ行の崩れを防ぐ

### 出力イメージ

```
file detected (path=/tmp/sample.jsonl)
[1/3] playback completed (text=こんにちは、今日はいい天気...)
[2/3] playback completed (text=それではいってみよ...)
[3/3] playback completed (text=短いセリフ)
```

## Test plan

- [x] `go test ./...` 全パス
- [x] `gofmt -l .` 出力なし
- [x] `golangci-lint run` 0 issues
- [x] `truncateAndEscapeText` のテーブルテスト（短文/15文字/16文字/空/LF/CR/CRLF/長文+改行）追加
- [x] `WatchUsecase` テスト更新
  - DEBUG降格メッセージがINFOレベルに出ないこと
  - DEBUGレベルでは `file deleted` が出ること
  - INFOで `[N/M] playback completed (text=...)` が出ること
  - 長文のtruncate/改行escapeが反映されること
  - 空スクリプトを混ぜた場合に連番Nが詰めて表示されること

Closes #185

---
🤖 Generated with [Claude Code](https://claude.ai/code)