### PR TITLE
refactor: dry-runモードのINFOログを非dry-runと同じメッセージ名に揃える #191

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,13 @@ vox-actor watch --dry-run /path/to/watch-dir
 出力例（標準エラー出力）:
 
 ```
-  [2026-04-19 15:04:05] [dry run] would synthesize and play (path=script.json, text=こんにちは, speaker=3, speed=1.2, pitch=0.1, intonation=1.5)
+  [2026-04-19 15:04:05] [dry run] synthesis completed (wavSize=0)
+  [2026-04-19 15:04:05] [dry run] playback completed (text=こんにちは, speaker=3, speed=1.2, pitch=0.1, intonation=1.5)
 ```
 
-- 合成・再生の代わりに `[dry run]` プレフィックス付きのログが出力されます
+- 非dry-run と同じメッセージ名（`synthesis completed` / `playback completed` 等）で、`[dry run]` プレフィックスが付与されます
+- `synthesis completed` の `wavSize` は `0`（実際には合成していないため）です
+- `playback completed` には dry-run 時のみ `text` / `speaker` / `speed` / `pitch` / `intonation` が属性として付与されます
 - 疎通確認（`HealthCheck`）も行いません
 - `watch` / `act --watch` ではディレクトリ監視・`done/` への移動／削除は通常通り実施されるため、監視フロー全体を検証できます
 

