### PR TITLE
refactor: monologue/speakのデフォルトキャラ設定を共通化しスキル名と表記を揃える #214

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 
 ### 対応キャラクター一覧
 
-`monologue` / `speak` スキルで利用できるキャラクターは `plugins/vox-actor-plugin/characters/` に設定ファイルとして同梱されています。キャラクター名（`<name>`）は `/vox-actor-plugin:monologue <name>` の引数や `speak` スキルの `explanation_character` メモリ設定で指定します。
+`monologue` / `speak` スキルで利用できるキャラクターは `plugins/vox-actor-plugin/characters/` に設定ファイルとして同梱されています。キャラクター名（`<name>`）は `/vox-actor-plugin:monologue <name>` の引数や、両スキル共通の `default_character` メモリ設定で指定します。
 
 | キャラクター名 | `<name>` | 分類 | 特徴 |
 |---|---|---|---|
@@ -306,6 +306,7 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 
 | 項目 | キー | デフォルト値 | 説明 |
 |------|------|-------------|------|
+| デフォルトキャラクター | `default_character` | `zundamon` | `characters/<name>.md` の `<name>`。`speak` スキルと共用。引数指定があればそちらが優先 |
 | 通知確率 | `monologue_probability` | `100` | 1〜100の整数。通知する確率（%） |
 
 ユーザー指示（例: 「独り言の頻度を30%にして」）で更新すると、以降の実行に反映されます。
@@ -328,8 +329,8 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 
 | 項目 | キー | デフォルト値 | 値 | 説明 |
 |------|------|-------------|----|-----|
-| 読み上げキャラクター | `explanation_character` | `zundamon` | `characters/<name>.md` の `<name>` | 例: 「読み上げはめたんで」→ `metan` を保存 |
-| 読み上げの長さ | `explanation_length` | `medium` | `short` / `medium` / `long` | 下記の長さ表を参照 |
+| デフォルトキャラクター | `default_character` | `zundamon` | `characters/<name>.md` の `<name>` | `monologue` スキルと共用。例: 「読み上げはめたんで」→ `metan` を保存 |
+| 読み上げの長さ | `speak_length` | `medium` | `short` / `medium` / `long` | 下記の長さ表を参照 |
 
 ##### 読み上げの長さ
 
@@ -370,7 +371,7 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 |---|---|---|
 | 読み上げ方式 | `vox-actor say` をその場で直接呼び出す | テキスト等をファイルに書き出し、別プロセスの `vox-actor watch` が読み上げる |
 | 監視プロセス | 不要 | `vox-actor watch` の常駐が必要 |
-| ファイル出力先 | エラーログのみ（`$VOX_ACTOR_WORKSPACE/monologue-errors.log`） | 通知ファイル（`$VOX_ACTOR_WORKSPACE/queue/notify_*.json`）＋エラーログ |
+| ファイル出力先 | エラーログのみ（`$VOX_ACTOR_WORKSPACE/monologue-errors.log`） | 通知ファイル（`$VOX_ACTOR_WORKSPACE/queue/monologue_*.json`）＋エラーログ |
 | 同時呼び出し時 | 同一セッション内は逐次再生、複数セッション間は並列再生 | 検知順に逐次再生 |
 | 前提 | `vox-actor` コマンドが `PATH` 上にある | claude code 側と `vox-actor watch` 側で `VOX_ACTOR_WORKSPACE` を共有 |
 

--- a/plugins/vox-actor-plugin/.claude-plugin/plugin.json
+++ b/plugins/vox-actor-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-actor-plugin",
   "description": "vox-actorを利用するためのプラグイン",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": {
     "name": "canpok1"
   }

--- a/plugins/vox-actor-plugin/skills/monologue/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/monologue/SKILL.md
@@ -49,9 +49,12 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 ## キャラクター設定
 
-`$ARGUMENTS` で指定されたキャラクターの設定ファイルを読み込み、そのキャラクターになりきった一言コメントを生成する。
+以下の優先順位でキャラクターを解決し、そのキャラクターになりきった一言コメントを生成する。
 
-- `$ARGUMENTS` が空の場合: デフォルトキャラクター「ずんだもん」を使用
+1. `$ARGUMENTS` が指定されていればそれを使用
+2. 指定がなければメモリの `default_character` を使用（`speak` スキルと共用）
+3. メモリ未設定なら `zundamon` を使用
+
 - キャラクター設定ファイル: `${CLAUDE_PLUGIN_ROOT}/characters/{キャラクター名}.md`（例: `${CLAUDE_PLUGIN_ROOT}/characters/zundamon.md`）
 
 ## メモリに保存する設定項目
@@ -60,6 +63,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 | 項目 | キー | デフォルト値 | 説明 |
 |------|------|-------------|------|
+| デフォルトキャラクター | `default_character` | `zundamon` | `characters/<name>.md` の `<name>`。`speak` スキルと共用 |
 | 通知確率 | `monologue_probability` | 100 | 1〜100の整数。通知する確率（%） |
 
 ## 前提条件
