### PR TITLE
refactor: 開発環境からVOX_ACTOR_WORKSPACE環境変数を削除

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,7 @@
 		"source=${devcontainerId}-claude-code-config,target=/home/vscode/.claude,type=volume"
 	],
 	"remoteEnv": {
-		"WORKSPACE_DIR": "${containerWorkspaceFolder}",
-		"VOX_ACTOR_WORKSPACE": "${containerWorkspaceFolder}/.tmp/notify"
+		"WORKSPACE_DIR": "${containerWorkspaceFolder}"
 	},
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
## Summary

- `.devcontainer/devcontainer.json` の `remoteEnv` から `VOX_ACTOR_WORKSPACE` を削除
- デフォルト出力先（gitリポジトリ直下の `.tmp/notify`）を利用する構成に統一

## Test plan

- [ ] devcontainerを再ビルドして `VOX_ACTOR_WORKSPACE` が未設定であることを確認
- [ ] monologueスキル実行時にデフォルトの `.tmp/notify` へ通知ファイルが出力されることを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)