--- a/internal/app/act_usecase.go
+++ b/internal/app/act_usecase.go
@@ -106,7 +106,9 @@ func (u *ActUsecase) Run(ctx context.Context, params ActParams) error {
 		intonation := script.ResolveIntonation(params.Intonation)
 
 		if params.DryRun {
-			logDryRunSynthesize(u.logger, script.Path, script.Text, speakerID, speed, pitch, intonation)
+			u.logger.Info("synthesis completed", "path", script.Path, "wavSize", 0)
+			attrs := append([]any{"path", script.Path}, dryRunPlaybackAttrs(script.Text, speakerID, speed, pitch, intonation)...)
+			u.logger.Info("playback completed", attrs...)
 			continue
 		}
 

--- a/internal/app/act_usecase_test.go
+++ b/internal/app/act_usecase_test.go
@@ -695,21 +695,35 @@ func TestActUsecase_Run_DryRun_SkipsClientAndPlayerAndLogs(t *testing.T) {
 	}
 
 	output := buf.String()
-	// dry-run時のログ: would synthesize, 進捗, 空ファイルスキップ
-	if !strings.Contains(output, "[dry run] would synthesize and play") {
-		t.Errorf("expected '[dry run] would synthesize and play' in log, got: %s", output)
-	}
+	// dry-run時のログ: 非dry-run と同じメッセージ名で出力される
 	if !strings.Contains(output, "[dry run] [1/2] processing script") {
 		t.Errorf("expected '[dry run] [1/2] processing script' in log, got: %s", output)
 	}
 	if !strings.Contains(output, "[dry run] [2/2] processing script") {
 		t.Errorf("expected '[dry run] [2/2] processing script' in log, got: %s", output)
 	}
+	if !strings.Contains(output, "[dry run] synthesis completed") {
+		t.Errorf("expected '[dry run] synthesis completed' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "wavSize=0") {
+		t.Errorf("expected 'wavSize=0' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "[dry run] playback completed") {
+		t.Errorf("expected '[dry run] playback completed' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "[dry run] all scripts processed") {
+		t.Errorf("expected '[dry run] all scripts processed' in log, got: %s", output)
+	}
 	if !strings.Contains(output, "path=a.txt") {
 		t.Errorf("expected 'path=a.txt' in log, got: %s", output)
 	}
 	if !strings.Contains(output, "text=おはよう") {
 		t.Errorf("expected 'text=おはよう' in log, got: %s", output)
+	}
+	for _, want := range []string{"speaker=3", "speed=default", "pitch=default", "intonation=default"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in log, got: %s", want, output)
+		}
 	}
 }
 

--- a/internal/app/log_text.go
+++ b/internal/app/log_text.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"log/slog"
 	"strconv"
 	"strings"
 )
@@ -37,19 +36,14 @@ func formatFloatPtr(v *float64) string {
 	return strconv.FormatFloat(*v, 'g', -1, 64)
 }
 
-// logDryRunSynthesize はdry-runモードで「合成・再生予定」をログ出力する共通ヘルパー。
-// path が空文字の場合は path 属性を省略する（say サブコマンド向け）。
-func logDryRunSynthesize(logger *slog.Logger, path, text string, speakerID int, speed, pitch, intonation *float64) {
-	attrs := make([]any, 0, 12)
-	if path != "" {
-		attrs = append(attrs, "path", path)
-	}
-	attrs = append(attrs,
+// dryRunPlaybackAttrs はdry-runモードの playback completed ログに付与する属性セットを返す。
+// 呼び出し側で path などの属性を前後に追加できるよう []any を返す。
+func dryRunPlaybackAttrs(text string, speakerID int, speed, pitch, intonation *float64) []any {
+	return []any{
 		"text", truncateAndEscapeText(text),
 		"speaker", speakerID,
 		"speed", formatFloatPtr(speed),
 		"pitch", formatFloatPtr(pitch),
 		"intonation", formatFloatPtr(intonation),
-	)
-	logger.Info("would synthesize and play", attrs...)
+	}
 }

--- a/internal/app/say_usecase.go
+++ b/internal/app/say_usecase.go
@@ -55,7 +55,9 @@ func (u *SayUsecase) Run(ctx context.Context, params SayParams) error {
 		"speed", params.Speed, "pitch", params.Pitch, "intonation", params.Intonation)
 
 	if params.DryRun {
-		logDryRunSynthesize(u.logger, "", params.Text, params.SpeakerID, params.Speed, params.Pitch, params.Intonation)
+		u.logger.Info("synthesis completed", "wavSize", 0)
+		attrs := dryRunPlaybackAttrs(params.Text, params.SpeakerID, params.Speed, params.Pitch, params.Intonation)
+		u.logger.Info("playback completed", attrs...)
 		return nil
 	}
 

--- a/internal/app/say_usecase_test.go
+++ b/internal/app/say_usecase_test.go
@@ -221,15 +221,25 @@ func TestSayUsecase_Run_DryRun_SkipsClientAndPlayerAndLogs(t *testing.T) {
 		t.Errorf("expected 0 Play calls in dry-run, got: %d", player.playCalls)
 	}
 
-	// ログに [dry run] プレフィックスと合成予定情報が含まれる
+	// ログに [dry run] プレフィックスと非dry-run同形式のメッセージが含まれる
 	output := buf.String()
-	if !strings.Contains(output, "[dry run] would synthesize and play") {
-		t.Errorf("expected '[dry run] would synthesize and play' in log, got: %s", output)
+	if !strings.Contains(output, "[dry run] synthesis completed") {
+		t.Errorf("expected '[dry run] synthesis completed' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "wavSize=0") {
+		t.Errorf("expected 'wavSize=0' in log, got: %s", output)
+	}
+	if !strings.Contains(output, "[dry run] playback completed") {
+		t.Errorf("expected '[dry run] playback completed' in log, got: %s", output)
 	}
 	for _, want := range []string{"text=こんにちは", "speaker=3", "speed=1.2", "pitch=0.1", "intonation=1.5"} {
 		if !strings.Contains(output, want) {
 			t.Errorf("expected %q in log, got: %s", want, output)
 		}
+	}
+	// say の dry-run では engine health check passed は出力されない
+	if strings.Contains(output, "engine health check passed") {
+		t.Errorf("expected no 'engine health check passed' in dry-run, got: %s", output)
 	}
 }
 

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -216,8 +216,10 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 		pitch := script.ResolvePitch(params.Pitch)
 		intonation := script.ResolveIntonation(params.Intonation)
 
+		playbackMsg := fmt.Sprintf("[%d/%d] playback completed", current, total)
 		if params.DryRun {
-			logDryRunSynthesize(u.logger, script.Path, script.Text, speakerID, speed, pitch, intonation)
+			attrs := dryRunPlaybackAttrs(script.Text, speakerID, speed, pitch, intonation)
+			u.logger.Info(playbackMsg, attrs...)
 			continue
 		}
 
@@ -240,6 +242,6 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 			u.logger.Error("play error (skipping script)", "path", script.Path, "error", err)
 			continue
 		}
-		u.logger.Info(fmt.Sprintf("[%d/%d] playback completed", current, total), "text", truncateAndEscapeText(script.Text))
+		u.logger.Info(playbackMsg, "text", truncateAndEscapeText(script.Text))
 	}
 }