@@ -91,7 +95,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 #### `file` モード
 
-`${VOX_ACTOR_WORKSPACE}/queue/` に通知ファイルを書き出す。ファイル名は `notify_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする
+`${VOX_ACTOR_WORKSPACE}/queue/` に通知ファイルを書き出す。ファイル名は `monologue_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする
 
 ## キャラクター設定ファイルについて
 

--- a/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
+++ b/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
@@ -88,7 +88,7 @@ case "$MODE" in
     QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"
     mkdir -p "$QUEUE_DIR"
     jq -cn --argjson speaker "$SPEAKER" --arg text "$TEXT" --argjson speedScale "$SPEED_SCALE" \
-      '{speaker: $speaker, text: $text, speedScale: $speedScale}' > "${QUEUE_DIR}/notify_$(($(date +%s%N)/1000000)).json"
+      '{speaker: $speaker, text: $text, speedScale: $speedScale}' > "${QUEUE_DIR}/monologue_$(($(date +%s%N)/1000000)).json"
     ;;
   *)
     echo "[ERROR] VOX_ACTOR_MONOLOGUE_MODE は 'direct' または 'file' で指定してください: '$MODE'"

--- a/plugins/vox-actor-plugin/skills/speak/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/speak/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools:
 ## 実行フロー
 
 1. `$ARGUMENTS` を読み上げ内容として受け取る
-2. メモリから `explanation_character`（既定 `zundamon`）と `explanation_length`（既定 `medium`）を読み取る
+2. メモリから `default_character`（既定 `zundamon`、`monologue` スキルと共用）と `speak_length`（既定 `medium`）を読み取る
 3. `${CLAUDE_PLUGIN_ROOT}/characters/<name>.md` を読み、`speakers` 一覧と性格を把握する
 4. 長さ設定に応じた **JSONL台本** を生成する（各行: `{"text":..., "speaker":..., "speedScale":...}`）
    - 冒頭の挨拶／つかみ → 本題 → まとめの流れを意識する
@@ -62,10 +62,10 @@ ${CLAUDE_PLUGIN_ROOT}/skills/speak/scripts/speak.sh <jsonl_path>
 
 | 項目 | キー | デフォルト値 | 値 | 説明 |
 |------|------|-------------|----|-----|
-| 読み上げキャラクター | `explanation_character` | `zundamon` | `characters/<name>.md` の `<name>` | 例: 「読み上げはめたんで」→ `metan` を保存 |
-| 読み上げの長さ | `explanation_length` | `medium` | `short` / `medium` / `long` | 上記の長さ表を参照 |
+| デフォルトキャラクター | `default_character` | `zundamon` | `characters/<name>.md` の `<name>` | `monologue` スキルと共用。例: 「読み上げはめたんで」→ `metan` を保存 |
+| 読み上げの長さ | `speak_length` | `medium` | `short` / `medium` / `long` | 上記の長さ表を参照 |
 
-`monologue` 側の `monologue_probability` とは衝突しない。
+`default_character` は `monologue` スキルと共有する。`speak_length` と `monologue_probability` はそれぞれのスキル固有で衝突しない。
 
 ## 前提条件
 


### PR DESCRIPTION
## Summary

- メモリキー `explanation_character` を `default_character` へリネームし、`monologue` / `speak` で共通参照にする
- メモリキー `explanation_length` を `speak_length` へリネーム（`speak` 固有）
- `monologue` のキャラクター解決順を「引数 → メモリ `default_character` → `zundamon`」に変更
- `monologue.sh` fileモード出力ファイル名を `queue/notify_<ms>.json` から `queue/monologue_<ms>.json` に変更
- README と両 SKILL.md を同期、プラグインバージョンを `0.0.7` → `0.0.8` に更新

## 既存メモリの移行手順

破壊的変更として扱い、旧キーへのフォールバックは実装しない。既存ユーザーは手動で以下を対応する。

1. `~/.claude/projects/<project>/memory/explanation_character.md` が存在する場合は、ファイル名を `default_character.md` にリネーム
2. ファイル内の `explanation_character: <value>` を `default_character: <value>` に書き換え
3. `MEMORY.md` の該当エントリのリンク先ファイル名・見出しを `default_character.md` / `default_character` に更新
4. `explanation_length` を設定していた場合は同様に `speak_length` に書き換え

未対応の場合はデフォルト値（`zundamon` / `medium`）にフォールバックする。

## Test plan

- [x] `monologue.sh` を file モードで実行し、`queue/monologue_<ms>.json` が生成されることを確認
- [x] `shellcheck` で `monologue.sh` を確認（指摘なし）
- [x] 旧キー名 `explanation_character` / `explanation_length` / `notify_` の参照が残っていないことを `grep` で確認
- [ ] CI（build / test / lint）

Closes #214

🤖 Generated with [Claude Code](https://claude.ai/code)