### PR TITLE
refactor: VOX_ACTOR_WORKSPACEのデフォルト挙動とディレクトリ構造を変更 #196

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,11 @@ vox-actor watch --dry-run /path/to/watch-dir
 |---|---|---|
 | 読み上げ方式 | `vox-actor say` をその場で直接呼び出す | テキスト等をファイルに書き出し、別プロセスの `vox-actor watch` が読み上げる |
 | 監視プロセス | 不要 | `vox-actor watch` の常駐が必要 |
-| ファイル出力先 | エラーログのみ（`$VOX_ACTOR_WORKSPACE/monologue-errors.log`） | 通知ファイル（`$VOX_ACTOR_WORKSPACE/notify_*.json`）＋エラーログ |
+| ファイル出力先 | エラーログのみ（`$VOX_ACTOR_WORKSPACE/monologue-errors.log`） | 通知ファイル（`$VOX_ACTOR_WORKSPACE/queue/notify_*.json`）＋エラーログ |
 | 同時呼び出し時 | 並列再生 | 検知順に逐次再生 |
 | 前提 | `vox-actor` コマンドが `PATH` 上にある | claude code 側と `vox-actor watch` 側で `VOX_ACTOR_WORKSPACE` を共有 |
 
-> `VOX_ACTOR_WORKSPACE` 未指定時は `<gitリポジトリ直下>/.tmp/notify` がデフォルト出力先として使われる（gitリポジトリ外では必須）。`file` モードでホストとLLM実行環境を分ける場合は、双方から参照可能な共有パスを明示的に指定する。
+> `VOX_ACTOR_WORKSPACE` は vox-actor 関連ファイルのルートディレクトリを指す（配下に `queue/` と `monologue-errors.log` が置かれる）。未指定時のデフォルトは gitリポジトリ内なら `<gitリポジトリ直下>/.vox-actor`、gitリポジトリ外なら `$PWD/.vox-actor`。`file` モードでホストとLLM実行環境を分ける場合は、双方から参照可能な共有パスを明示的に指定する。
 
 モードは `VOX_ACTOR_MONOLOGUE_MODE` 環境変数で明示するか、未設定時は `vox-actor` コマンドの有無で自動判定されます（あり → `direct`、なし → `file`）。
 
@@ -271,9 +271,10 @@ vox-actor watch --dry-run /path/to/watch-dir
 
 1. **ホスト側で監視プロセスを常駐させる**
    ```bash
-   # テキストファイルの受け渡し先ディレクトリを指定
+   # vox-actor 関連ファイルのルートディレクトリを指定
    export VOX_ACTOR_WORKSPACE=/path/to/shared/directory
-   vox-actor watch "$VOX_ACTOR_WORKSPACE"
+   # 通知ファイルは $VOX_ACTOR_WORKSPACE/queue/ に配置されるためそこを監視する
+   vox-actor watch "$VOX_ACTOR_WORKSPACE/queue"
    ```
 
 2. **claude code 側で `file` モードを明示し、共有ディレクトリを指定する**

--- a/plugins/vox-actor-plugin/skills/monologue/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/monologue/SKILL.md
@@ -68,8 +68,10 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 通知の実行に使用する `${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh` は以下の前提条件を必要とする:
 
-- **環境変数 `VOX_ACTOR_WORKSPACE`**: 通知ファイルやエラーログの出力先ディレクトリを指定する。未設定の場合はgitリポジトリ直下の `.tmp/notify` がデフォルト出力先として使用される。gitリポジトリ外かつ未設定の場合はエラー終了する
-- **出力先ディレクトリ**: `${VOX_ACTOR_WORKSPACE}` またはデフォルトの `<gitリポジトリ直下>/.tmp/notify`。ディレクトリが存在しない場合はスクリプトが自動作成する
+- **環境変数 `VOX_ACTOR_WORKSPACE`**: vox-actor関連ファイルのルートディレクトリを指定する。配下に `queue/`（fileモードの通知JSON出力先）および `monologue-errors.log`（directモードのエラーログ）が置かれる。未設定の場合のデフォルト値は以下のとおり
+  - gitリポジトリ内: `<gitリポジトリ直下>/.vox-actor`
+  - gitリポジトリ外: `$PWD/.vox-actor`
+- **出力先ディレクトリ**: 上記のルートディレクトリおよび配下の `queue/` はスクリプトが必要に応じて自動作成する
 
 ### 通知モード
 
