### PR TITLE
chore: vox-actor-pluginのバージョンを0.0.4に更新 #198

### DIFF
--- a/plugins/vox-actor-plugin/.claude-plugin/plugin.json
+++ b/plugins/vox-actor-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-actor-plugin",
   "description": "vox-actorを利用するためのプラグイン",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": {
     "name": "canpok1"
   }


### PR DESCRIPTION
## Summary

- `plugins/vox-actor-plugin/.claude-plugin/plugin.json` の `version` を `0.0.3` → `0.0.4` に更新
- PR #197 で monologue スキルに破壊的変更（`VOX_ACTOR_WORKSPACE` の意味変更・デフォルト出力先の変更）が入ったが plugin.json の version が上がっていなかったため、SemVer パッチバージョンを揃える

Closes #198

🤖 Generated with [Claude Code](https://claude.ai/code)