### PR TITLE
refactor: monologue/explainのdirectモードを同期実行にし発話の被りを解消 #208

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 以下のようなケースでは、`watch` コマンドを常駐させる `file` モードでの利用が適しています。
 
 - claude code がコンテナ／リモート環境で動作し、`vox-actor` コマンドはホスト側にしか存在しない
-- 複数セッションから同時に呼ばれても音声を逐次再生したい（`direct` モードは並列再生になる）
+- 複数セッションから同時に呼ばれても音声を逐次再生したい（`direct` モードは同一セッション内では逐次だが、セッション間では並列再生になる）
 
 ### `direct` モードと `file` モードの違い
 
@@ -358,7 +358,7 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 | 読み上げ方式 | `vox-actor say` をその場で直接呼び出す | テキスト等をファイルに書き出し、別プロセスの `vox-actor watch` が読み上げる |
 | 監視プロセス | 不要 | `vox-actor watch` の常駐が必要 |
 | ファイル出力先 | エラーログのみ（`$VOX_ACTOR_WORKSPACE/monologue-errors.log`） | 通知ファイル（`$VOX_ACTOR_WORKSPACE/queue/notify_*.json`）＋エラーログ |
-| 同時呼び出し時 | 並列再生 | 検知順に逐次再生 |
+| 同時呼び出し時 | 同一セッション内は逐次再生、複数セッション間は並列再生 | 検知順に逐次再生 |
 | 前提 | `vox-actor` コマンドが `PATH` 上にある | claude code 側と `vox-actor watch` 側で `VOX_ACTOR_WORKSPACE` を共有 |
 
 > `VOX_ACTOR_WORKSPACE` は vox-actor 関連ファイルのルートディレクトリを指す（配下に `queue/` と `monologue-errors.log` が置かれる）。未指定時のデフォルトは gitリポジトリ内なら `<gitリポジトリ直下>/.vox-actor`、gitリポジトリ外なら `$PWD/.vox-actor`。`file` モードでホストとLLM実行環境を分ける場合は、双方から参照可能な共有パスを明示的に指定する。

--- a/plugins/vox-actor-plugin/skills/explain/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/explain/SKILL.md
@@ -87,12 +87,12 @@ ${CLAUDE_PLUGIN_ROOT}/skills/explain/scripts/explain.sh <jsonl_path>
 
 #### `direct` モード
 
-`vox-actor act <jsonl_path>` をバックグラウンドで起動し、スクリプトは即座に戻る。
+`vox-actor act <jsonl_path>` を同期実行し、再生の完了を待ってスクリプトが戻る。
 
 - VOICEVOXエンジンのURLは `vox-actor` 側の環境変数 `VOX_ENGINE_URL` で解決する（非デフォルトポート時はユーザーが設定）
 - 監視プロセス（`vox-actor watch`）の常駐は不要
-- 再生プロセス終了後、渡された一時ファイルを `rm -f` で削除する
-- 複数セッションから並列に呼ばれても許容する（エンジンへの並列リクエストと音声再生の重なりは発生するがエラーにはならない）。逐次再生が必要な場合は `VOX_ACTOR_MONOLOGUE_MODE=file` + 監視プロセス構成に切り替えれば対応可能
+- 再生完了後、渡された一時ファイルを `rm -f` で削除する
+- 同期実行のため、同一セッション内で連続して呼び出した場合は先の再生が完了してから次が再生される。ただし複数セッションから並列に呼ばれた場合はエンジンへの並列リクエストと音声再生の重なりが発生しうる。複数セッション間でも逐次再生したい場合は `VOX_ACTOR_MONOLOGUE_MODE=file` + 監視プロセス構成に切り替える
 - `vox-actor act` 失敗時もスクリプト本体はエラー終了せず、標準出力/標準エラーの内容を `${VOX_ACTOR_WORKSPACE}/explain-errors.log` にタイムスタンプ付きで追記する。ログは末尾200行でローテーションされる。失敗検知は `tail -f ${VOX_ACTOR_WORKSPACE}/explain-errors.log` で行える
 
 #### `file` モード