@@ -89,7 +91,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 #### `file` モード
 
-`${VOX_ACTOR_WORKSPACE}` に通知ファイルを書き出す。ファイル名は `notify_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）がこのファイルを検知して読み上げる
+`${VOX_ACTOR_WORKSPACE}/queue/` に通知ファイルを書き出す。ファイル名は `notify_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする
 
 ## キャラクター設定ファイルについて
 

--- a/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
+++ b/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 if [ -z "$VOX_ACTOR_WORKSPACE" ]; then
   GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
-  if [ -z "$GIT_COMMON_DIR" ]; then
-    echo "[ERROR] 環境変数 'VOX_ACTOR_WORKSPACE' が設定されておらず、gitリポジトリ外のためデフォルト出力先を決定できません。"
-    exit 1
+  if [ -n "$GIT_COMMON_DIR" ]; then
+    VOX_ACTOR_WORKSPACE="$(dirname "$GIT_COMMON_DIR")/.vox-actor"
+  else
+    VOX_ACTOR_WORKSPACE="$PWD/.vox-actor"
   fi
-  VOX_ACTOR_WORKSPACE="$(dirname "$GIT_COMMON_DIR")/.tmp/notify"
 fi
 
 PROBABILITY="$1"
@@ -88,8 +88,10 @@ case "$MODE" in
     disown 2>/dev/null
     ;;
   file)
+    QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"
+    mkdir -p "$QUEUE_DIR"
     jq -cn --argjson speaker "$SPEAKER" --arg text "$TEXT" --argjson speedScale "$SPEED_SCALE" \
-      '{speaker: $speaker, text: $text, speedScale: $speedScale}' > "${VOX_ACTOR_WORKSPACE}/notify_$(($(date +%s%N)/1000000)).json"
+      '{speaker: $speaker, text: $text, speedScale: $speedScale}' > "${QUEUE_DIR}/notify_$(($(date +%s%N)/1000000)).json"
     ;;
   *)
     echo "[ERROR] VOX_ACTOR_MONOLOGUE_MODE は 'direct' または 'file' で指定してください: '$MODE'"


### PR DESCRIPTION
## Summary

- `VOX_ACTOR_WORKSPACE` を「通知ファイル出力先」から「vox-actor関連ファイルのルートディレクトリ」の意味に変更（破壊的）
- 未設定時のデフォルトを git内 = `<git-root>/.vox-actor`、git外 = `$PWD/.vox-actor` に変更。git管理外でもエラー終了しなくなった
- `file` モードの通知JSON出力先を `$WORKSPACE/queue/` に変更（`queue/` は自動作成）。`direct` モードのエラーログは `$WORKSPACE/monologue-errors.log` のまま
- `SKILL.md` / `README.md` の前提条件・モード比較表・`file` モード手順を新仕様に追随

## 破壊的変更の注意

- `VOX_ACTOR_WORKSPACE` を明示設定している既存利用者は、`vox-actor watch` の監視対象を `$VOX_ACTOR_WORKSPACE` から `$VOX_ACTOR_WORKSPACE/queue` に変更する必要がある
- git内で未設定利用していたユーザーは、デフォルト出力先が `<git-root>/.tmp/notify` から `<git-root>/.vox-actor/queue/` に変わる

## 受け入れ条件の検証

- [x] git管理外 + 未設定で `monologue.sh` を実行してもエラー終了しない
- [x] git管理内デフォルトで通知JSONが `<git-root>/.vox-actor/queue/notify_*.json` に出力される
- [x] git管理内デフォルトでエラーログが `<git-root>/.vox-actor/monologue-errors.log` に出力される
- [x] git管理外デフォルトで通知JSONが `$PWD/.vox-actor/queue/notify_*.json` に出力される
- [x] git管理外デフォルトでエラーログが `$PWD/.vox-actor/monologue-errors.log` に出力される
- [x] `VOX_ACTOR_WORKSPACE` 明示設定時、通知JSONが `$WORKSPACE/queue/` に、エラーログが `$WORKSPACE/` 直下に出力される
- [x] `README.md` / `SKILL.md` の記載が新仕様と一致している

## Test plan

- [x] `shellcheck plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh` に指摘なし
- [x] 各受け入れ条件を一時ディレクトリで手動検証

Closes #196

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)