--- a/internal/app/watch_usecase_test.go
+++ b/internal/app/watch_usecase_test.go
@@ -607,15 +607,32 @@ func TestWatchUsecase_Run_DryRun_SkipsClientAndPlayerAndMovesToDone(t *testing.T
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "[dry run] would synthesize and play") {
-		t.Errorf("expected '[dry run] would synthesize and play' in log, got: %s", output)
+	if !strings.Contains(output, "[dry run] [1/1] playback completed") {
+		t.Errorf("expected '[dry run] [1/1] playback completed' in log, got: %s", output)
 	}
-	if !strings.Contains(output, "path=/tmp/watch/a.txt") {
-		t.Errorf("expected 'path=/tmp/watch/a.txt' in log, got: %s", output)
+	for _, want := range []string{"text=おはよう", "speaker=3", "speed=default", "pitch=default", "intonation=default"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in log, got: %s", want, output)
+		}
 	}
-	if !strings.Contains(output, "text=おはよう") {
-		t.Errorf("expected 'text=おはよう' in log, got: %s", output)
+	// watch の playback completed には path を含めない
+	playbackLine := findLineContaining(output, "playback completed")
+	if playbackLine == "" {
+		t.Fatalf("expected a 'playback completed' log line, got: %s", output)
 	}
+	if strings.Contains(playbackLine, "path=") {
+		t.Errorf("expected no 'path=...' on playback completed, got: %s", playbackLine)
+	}
+}
+
+// findLineContaining は s の中から substr を含む最初の行を返す（見つからなければ空文字）。
+func findLineContaining(s, substr string) string {
+	for line := range strings.SplitSeq(s, "\n") {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	return ""
 }
 
 func TestWatchUsecase_Run_DryRun_NoHealthCheck(t *testing.T) {

--- a/internal/infra/logging/handler_test.go
+++ b/internal/infra/logging/handler_test.go
@@ -251,11 +251,11 @@ func TestHumanHandler_Handle_DryRunPrefix(t *testing.T) {
 	})
 	logger := slog.New(h)
 
-	logger.Info("would synthesize and play", "path", "script.json", "text", "こんにちは")
+	logger.Info("playback completed", "path", "script.json", "text", "こんにちは")
 
 	output := buf.String()
 	// 時刻の直後に [dry run] プレフィックスが挿入される
-	if !strings.Contains(output, "] [dry run] would synthesize and play") {
+	if !strings.Contains(output, "] [dry run] playback completed") {
 		t.Errorf("expected '[dry run]' prefix after timestamp, got: %q", output)
 	}
 	// 属性も通常通り出力される


### PR DESCRIPTION
## Summary

Issue #191 対応。dry-run モードの INFO ログで出力されていた独自メッセージ `would synthesize and play` を廃止し、非dry-run と同じメッセージ名（`playback completed` / `synthesis completed` 等）に統一する。dry-run / 非dry-run を切り替えた際にログ構成が大きく変わる問題を解消する。

## Changes

- `internal/app/log_text.go`: `logDryRunSynthesize` を廃止し、dry-run 時の `playback completed` 属性セット（text / speaker / speed / pitch / intonation）を返すヘルパー `dryRunPlaybackAttrs` に置き換え
- `internal/app/watch_usecase.go`: dry-run 時も非dry-run と同じ `[N/M] playback completed` を出力し、dry-run 時のみ追加属性を付与
- `internal/app/act_usecase.go`: dry-run 時も `synthesis completed (path=..., wavSize=0)` と `playback completed (path=..., text=..., 等)` を出力
- `internal/app/say_usecase.go`: dry-run 時も `synthesis completed (wavSize=0)` と `playback completed (text=..., 等)` を出力。疎通確認スキップは維持
- `README.md`: dry-run 出力例を新形式に更新
- 各ユースケースおよび `handler_test.go` のテストを新メッセージ名に合わせて更新

## Test plan

- [x] `go test ./...` が全てパス
- [x] `gofmt -l .` の出力なし
- [x] `golangci-lint run` でゼロ指摘
- [ ] CI が全てグリーン

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)