--- a/plugins/vox-actor-plugin/skills/explain/scripts/explain.sh
+++ b/plugins/vox-actor-plugin/skills/explain/scripts/explain.sh
@@ -35,25 +35,22 @@ case "$MODE" in
   direct)
     ERROR_LOG="${VOX_ACTOR_WORKSPACE}/explain-errors.log"
     MAX_LOG_LINES=200
-    (
-      OUTPUT=$(vox-actor act "$JSONL_PATH" 2>&1)
-      STATUS=$?
-      if [ "$STATUS" -ne 0 ]; then
-        TS=$(date '+%Y-%m-%d %H:%M:%S')
-        {
-          echo "[$TS] exit=$STATUS path=$JSONL_PATH"
-          printf '%s\n' "$OUTPUT" | sed 's/^/  /'
-        } >> "$ERROR_LOG"
-        LINES=$(wc -l < "$ERROR_LOG")
-        if [ "$LINES" -gt "$MAX_LOG_LINES" ]; then
-          TMP_LOG=$(mktemp "${ERROR_LOG}.XXXXXX")
-          tail -n "$MAX_LOG_LINES" "$ERROR_LOG" > "$TMP_LOG"
-          mv "$TMP_LOG" "$ERROR_LOG"
-        fi
+    OUTPUT=$(vox-actor act "$JSONL_PATH" 2>&1)
+    STATUS=$?
+    if [ "$STATUS" -ne 0 ]; then
+      TS=$(date '+%Y-%m-%d %H:%M:%S')
+      {
+        echo "[$TS] exit=$STATUS path=$JSONL_PATH"
+        printf '%s\n' "$OUTPUT" | sed 's/^/  /'
+      } >> "$ERROR_LOG"
+      LINES=$(wc -l < "$ERROR_LOG")
+      if [ "$LINES" -gt "$MAX_LOG_LINES" ]; then
+        TMP_LOG=$(mktemp "${ERROR_LOG}.XXXXXX")
+        tail -n "$MAX_LOG_LINES" "$ERROR_LOG" > "$TMP_LOG"
+        mv "$TMP_LOG" "$ERROR_LOG"
       fi
-      rm -f "$JSONL_PATH"
-    ) </dev/null >/dev/null 2>&1 &
-    disown 2>/dev/null
+    fi
+    rm -f "$JSONL_PATH"
     ;;
   file)
     QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"

--- a/plugins/vox-actor-plugin/skills/monologue/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/monologue/SKILL.md
@@ -82,11 +82,11 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 #### `direct` モード
 
-`vox-actor say --speaker <スピーカーID> --speed <話速> "<セリフ>"` をバックグラウンドで起動し、スクリプトは即座に戻る。
+`vox-actor say --speaker <スピーカーID> --speed <話速> "<セリフ>"` を同期実行し、再生の完了を待ってスクリプトが戻る。
 
 - VOICEVOXエンジンのURLは `vox-actor` 側の環境変数 `VOX_ENGINE_URL` で解決する（非デフォルトポート時はユーザーが設定）
 - 監視プロセス（`vox-actor watch`）の常駐は不要
-- 複数セッションから並列に呼ばれても許容する（エンジンへの並列リクエストと音声再生の重なりは発生するがエラーにはならない）。逐次再生が必要な場合は `VOX_ACTOR_MONOLOGUE_MODE=file` + 監視プロセス構成に切り替えれば対応可能
+- 同期実行のため、同一セッション内で連続して呼び出した場合は先の発話が完了してから次が再生される。ただし複数セッションから並列に呼ばれた場合はエンジンへの並列リクエストと音声再生の重なりが発生しうる。複数セッション間でも逐次再生したい場合は `VOX_ACTOR_MONOLOGUE_MODE=file` + 監視プロセス構成に切り替える
 - `vox-actor say` 失敗時もスクリプト本体はエラー終了せず、標準出力/標準エラーの内容を `${VOX_ACTOR_WORKSPACE}/monologue-errors.log` にタイムスタンプ付きで追記する。ログは末尾200行でローテーションされる。失敗検知は `tail -f ${VOX_ACTOR_WORKSPACE}/monologue-errors.log` で行える
 
 #### `file` モード

