### PR TITLE
feat: dry-runモードを追加してVOICEVOX/音声出力なしで動作確認できるようにする #189

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ vox-actor say <text>
 | `--pitch` | — | `0.0` | 音高 |
 | `--intonation` | — | `1.0` | 抑揚 |
 | `--verbose` | — | `false` | 詳細ログを出力 |
+| `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#-dry-runモード)） |
 
 ### `act` サブコマンド
 
@@ -140,6 +141,7 @@ vox-actor act <path>
 | `--watch` | — | `false` | ディレクトリ監視モードを有効化（後方互換。[高度な利用](#-高度な利用リモート環境監視モード)参照） |
 | `--watch-delete` | — | `false` | ディレクトリ監視モード（処理済みファイルを削除。後方互換） |
 | `--verbose` | — | `false` | 詳細ログを出力 |
+| `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#-dry-runモード)） |
 
 ### `watch` サブコマンド
 
@@ -158,6 +160,32 @@ vox-actor watch <dir1> [<dir2> ...]
 | `--intonation` | — | `1.0` | 抑揚 |
 | `--delete` | — | `false` | 処理済みファイルを削除（未指定時は各ディレクトリの `done/` に移動） |
 | `--verbose` | — | `false` | 詳細ログを出力 |
+| `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#-dry-runモード)） |
+
+### 🧪 dry-runモード
+
+`--dry-run` を付けると、VOICEVOXエンジンへの通信・音声再生を一切行わず、読み上げ対象の情報のみをログ出力します。VOICEVOXエンジン未起動の環境や音声出力不可の環境（CI・リモート・コンテナなど）での動作確認に利用できます。
+
+```bash
+# テキスト指定
+vox-actor say --dry-run "こんにちは"
+
+# ファイル指定
+vox-actor act --dry-run script.json
+
+# ディレクトリ監視（ディレクトリ監視・done/移動・削除は通常通り実施）
+vox-actor watch --dry-run /path/to/watch-dir
+```
+
+出力例（標準エラー出力）:
+
+```
+  [2026-04-19 15:04:05] [dry run] would synthesize and play (path=script.json, text=こんにちは, speaker=3, speed=1.2, pitch=0.1, intonation=1.5)
+```
+
+- 合成・再生の代わりに `[dry run]` プレフィックス付きのログが出力されます
+- 疎通確認（`HealthCheck`）も行いません
+- `watch` / `act --watch` ではディレクトリ監視・`done/` への移動／削除は通常通り実施されるため、監視フロー全体を検証できます
 
 ## 📦 インストール方法
 

--- a/cmd/act.go
+++ b/cmd/act.go
@@ -77,6 +77,7 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 	speed, _ := cmd.Flags().GetFloat64("speed")
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 	logger := buildLoggerFromFlags(cmd)
 
@@ -101,6 +102,7 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 			Speed:      &speed,
 			Pitch:      &pitch,
 			Intonation: &intonation,
+			DryRun:     dryRun,
 		})
 	}
 
@@ -111,5 +113,6 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 		Speed:      &speed,
 		Pitch:      &pitch,
 		Intonation: &intonation,
+		DryRun:     dryRun,
 	})
 }

--- a/cmd/act_test.go
+++ b/cmd/act_test.go
@@ -109,7 +109,7 @@ func TestActCmd_HelpContainsFlags(t *testing.T) {
 	}
 
 	output := buf.String()
-	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--watch", "--verbose"}
+	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--watch", "--verbose", "--dry-run"}
 	for _, flag := range flags {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected help output to contain '%s'", flag)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -10,10 +10,12 @@ import (
 	"golang.org/x/term"
 )
 
-// buildLoggerFromFlags は --verbose フラグと端末/環境変数の状態からロガーを構築する。
+// buildLoggerFromFlags は --verbose / --dry-run フラグと端末/環境変数の状態からロガーを構築する。
 // 標準エラー出力が端末でない場合、または NO_COLOR 環境変数が設定されている場合は色を無効化する。
+// --dry-run が指定されている場合はログメッセージに [dry run] プレフィックスを挿入する。
 func buildLoggerFromFlags(cmd *cobra.Command) *slog.Logger {
 	verbose, _ := cmd.Flags().GetBool("verbose")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	logLevel := slog.LevelInfo
 	if verbose {
 		logLevel = slog.LevelDebug
@@ -22,6 +24,7 @@ func buildLoggerFromFlags(cmd *cobra.Command) *slog.Logger {
 	return slog.New(logging.NewHumanHandler(os.Stderr, &logging.HumanHandlerOptions{
 		Level:   logLevel,
 		NoColor: noColor,
+		DryRun:  dryRun,
 	}))
 }
 
@@ -45,4 +48,5 @@ func registerCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().Float64("pitch", 0.0, "音高")
 	cmd.Flags().Float64("intonation", 1.0, "抑揚")
 	cmd.Flags().Bool("verbose", false, "詳細ログを出力")
+	cmd.Flags().Bool("dry-run", false, "VOICEVOX・音声再生を行わず、読み上げ対象をログ出力")
 }

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -109,6 +109,19 @@ func TestRegisterCommonFlags_Verbose(t *testing.T) {
 	}
 }
 
+func TestRegisterCommonFlags_DryRun(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	registerCommonFlags(cmd)
+
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		t.Fatalf("expected dry-run flag to exist, got error: %v", err)
+	}
+	if dryRun {
+		t.Error("expected default dry-run to be false")
+	}
+}
+
 func TestRegisterCommonFlags_EngineURL(t *testing.T) {
 	t.Setenv("VOX_ENGINE_URL", "")
 

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -50,6 +50,7 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 	speed, _ := cmd.Flags().GetFloat64("speed")
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 	logger := buildLoggerFromFlags(cmd)
 
@@ -64,6 +65,7 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 		Speed:      &speed,
 		Pitch:      &pitch,
 		Intonation: &intonation,
+		DryRun:     dryRun,
 	}
 
 	uc := app.NewSayUsecase(client, deps.Player, app.WithSayLogger(logger))

--- a/cmd/say_test.go
+++ b/cmd/say_test.go
@@ -75,7 +75,7 @@ func TestSayCmd_HelpContainsFlags(t *testing.T) {
 	}
 
 	output := buf.String()
-	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose"}
+	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run"}
 	for _, flag := range flags {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected help output to contain '%s'", flag)

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -65,6 +65,7 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 	speed, _ := cmd.Flags().GetFloat64("speed")
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 	logger := buildLoggerFromFlags(cmd)
 
@@ -86,5 +87,6 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 		Speed:      &speed,
 		Pitch:      &pitch,
 		Intonation: &intonation,
+		DryRun:     dryRun,
 	})
 }

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -161,7 +161,7 @@ func TestWatchCmd_HelpContainsFlags(t *testing.T) {
 	}
 
 	output := buf.String()
-	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--delete", "--verbose"}
+	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--delete", "--verbose", "--dry-run"}
 	for _, flag := range flags {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected help output to contain '%s'", flag)

--- a/internal/app/act_usecase.go
+++ b/internal/app/act_usecase.go
@@ -106,14 +106,7 @@ func (u *ActUsecase) Run(ctx context.Context, params ActParams) error {
 		intonation := script.ResolveIntonation(params.Intonation)
 
 		if params.DryRun {
-			u.logger.Info("would synthesize and play",
-				"path", script.Path,
-				"text", truncateAndEscapeText(script.Text),
-				"speaker", speakerID,
-				"speed", formatFloatPtr(speed),
-				"pitch", formatFloatPtr(pitch),
-				"intonation", formatFloatPtr(intonation),
-			)
+			logDryRunSynthesize(u.logger, script.Path, script.Text, speakerID, speed, pitch, intonation)
 			continue
 		}
 

--- a/internal/app/act_usecase.go
+++ b/internal/app/act_usecase.go
@@ -14,6 +14,8 @@ type ActParams struct {
 	Speed      *float64
 	Pitch      *float64
 	Intonation *float64
+	// DryRun が true の場合、VOICEVOXエンジン/音声再生を一切呼ばずログ出力のみ行う。
+	DryRun bool
 }
 
 // ActOption はActUsecaseの生成時に指定するオプション。
@@ -62,10 +64,12 @@ func (u *ActUsecase) Run(ctx context.Context, params ActParams) error {
 	u.logger.Debug("act starting", "path", params.Path, "speakerID", params.SpeakerID,
 		"speed", params.Speed, "pitch", params.Pitch, "intonation", params.Intonation)
 
-	if err := u.client.HealthCheck(ctx); err != nil {
-		return err
+	if !params.DryRun {
+		if err := u.client.HealthCheck(ctx); err != nil {
+			return err
+		}
+		u.logger.Info("engine health check passed")
 	}
-	u.logger.Info("engine health check passed")
 
 	scripts, err := u.reader.Read(params.Path)
 	if err != nil {
@@ -100,6 +104,18 @@ func (u *ActUsecase) Run(ctx context.Context, params ActParams) error {
 		speed := script.ResolveSpeed(params.Speed)
 		pitch := script.ResolvePitch(params.Pitch)
 		intonation := script.ResolveIntonation(params.Intonation)
+
+		if params.DryRun {
+			u.logger.Info("would synthesize and play",
+				"path", script.Path,
+				"text", truncateAndEscapeText(script.Text),
+				"speaker", speakerID,
+				"speed", formatFloatPtr(speed),
+				"pitch", formatFloatPtr(pitch),
+				"intonation", formatFloatPtr(intonation),
+			)
+			continue
+		}
 
 		query, err := u.client.CreateQuery(ctx, script.Text, speakerID)
 		if err != nil {

--- a/internal/app/act_usecase_test.go
+++ b/internal/app/act_usecase_test.go
@@ -649,6 +649,95 @@ func TestActUsecase_Run_WithNilLogger_NoPanic(t *testing.T) {
 	}
 }
 
+// --- dry-run テスト ---
+
+func TestActUsecase_Run_DryRun_SkipsClientAndPlayerAndLogs(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
+			{Path: "b.txt", Text: "", IsEmpty: true},
+			{Path: "c.txt", Text: "こんにちは", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+
+	var buf bytes.Buffer
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+		DryRun:  true,
+	}))
+
+	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
+	params := app.ActParams{
+		Path:      "scripts/",
+		SpeakerID: 3,
+		DryRun:    true,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if client.createQueryCalls != 0 {
+		t.Errorf("expected 0 CreateQuery calls in dry-run, got: %d", client.createQueryCalls)
+	}
+	if client.synthesizeCalls != 0 {
+		t.Errorf("expected 0 Synthesize calls in dry-run, got: %d", client.synthesizeCalls)
+	}
+	if player.playCalls != 0 {
+		t.Errorf("expected 0 Play calls in dry-run, got: %d", player.playCalls)
+	}
+
+	output := buf.String()
+	// dry-run時のログ: would synthesize, 進捗, 空ファイルスキップ
+	if !strings.Contains(output, "[dry run] would synthesize and play") {
+		t.Errorf("expected '[dry run] would synthesize and play' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "[dry run] [1/2] processing script") {
+		t.Errorf("expected '[dry run] [1/2] processing script' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "[dry run] [2/2] processing script") {
+		t.Errorf("expected '[dry run] [2/2] processing script' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "path=a.txt") {
+		t.Errorf("expected 'path=a.txt' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "text=おはよう") {
+		t.Errorf("expected 'text=おはよう' in log, got: %s", output)
+	}
+}
+
+func TestActUsecase_Run_DryRun_NoHealthCheck(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
+		},
+	}
+	// HealthCheckがエラーを返してもdry-runでは呼ばれずエラーにならない
+	client := &mockVoicevoxClient{
+		healthCheckErr: errors.New("connection refused"),
+	}
+	player := &mockAudioPlayer{}
+
+	uc := app.NewActUsecase(reader, client, player)
+	params := app.ActParams{
+		Path:      "scripts/",
+		SpeakerID: 3,
+		DryRun:    true,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err != nil {
+		t.Fatalf("expected no error in dry-run even with HealthCheck failing, got: %v", err)
+	}
+}
+
 // --- セリフ単位パラメータ テスト ---
 
 // テストリスト: セリフ単位パラメータ

--- a/internal/app/log_text.go
+++ b/internal/app/log_text.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"log/slog"
 	"strconv"
 	"strings"
 )
@@ -34,4 +35,21 @@ func formatFloatPtr(v *float64) string {
 		return "default"
 	}
 	return strconv.FormatFloat(*v, 'g', -1, 64)
+}
+
+// logDryRunSynthesize はdry-runモードで「合成・再生予定」をログ出力する共通ヘルパー。
+// path が空文字の場合は path 属性を省略する（say サブコマンド向け）。
+func logDryRunSynthesize(logger *slog.Logger, path, text string, speakerID int, speed, pitch, intonation *float64) {
+	attrs := make([]any, 0, 12)
+	if path != "" {
+		attrs = append(attrs, "path", path)
+	}
+	attrs = append(attrs,
+		"text", truncateAndEscapeText(text),
+		"speaker", speakerID,
+		"speed", formatFloatPtr(speed),
+		"pitch", formatFloatPtr(pitch),
+		"intonation", formatFloatPtr(intonation),
+	)
+	logger.Info("would synthesize and play", attrs...)
 }

--- a/internal/app/log_text.go
+++ b/internal/app/log_text.go
@@ -1,6 +1,9 @@
 package app
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // logTextMaxRunes はログ出力時にtextを切り詰めるrune数の上限。
 const logTextMaxRunes = 15
@@ -22,4 +25,13 @@ func truncateAndEscapeText(text string) string {
 		s += "..."
 	}
 	return s
+}
+
+// formatFloatPtr は *float64 をログ表示用文字列に整形する。
+// nil の場合は "default" を返す。
+func formatFloatPtr(v *float64) string {
+	if v == nil {
+		return "default"
+	}
+	return strconv.FormatFloat(*v, 'g', -1, 64)
 }

--- a/internal/app/say_usecase.go
+++ b/internal/app/say_usecase.go
@@ -55,13 +55,7 @@ func (u *SayUsecase) Run(ctx context.Context, params SayParams) error {
 		"speed", params.Speed, "pitch", params.Pitch, "intonation", params.Intonation)
 
 	if params.DryRun {
-		u.logger.Info("would synthesize and play",
-			"text", truncateAndEscapeText(params.Text),
-			"speaker", params.SpeakerID,
-			"speed", formatFloatPtr(params.Speed),
-			"pitch", formatFloatPtr(params.Pitch),
-			"intonation", formatFloatPtr(params.Intonation),
-		)
+		logDryRunSynthesize(u.logger, "", params.Text, params.SpeakerID, params.Speed, params.Pitch, params.Intonation)
 		return nil
 	}
 

--- a/internal/app/say_usecase.go
+++ b/internal/app/say_usecase.go
@@ -12,6 +12,8 @@ type SayParams struct {
 	Speed      *float64
 	Pitch      *float64
 	Intonation *float64
+	// DryRun が true の場合、VOICEVOXエンジン/音声再生を一切呼ばずログ出力のみ行う。
+	DryRun bool
 }
 
 // SayOption はSayUsecaseの生成時に指定するオプション。
@@ -51,6 +53,17 @@ func NewSayUsecase(client VoicevoxClient, player AudioPlayer, opts ...SayOption)
 func (u *SayUsecase) Run(ctx context.Context, params SayParams) error {
 	u.logger.Debug("say starting", "text", params.Text, "speakerID", params.SpeakerID,
 		"speed", params.Speed, "pitch", params.Pitch, "intonation", params.Intonation)
+
+	if params.DryRun {
+		u.logger.Info("would synthesize and play",
+			"text", truncateAndEscapeText(params.Text),
+			"speaker", params.SpeakerID,
+			"speed", formatFloatPtr(params.Speed),
+			"pitch", formatFloatPtr(params.Pitch),
+			"intonation", formatFloatPtr(params.Intonation),
+		)
+		return nil
+	}
 
 	if err := u.client.HealthCheck(ctx); err != nil {
 		if ctx.Err() != nil {

--- a/internal/app/say_usecase_test.go
+++ b/internal/app/say_usecase_test.go
@@ -1,12 +1,16 @@
 package app_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-actor/internal/app"
 	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/canpok1/vox-actor/internal/infra/logging"
 )
 
 // say_usecase テストリスト
@@ -170,6 +174,82 @@ func TestWithSayLogger_Nil_NoPanic(t *testing.T) {
 	err := uc.Run(context.Background(), params)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestSayUsecase_Run_DryRun_SkipsClientAndPlayerAndLogs(t *testing.T) {
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+
+	var buf bytes.Buffer
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+		DryRun:  true,
+	}))
+
+	speed := 1.2
+	pitch := 0.1
+	intonation := 1.5
+
+	uc := app.NewSayUsecase(client, player, app.WithSayLogger(logger))
+	params := app.SayParams{
+		Text:       "こんにちは",
+		SpeakerID:  3,
+		Speed:      &speed,
+		Pitch:      &pitch,
+		Intonation: &intonation,
+		DryRun:     true,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// dry-run時: VoicevoxClient/AudioPlayer のメソッドは一切呼ばれない
+	if client.createQueryCalls != 0 {
+		t.Errorf("expected 0 CreateQuery calls in dry-run, got: %d", client.createQueryCalls)
+	}
+	if client.synthesizeCalls != 0 {
+		t.Errorf("expected 0 Synthesize calls in dry-run, got: %d", client.synthesizeCalls)
+	}
+	if player.playCalls != 0 {
+		t.Errorf("expected 0 Play calls in dry-run, got: %d", player.playCalls)
+	}
+
+	// ログに [dry run] プレフィックスと合成予定情報が含まれる
+	output := buf.String()
+	if !strings.Contains(output, "[dry run] would synthesize and play") {
+		t.Errorf("expected '[dry run] would synthesize and play' in log, got: %s", output)
+	}
+	for _, want := range []string{"text=こんにちは", "speaker=3", "speed=1.2", "pitch=0.1", "intonation=1.5"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in log, got: %s", want, output)
+		}
+	}
+}
+
+func TestSayUsecase_Run_DryRun_NoHealthCheck(t *testing.T) {
+	// HealthCheckがエラーを返してもdry-runでは呼ばれずエラーにならない
+	client := &mockVoicevoxClient{
+		healthCheckErr: errors.New("connection refused"),
+	}
+	player := &mockAudioPlayer{}
+
+	uc := app.NewSayUsecase(client, player)
+	params := app.SayParams{
+		Text:      "こんにちは",
+		SpeakerID: 3,
+		DryRun:    true,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err != nil {
+		t.Fatalf("expected no error in dry-run even with HealthCheck failing, got: %v", err)
 	}
 }
 

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -217,14 +217,7 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 		intonation := script.ResolveIntonation(params.Intonation)
 
 		if params.DryRun {
-			u.logger.Info("would synthesize and play",
-				"path", script.Path,
-				"text", truncateAndEscapeText(script.Text),
-				"speaker", speakerID,
-				"speed", formatFloatPtr(speed),
-				"pitch", formatFloatPtr(pitch),
-				"intonation", formatFloatPtr(intonation),
-			)
+			logDryRunSynthesize(u.logger, script.Path, script.Text, speakerID, speed, pitch, intonation)
 			continue
 		}
 

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -15,6 +15,9 @@ type WatchParams struct {
 	Speed      *float64
 	Pitch      *float64
 	Intonation *float64
+	// DryRun が true の場合、VOICEVOXエンジン/音声再生は一切呼ばずログ出力のみ行う。
+	// ディレクトリ監視・done/移動・削除は通常通り実施する。
+	DryRun bool
 }
 
 // WatchOption はWatchUsecaseの生成時に指定するオプション。
@@ -66,10 +69,12 @@ func NewWatchUsecase(reader ScriptReader, client VoicevoxClient, player AudioPla
 func (u *WatchUsecase) Run(ctx context.Context, params WatchParams) error {
 	u.logger.Debug("watch mode starting", "paths", params.Paths, "speakerID", params.SpeakerID)
 
-	if err := u.client.HealthCheck(ctx); err != nil {
-		return err
+	if !params.DryRun {
+		if err := u.client.HealthCheck(ctx); err != nil {
+			return err
+		}
+		u.logger.Info("engine health check passed")
 	}
-	u.logger.Info("engine health check passed")
 
 	paths := u.dedupePaths(params.Paths)
 	fileCh := u.fanInWatchers(ctx, paths)
@@ -210,6 +215,18 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 		speed := script.ResolveSpeed(params.Speed)
 		pitch := script.ResolvePitch(params.Pitch)
 		intonation := script.ResolveIntonation(params.Intonation)
+
+		if params.DryRun {
+			u.logger.Info("would synthesize and play",
+				"path", script.Path,
+				"text", truncateAndEscapeText(script.Text),
+				"speaker", speakerID,
+				"speed", formatFloatPtr(speed),
+				"pitch", formatFloatPtr(pitch),
+				"intonation", formatFloatPtr(intonation),
+			)
+			continue
+		}
 
 		query, err := u.client.CreateQuery(ctx, script.Text, speakerID)
 		if err != nil {

--- a/internal/app/watch_usecase_test.go
+++ b/internal/app/watch_usecase_test.go
@@ -557,6 +557,131 @@ func TestWatchUsecase_Run_DeleteMode_FileDeletedAppearsAtDebugLevel(t *testing.T
 	}
 }
 
+func TestWatchUsecase_Run_DryRun_SkipsClientAndPlayerAndMovesToDone(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{
+		files: []string{"/tmp/watch/a.txt"},
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+		DryRun:  true,
+	}))
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
+	params := app.WatchParams{
+		Paths:     []string{"/tmp/watch"},
+		SpeakerID: 3,
+		DryRun:    true,
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// dry-run: 合成・再生は呼ばれない
+	if client.createQueryCalls != 0 {
+		t.Errorf("expected 0 CreateQuery calls in dry-run, got: %d", client.createQueryCalls)
+	}
+	if player.playCalls != 0 {
+		t.Errorf("expected 0 Play calls in dry-run, got: %d", player.playCalls)
+	}
+	// ただしdone/への移動は通常通り実施
+	if len(mover.movedFiles) != 1 {
+		t.Fatalf("expected 1 file moved to done in dry-run, got: %d", len(mover.movedFiles))
+	}
+	if mover.movedFiles[0] != "/tmp/watch/a.txt" {
+		t.Errorf("expected moved file '/tmp/watch/a.txt', got: %s", mover.movedFiles[0])
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "[dry run] would synthesize and play") {
+		t.Errorf("expected '[dry run] would synthesize and play' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "path=/tmp/watch/a.txt") {
+		t.Errorf("expected 'path=/tmp/watch/a.txt' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "text=おはよう") {
+		t.Errorf("expected 'text=おはよう' in log, got: %s", output)
+	}
+}
+
+func TestWatchUsecase_Run_DryRun_NoHealthCheck(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		healthCheckErr: errors.New("connection refused"),
+	}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{
+		files: []string{"/tmp/watch/a.txt"},
+	}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
+	params := app.WatchParams{
+		Paths:     []string{"/tmp/watch"},
+		SpeakerID: 3,
+		DryRun:    true,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err != nil {
+		t.Fatalf("expected no error in dry-run even with HealthCheck failing, got: %v", err)
+	}
+}
+
+func TestWatchUsecase_Run_DryRun_DeleteModeStillDeletes(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "おはよう", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{
+		files: []string{"/tmp/watch/a.txt"},
+	}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithDeleteMode())
+	params := app.WatchParams{
+		Paths:     []string{"/tmp/watch"},
+		SpeakerID: 3,
+		DryRun:    true,
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// dry-runでもdelete modeは維持される
+	if len(mover.deletedFiles) != 1 {
+		t.Fatalf("expected 1 file deleted in dry-run delete mode, got: %d", len(mover.deletedFiles))
+	}
+	if len(mover.movedFiles) != 0 {
+		t.Errorf("expected 0 files moved in dry-run delete mode, got: %d", len(mover.movedFiles))
+	}
+}
+
 // blockingDirWatcher はテスト用のブロッキングウォッチャー。
 type blockingDirWatcher struct {
 	fileCh chan string

--- a/internal/infra/logging/handler.go
+++ b/internal/infra/logging/handler.go
@@ -12,6 +12,8 @@ import (
 type HumanHandlerOptions struct {
 	Level   slog.Level
 	NoColor bool
+	// DryRun を true にすると、時刻の直後に "[dry run] " プレフィックスが挟まれる。
+	DryRun bool
 }
 
 // HumanHandler は人間が読みやすい形式でログを出力する slog.Handler 実装。
@@ -67,7 +69,11 @@ func (h *HumanHandler) Handle(_ context.Context, r slog.Record) error {
 		attrStr += ")"
 	}
 
-	line := fmt.Sprintf("%s[%s] %s%s\n", prefix, timeStr, r.Message, attrStr)
+	dryRunPrefix := ""
+	if h.opts.DryRun {
+		dryRunPrefix = "[dry run] "
+	}
+	line := fmt.Sprintf("%s[%s] %s%s%s\n", prefix, timeStr, dryRunPrefix, r.Message, attrStr)
 
 	if !h.opts.NoColor {
 		line = colorize(r.Level, line)

--- a/internal/infra/logging/handler_test.go
+++ b/internal/infra/logging/handler_test.go
@@ -242,6 +242,45 @@ func TestHumanHandler_Handle_ColorEnabledForInfo(t *testing.T) {
 	}
 }
 
+func TestHumanHandler_Handle_DryRunPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+		DryRun:  true,
+	})
+	logger := slog.New(h)
+
+	logger.Info("would synthesize and play", "path", "script.json", "text", "こんにちは")
+
+	output := buf.String()
+	// 時刻の直後に [dry run] プレフィックスが挿入される
+	if !strings.Contains(output, "] [dry run] would synthesize and play") {
+		t.Errorf("expected '[dry run]' prefix after timestamp, got: %q", output)
+	}
+	// 属性も通常通り出力される
+	if !strings.Contains(output, "(path=script.json, text=こんにちは)") {
+		t.Errorf("expected attributes after message, got: %q", output)
+	}
+}
+
+func TestHumanHandler_Handle_DryRunPrefix_Disabled(t *testing.T) {
+	var buf bytes.Buffer
+	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{
+		Level:   slog.LevelInfo,
+		NoColor: true,
+		DryRun:  false,
+	})
+	logger := slog.New(h)
+
+	logger.Info("normal message")
+
+	output := buf.String()
+	if strings.Contains(output, "[dry run]") {
+		t.Errorf("expected no '[dry run]' prefix when DryRun=false, got: %q", output)
+	}
+}
+
 func TestHumanHandler_Handle_NewlineTerminated(t *testing.T) {
 	var buf bytes.Buffer
 	h := logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{


### PR DESCRIPTION
## Summary

- `say` / `act` / `watch` サブコマンドに共通フラグ `--dry-run` を追加
- dry-run時は `HealthCheck` / `CreateQuery` / `Synthesize` / `Play` を一切呼ばず、「would synthesize and play」Infoログを出力
- ログは既存の `HumanHandler` の書式を踏襲し、時刻の直後に `[dry run]` プレフィックスを挿入
- `watch` / `act --watch` ではディレクトリ監視・`done/` 移動／削除は通常通り実施し、監視フロー全体を検証可能

## 変更内容

| レイヤ | 変更 |
|---|---|
| `internal/infra/logging` | `HumanHandlerOptions` に `DryRun bool` を追加。時刻直後に `[dry run] ` プレフィックスを挿入 |
| `internal/app` | `SayParams` / `ActParams` / `WatchParams` に `DryRun` フィールドを追加。dry-run時は外部呼び出しをスキップし `logDryRunSynthesize` ヘルパー経由でログ出力 |
| `cmd` | `registerCommonFlags` に `--dry-run` を追加し、ロガーと `*Params` の両方に反映 |
| `README.md` | 各サブコマンドのオプション表に `--dry-run` を追記し、専用セクション「dry-runモード」を追加 |

## 出力例

```
  [2026-04-19 15:04:05] [dry run] scripts loaded (path=scripts/, count=3)
  [2026-04-19 15:04:05] [dry run] [1/3] processing script (path=scripts/a.txt)
  [2026-04-19 15:04:05] [dry run] would synthesize and play (path=scripts/a.txt, text=おはよう, speaker=3, speed=1.2, pitch=0.1, intonation=1.5)
```

## Test plan

- [x] `go test ./...` で全テスト成功
- [x] `gofmt -l .` で差分なし
- [x] `golangci-lint run` で指摘なし
- [x] 実バイナリで `vox-actor say --dry-run` / `act --dry-run` / `watch --dry-run` の出力を確認

Closes #189

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)