--- a/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
+++ b/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
@@ -68,24 +68,21 @@ case "$MODE" in
   direct)
     ERROR_LOG="${VOX_ACTOR_WORKSPACE}/monologue-errors.log"
     MAX_LOG_LINES=200
-    (
-      OUTPUT=$(vox-actor say --speaker "$SPEAKER" --speed "$SPEED_SCALE" "$TEXT" 2>&1)
-      STATUS=$?
-      if [ "$STATUS" -ne 0 ]; then
-        TS=$(date '+%Y-%m-%d %H:%M:%S')
-        {
-          echo "[$TS] exit=$STATUS speaker=$SPEAKER speed=$SPEED_SCALE text=$TEXT"
-          printf '%s\n' "$OUTPUT" | sed 's/^/  /'
-        } >> "$ERROR_LOG"
-        LINES=$(wc -l < "$ERROR_LOG")
-        if [ "$LINES" -gt "$MAX_LOG_LINES" ]; then
-          TMP_LOG=$(mktemp "${ERROR_LOG}.XXXXXX")
-          tail -n "$MAX_LOG_LINES" "$ERROR_LOG" > "$TMP_LOG"
-          mv "$TMP_LOG" "$ERROR_LOG"
-        fi
+    OUTPUT=$(vox-actor say --speaker "$SPEAKER" --speed "$SPEED_SCALE" "$TEXT" 2>&1)
+    STATUS=$?
+    if [ "$STATUS" -ne 0 ]; then
+      TS=$(date '+%Y-%m-%d %H:%M:%S')
+      {
+        echo "[$TS] exit=$STATUS speaker=$SPEAKER speed=$SPEED_SCALE text=$TEXT"
+        printf '%s\n' "$OUTPUT" | sed 's/^/  /'
+      } >> "$ERROR_LOG"
+      LINES=$(wc -l < "$ERROR_LOG")
+      if [ "$LINES" -gt "$MAX_LOG_LINES" ]; then
+        TMP_LOG=$(mktemp "${ERROR_LOG}.XXXXXX")
+        tail -n "$MAX_LOG_LINES" "$ERROR_LOG" > "$TMP_LOG"
+        mv "$TMP_LOG" "$ERROR_LOG"
       fi
-    ) </dev/null >/dev/null 2>&1 &
-    disown 2>/dev/null
+    fi
     ;;
   file)
     QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"


### PR DESCRIPTION
## Summary

`plugins/vox-actor-plugin/skills/{monologue,explain}/scripts/*.sh` の `direct` モードを、バックグラウンド実行（`&` + `disown`）から同期実行に変更。同一セッション内で連続呼び出しした際に `vox-actor` 発話が被らなくなる。

- `monologue.sh` / `explain.sh`: direct 分岐のサブシェル・バックグラウンド化を削除し、`vox-actor say` / `vox-actor act` の完了を待って戻るように変更
- `monologue/SKILL.md` / `explain/SKILL.md`: direct モードの挙動説明を同期実行前提に書き換え
- `README.md`: `direct` と `file` モードの比較表および該当箇所の記述を実態に合わせて更新（同一セッション内は逐次、セッション間は並列）
- `file` モードは未変更

## Test plan

- [x] `shellcheck` 実行（指摘なし）
- [x] モック `vox-actor`（`sleep 1`）で `monologue.sh` を連続 2 回呼び出し、所要時間が約 2 秒であることを確認（同期化の検証）
- [x] 同条件で `explain.sh` を連続 2 回呼び出し、所要時間が約 2 秒 + JSONL 一時ファイル削除を確認
- [x] モック `vox-actor` の失敗終了で `monologue-errors.log` / `explain-errors.log` が追記されることを確認（既存のエラーログ挙動の継続）
- [x] `VOX_ACTOR_MONOLOGUE_MODE=file` で `queue/notify_*.json` / `queue/explain_*.jsonl` が従来通り出力されることを確認

Closes #208

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * `direct` モードの再生実行が、バックグラウンド実行から同期実行に変更されました。再生完了まで待機してからスクリプトが戻るようになります。
  * 同一セッション内での複数呼び出しは逐次実行に、異なるセッション間では並列実行が可能です。

* **Documentation**
  * `direct` / `file` モードの動作説明とドキュメントを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->