### PR TITLE
feat: vox-actor-plugin に talk スキルを追加 #216

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ claude code で作業の区切りごとに独り言を読み上げさせる最�
 
 3. **作業の区切りで自動的に独り言が読み上げられる**
 
-   `auto-monologue-plugin` を導入していれば、claude code の作業の区切りごとに自動で独り言が生成・読み上げされます。手動で呼び出す場合は `/vox-actor-plugin:monologue` を、解説・朗読・作業結果の報告などをキャラクターにまとまった長さで話させたい場合は `/vox-actor-plugin:speak <内容>` を実行します。
+   `auto-monologue-plugin` を導入していれば、claude code の作業の区切りごとに自動で独り言が生成・読み上げされます。手動で呼び出す場合は `/vox-actor-plugin:monologue` を、解説・朗読・作業結果の報告などを1キャラにまとまった長さで話させたい場合は `/vox-actor-plugin:speak <内容>` を、複数キャラが会話する形式で読み上げてほしい場合は `/vox-actor-plugin:talk <内容>` を実行します。
 
 リモート環境での利用や複数セッションの音声を逐次再生したい場合は[高度な利用](#-高度な利用リモート環境監視モード)を参照してください。
 
@@ -63,7 +63,8 @@ vox-actor は **CLI** と **claude code プラグイン／スキル** の 2 系�
 claude code から `/vox-actor-plugin:<skill>` 形式で呼び出すスキルです。LLM が生成したセリフをキャラクターになりきって読み上げます。
 
 - `/vox-actor-plugin:monologue`: 作業開始／終了／想定外のことが起こった時など、節目のキャラクターの一言独り言
-- `/vox-actor-plugin:speak <内容>`: 解説・朗読・結果報告・ストーリーテリングなど、渡した内容を冒頭→本題→まとめの流れで複数セリフのJSONL台本としてキャラクターに読み上げさせる
+- `/vox-actor-plugin:speak <内容>`: 解説・朗読・結果報告・ストーリーテリングなど、渡した内容を冒頭→本題→まとめの流れで複数セリフのJSONL台本として1キャラに読み上げさせる
+- `/vox-actor-plugin:talk <内容>`: 複数キャラクターが会話する形式のJSONL台本を生成し、掛け合い・対話・漫才風などで読み上げさせる
 
 詳細は [プラグイン／スキルリファレンス](#-プラグインスキルリファレンス) を参照してください。
 
@@ -279,7 +280,7 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 
 ### 対応キャラクター一覧
 
-`monologue` / `speak` スキルで利用できるキャラクターは `plugins/vox-actor-plugin/characters/` に設定ファイルとして同梱されています。キャラクター名（`<name>`）は `/vox-actor-plugin:monologue <name>` の引数や、両スキル共通の `default_character` メモリ設定で指定します。
+`monologue` / `speak` / `talk` スキルで利用できるキャラクターは `plugins/vox-actor-plugin/characters/` に設定ファイルとして同梱されています。キャラクター名（`<name>`）は `/vox-actor-plugin:monologue <name>` の引数や、`monologue` / `speak` 共通の `default_character`、`talk` 用の `talk_characters` メモリ設定で指定します。
 
 | キャラクター名 | `<name>` | 分類 | 特徴 |
 |---|---|---|---|
@@ -358,6 +359,54 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 {"text": "わかったかな？お疲れ様なのだ！", "speaker": 1, "speedScale": 1.0}
 ```
 
+### `/vox-actor-plugin:talk <内容>`
+
+渡した内容を、複数キャラクターが会話する形式のJSONL台本として生成し、掛け合い・対話・漫才風・ニュース番組風などの読み上げを行います。`speak` が1キャラでまとまった長さを語るのに対し、本スキルは2〜4人のキャラによる役割配分と会話の流れを構成します。
+
+```
+/vox-actor-plugin:talk <内容>
+```
+
+- `<内容>`: 会話のトピックにしたい概念・メモ・調査結果・文章などを自由記述で渡します
+- 生成されたJSONL台本は一時ファイルに書き出され、`vox-actor act` で再生されます
+- 再生方式は `direct` / `file` モードで自動切替されます（[高度な利用](#-高度な利用リモート環境監視モード) を参照）
+
+#### メモリ設定
+
+以下の設定を claude code のメモリに保存しておくと、次回以降の実行に反映されます。
+
+| 項目 | キー | デフォルト値 | 値 | 説明 |
+|------|------|-------------|----|-----|
+| 会話キャラクター | `talk_characters` | `[zundamon, metan]` | `characters/<name>.md` の `<name>` の配列（2〜4人） | 本スキル専用。`default_character` とは別に管理 |
+| 会話の長さ | `talk_length` | `medium` | `short` / `medium` / `long` | 下記の長さ表を参照 |
+
+##### 会話の長さ
+
+| 設定 | セリフ数の目安 | 想定再生時間 |
+|------|---------------|------------|
+| `short` | 4〜6 | 〜30秒 |
+| `medium`（既定） | 8〜12 | 1〜2分 |
+| `long` | 14+ | 数分 |
+
+#### 呼び出し例
+
+```
+/vox-actor-plugin:talk クロージャとは何か
+```
+
+#### JSONL出力例
+
+ずんだもん（`speakers.ノーマル: 3`、`あまあま: 1`）と四国めたん（`ノーマル: 2`、`ツンツン: 6`）の会話例:
+
+```jsonl
+{"text": "今日はクロージャについて解説するのだ！", "speaker": 3, "speedScale": 1.1}
+{"text": "あら、わたくしも勉強させてもらおうかしら", "speaker": 2, "speedScale": 1.0}
+{"text": "簡単に言うと、関数が作られた時の周りの変数を覚えておく仕組みなのだ", "speaker": 3, "speedScale": 1.0}
+{"text": "なるほど、お弁当箱みたいなものですわね", "speaker": 2, "speedScale": 1.0}
+{"text": "そう、そんな感じなのだー", "speaker": 1, "speedScale": 0.9}
+{"text": "よく分かりましたわ。ありがとう、ずんだもん", "speaker": 2, "speedScale": 1.0}
+```
+
 ## 🔀 高度な利用（リモート環境・監視モード）
 
 以下のようなケースでは、`watch` コマンドを常駐させる `file` モードでの利用が適しています。
@@ -371,11 +420,11 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 |---|---|---|
 | 読み上げ方式 | `vox-actor say` をその場で直接呼び出す | テキスト等をファイルに書き出し、別プロセスの `vox-actor watch` が読み上げる |
 | 監視プロセス | 不要 | `vox-actor watch` の常駐が必要 |
-| ファイル出力先 | エラーログのみ（`$VOX_ACTOR_WORKSPACE/monologue-errors.log`） | 通知ファイル（`$VOX_ACTOR_WORKSPACE/queue/monologue_*.json`）＋エラーログ |
+| ファイル出力先 | エラーログのみ（`monologue` は `$VOX_ACTOR_WORKSPACE/monologue-errors.log`、`speak` / `talk` は `$VOX_ACTOR_WORKSPACE/play-script-errors.log`） | 通知ファイル（`$VOX_ACTOR_WORKSPACE/queue/monologue_*.json` / `speak_*.jsonl` / `talk_*.jsonl`）＋エラーログ |
 | 同時呼び出し時 | 同一セッション内は逐次再生、複数セッション間は並列再生 | 検知順に逐次再生 |
 | 前提 | `vox-actor` コマンドが `PATH` 上にある | claude code 側と `vox-actor watch` 側で `VOX_ACTOR_WORKSPACE` を共有 |
 
-> `VOX_ACTOR_WORKSPACE` は vox-actor 関連ファイルのルートディレクトリを指す（配下に `queue/` と `monologue-errors.log` が置かれる）。未指定時のデフォルトは gitリポジトリ内なら `<gitリポジトリ直下>/.vox-actor`、gitリポジトリ外なら `$PWD/.vox-actor`。`file` モードでホストとLLM実行環境を分ける場合は、双方から参照可能な共有パスを明示的に指定する。
+> `VOX_ACTOR_WORKSPACE` は vox-actor 関連ファイルのルートディレクトリを指す（配下に `queue/` と `monologue-errors.log`、`speak` / `talk` 用の `play-script-errors.log` が置かれる）。未指定時のデフォルトは gitリポジトリ内なら `<gitリポジトリ直下>/.vox-actor`、gitリポジトリ外なら `$PWD/.vox-actor`。`file` モードでホストとLLM実行環境を分ける場合は、双方から参照可能な共有パスを明示的に指定する。
 
 モードは `VOX_ACTOR_MONOLOGUE_MODE` 環境変数で明示するか、未設定時は `vox-actor` コマンドの有無で自動判定されます（あり → `direct`、なし → `file`）。
 
@@ -439,7 +488,10 @@ vox-actor act --watch-delete /path/to/watch-dir
 
 ### エラーログ
 
-`direct` モードでの `vox-actor say` 失敗は `$VOX_ACTOR_WORKSPACE/monologue-errors.log` に追記されます（ログは末尾200行でローテーション）。`tail -f` で確認できます。
+`direct` モードでの失敗は以下のログに追記されます（いずれも末尾200行でローテーション）。`tail -f` で確認できます。
+
+- `monologue` スキル: `$VOX_ACTOR_WORKSPACE/monologue-errors.log`
+- `speak` / `talk` スキル: `$VOX_ACTOR_WORKSPACE/play-script-errors.log`
 
 ## 👩‍💻 開発者向け情報
 

--- a/plugins/vox-actor-plugin/.claude-plugin/plugin.json
+++ b/plugins/vox-actor-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-actor-plugin",
   "description": "vox-actorを利用するためのプラグイン",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": {
     "name": "canpok1"
   }

--- a/plugins/vox-actor-plugin/scripts/play-script.sh
+++ b/plugins/vox-actor-plugin/scripts/play-script.sh
@@ -33,7 +33,7 @@ mkdir -p "$VOX_ACTOR_WORKSPACE"
 
 case "$MODE" in
   direct)
-    ERROR_LOG="${VOX_ACTOR_WORKSPACE}/speak-errors.log"
+    ERROR_LOG="${VOX_ACTOR_WORKSPACE}/play-script-errors.log"
     MAX_LOG_LINES=200
     OUTPUT=$(vox-actor act "$JSONL_PATH" 2>&1)
     STATUS=$?
@@ -55,7 +55,7 @@ case "$MODE" in
   file)
     QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"
     mkdir -p "$QUEUE_DIR"
-    DEST="${QUEUE_DIR}/speak_$(($(date +%s%N)/1000000)).jsonl"
+    DEST="${QUEUE_DIR}/$(basename "$JSONL_PATH")"
     mv "$JSONL_PATH" "$DEST"
     ;;
   *)

--- a/plugins/vox-actor-plugin/skills/talk/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/talk/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: speak
-description: 渡されたトピック・メモ・作業結果などをキャラクター付きの複数セリフJSONL台本として生成し、vox-actor経由で解説・朗読・結果報告を音声で届けるスキル。
+name: talk
+description: 渡されたトピックを複数キャラクターの会話形式JSONL台本として生成し、vox-actor経由で掛け合い・対話・漫才風の読み上げを届けるスキル。
 argument-hint: "<内容>"
 allowed-tools:
   - "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh *)"
@@ -9,19 +9,21 @@ allowed-tools:
   - "Write(${VOX_ACTOR_WORKSPACE}/tmp/*)"
 ---
 
-ユーザーから渡された内容を、キャラクターになりきった複数セリフのJSONL台本として生成し、音声で届けます。解説・朗読・作業の結果報告・ストーリーテリングなど、まとまった長さの音声アウトプット全般に利用できます。`monologue` が1文の独り言用であるのに対し、本スキルは冒頭→本題→まとめのまとまった長さを扱います。
+ユーザーから渡された内容を、複数キャラクターが会話する形式のJSONL台本として生成し、音声で届けます。掛け合いや対話、漫才、ニュース番組風の読み上げなど、複数人の語りが求められる音声アウトプットに利用できます。`speak` スキルが1キャラで冒頭→本題→まとめを語るのに対し、本スキルは複数キャラの役割配分と会話の流れを構成します。
 
 ## 実行フロー
 
 1. `$ARGUMENTS` を読み上げ内容として受け取る
-2. メモリから `default_character`（既定 `zundamon`、`monologue` スキルと共用）と `speak_length`（既定 `medium`）を読み取る
-3. `${CLAUDE_PLUGIN_ROOT}/characters/<name>.md` を読み、`speakers` 一覧と性格を把握する
-4. 長さ設定に応じた **JSONL台本** を生成する（各行: `{"text":..., "speaker":..., "speedScale":...}`）
-   - 冒頭の挨拶／つかみ → 本題 → まとめの流れを意識する
-   - セリフ毎に内容の感情に合う `speaker` と `speedScale` を選定する
-5. `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で一時ディレクトリを作成する
-6. 一時ファイル `${VOX_ACTOR_WORKSPACE}/tmp/speak_<unix_ms>.jsonl` に Write する
-7. `play-script.sh <path>` を呼び出す
+2. メモリから `talk_characters`（既定 `[zundamon, metan]`）と `talk_length`（既定 `medium`）を読み取る
+3. `talk_characters` の各キャラについて `${CLAUDE_PLUGIN_ROOT}/characters/<name>.md` を読み、`speakers` 一覧と性格を把握する
+4. 内容に応じて役割配分（例: 解説役／聞き役／ツッコミ役 など）をその場で組み立てる
+5. 長さ設定に応じた **JSONL台本** を生成する（各行: `{"text":..., "speaker":..., "speedScale":...}`）
+   - 冒頭で全キャラが登場する（自己紹介・挨拶など）よう意識する
+   - 本題ではキャラ同士の掛け合い・質問応答・補足などで会話を展開する
+   - セリフ毎に担当キャラの `speakers` から感情に合うIDを選定し、`speedScale` も感情に合わせる
+6. `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で一時ディレクトリを作成する
+7. 一時ファイル `${VOX_ACTOR_WORKSPACE}/tmp/talk_<unix_ms>.jsonl` に Write する
+8. `play-script.sh <path>` を呼び出す
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
@@ -33,11 +35,11 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 | 設定 | セリフ数の目安 | 想定再生時間 |
 |------|---------------|------------|
-| `short` | 3〜5 | 〜十数秒 |
-| `medium`（既定） | 6〜10 | 30秒〜1分 |
-| `long` | 10+ | 数分 |
+| `short` | 4〜6 | 〜30秒 |
+| `medium`（既定） | 8〜12 | 1〜2分 |
+| `long` | 14+ | 数分 |
 
-ユーザー指示「読み上げを短めにして」等でメモリを更新すれば次回以降に反映される。
+ユーザー指示「会話を短めにして」等でメモリを更新すれば次回以降に反映される。
 
 ## 話速の目安
 
@@ -51,9 +53,9 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 ## キャラクター設定
 
-メモリで指定されたキャラクターの設定ファイルを読み込み、そのキャラクターになりきった台本を生成する。
+メモリ `talk_characters` に指定された2〜4人のキャラクター設定ファイルを読み込み、それぞれになりきった台本を生成する。
 
-- メモリ未設定時のデフォルト: ずんだもん（`zundamon`）
+- メモリ未設定時のデフォルト: ずんだもん（`zundamon`）と四国めたん（`metan`）の2人
 - キャラクター設定ファイル: `${CLAUDE_PLUGIN_ROOT}/characters/{キャラクター名}.md`（例: `${CLAUDE_PLUGIN_ROOT}/characters/zundamon.md`）
 
 ## メモリに保存する設定項目
@@ -62,10 +64,10 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 | 項目 | キー | デフォルト値 | 値 | 説明 |
 |------|------|-------------|----|-----|
-| デフォルトキャラクター | `default_character` | `zundamon` | `characters/<name>.md` の `<name>` | `monologue` スキルと共用。例: 「読み上げはめたんで」→ `metan` を保存 |
-| 読み上げの長さ | `speak_length` | `medium` | `short` / `medium` / `long` | 上記の長さ表を参照 |
+| 会話キャラクター | `talk_characters` | `[zundamon, metan]` | `characters/<name>.md` の `<name>` の配列（2〜4人） | 本スキル専用。`default_character` とは別に管理 |
+| 会話の長さ | `talk_length` | `medium` | `short` / `medium` / `long` | 上記の長さ表を参照 |
 
-`default_character` は `monologue` スキルと共有する。`speak_length` と `monologue_probability` はそれぞれのスキル固有で衝突しない。
+`talk_characters` は本スキル固有の設定で、`monologue` / `speak` の `default_character` とは独立している。
 
 ## 前提条件
 
@@ -97,23 +99,24 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 #### `file` モード
 
-一時ファイルを `${VOX_ACTOR_WORKSPACE}/queue/$(basename <jsonl_path>)` へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`speak_<ms>.jsonl` なら `queue/speak_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
+一時ファイルを `${VOX_ACTOR_WORKSPACE}/queue/$(basename <jsonl_path>)` へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`talk_<ms>.jsonl` なら `queue/talk_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
 
 ## JSONL 出力例
 
-解説用途の例（ずんだもん）。朗読・結果報告・ストーリーテリングでも同じJSONL形式で台本を生成する:
+ずんだもん（`speakers.ノーマル: 3`、`あまあま: 1`）と四国めたん（`ノーマル: 2`、`ツンツン: 6`）の会話例:
 
 ```jsonl
-{"text": "クロージャって何なのだ？説明するのだ！", "speaker": 3, "speedScale": 1.1}
+{"text": "今日はクロージャについて解説するのだ！", "speaker": 3, "speedScale": 1.1}
+{"text": "あら、わたくしも勉強させてもらおうかしら", "speaker": 2, "speedScale": 1.0}
 {"text": "簡単に言うと、関数が作られた時の周りの変数を覚えておく仕組みなのだ", "speaker": 3, "speedScale": 1.0}
-{"text": "むむっ、ちょっと難しいけど…例えるならお弁当箱に具材を詰めて持ち歩く感じなのだ", "speaker": 3, "speedScale": 1.0}
-{"text": "後から開けても中身がそのまま残ってるみたいに、変数の値も残るのだ〜", "speaker": 1, "speedScale": 0.9}
-{"text": "わかったかな？お疲れ様なのだ！", "speaker": 1, "speedScale": 1.0}
+{"text": "なるほど、お弁当箱みたいなものですわね", "speaker": 2, "speedScale": 1.0}
+{"text": "そう、そんな感じなのだー", "speaker": 1, "speedScale": 0.9}
+{"text": "よく分かりましたわ。ありがとう、ずんだもん", "speaker": 2, "speedScale": 1.0}
 ```
 
 ## キャラクター設定ファイルについて
 
-`characters/` 配下のキャラクター設定ファイルはClaude向けの自然言語テキストとして消費される。キャラクター名や口調特徴などの主要メタデータはYAML frontmatterに構造化されており、本文にはClaude向けの詳細な性格・口調の説明やセリフ例が記載されている。`monologue` スキルと共用する。
+`characters/` 配下のキャラクター設定ファイルはClaude向けの自然言語テキストとして消費される。キャラクター名や口調特徴などの主要メタデータはYAML frontmatterに構造化されており、本文にはClaude向けの詳細な性格・口調の説明やセリフ例が記載されている。`monologue` / `speak` スキルと同一のファイルを共用する。
 
 ## 制約
 
@@ -124,4 +127,5 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 - ファイルパス、URL、UUIDなど長い文字情報は発音しても分かりづらいため、セリフに含めないこと
 - 内容にコード断片や仕様文書が含まれる場合も、識別子は「読める形」に変換すること
 - セリフ内のダブルクォート・バックスラッシュ等は JSONL 仕様に従って適切にエスケープすること
-- 同じ `speaker` を連続で使ってもよいが、感情に合わせて切り替えるとキャラクターらしさが出る
+- 同一キャラが連続で話してもよいが、会話らしさを保つため役割配分とターン交代を意識する
+- 冒頭では全キャラが1回以上登場するよう配慮する（自己紹介・挨拶・呼びかけなど）


### PR DESCRIPTION
## 概要

Issue #216 に対応。`vox-actor-plugin` に複数キャラクターが会話する形式で内容を読み上げる新スキル `talk` を追加し、`speak` / `talk` で共用する再生処理を `scripts/play-script.sh` に切り出した。

Close #216

## 変更点

### 共用スクリプト
- `plugins/vox-actor-plugin/scripts/play-script.sh` を新設（旧 `skills/speak/scripts/speak.sh` の移動＋汎用化）
  - file モードの出力先を渡された JSONL ファイルの basename のまま `${QUEUE_DIR}/` に移すよう変更（`speak_` プレフィックス固定を廃止）
  - エラーログを `play-script-errors.log` に統一
- 旧 `skills/speak/scripts/speak.sh` を削除

### 新規スキル
- `plugins/vox-actor-plugin/skills/talk/SKILL.md` を新規追加
  - メモリ: `talk_characters`（既定 `[zundamon, metan]`）、`talk_length`（既定 `medium`）
  - 冒頭で全キャラ登場 → 本題で掛け合いの流れで JSONL 台本を生成
  - `${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh` を呼び出す

### 既存スキル更新
- `skills/speak/SKILL.md` を `play-script.sh` 経由に変更（`allowed-tools` とエラーログ記述も更新）

### ドキュメント
- README に talk スキルを追加（概要／スキル一覧／詳細節／エラーログ記述）
- `plugin.json` を `0.0.8` → `0.0.9` へアップ
  - ※ Issue 本文は `0.0.7 → 0.0.8` 記載だが、#214 マージ時点で既に 0.0.8 のため、本 PR で 0.0.9 にアップ

## 動作確認

`mktemp -d` でワークスペースを用意し、以下を手動検証:

- file モード:
  - `speak_<ms>.jsonl` → `queue/speak_<ms>.jsonl` として保存されることを確認
  - `talk_<ms>.jsonl` → `queue/talk_<ms>.jsonl` として保存されることを確認
- direct モード（`vox-actor` 未インストール環境で意図的に失敗させる）:
  - `play-script-errors.log` にタイムスタンプ付きで追記されることを確認
  - 一時ファイルが `rm -f` で削除されることを確認
- `shellcheck plugins/vox-actor-plugin/scripts/play-script.sh`: 指摘なし

## 受け入れ条件チェック

- [x] `/vox-actor-plugin:talk <内容>` で 2〜4人のキャラが会話形式で読み上げ（talk/SKILL.md に実行フロー／制約を記載）
- [x] メモリ未設定時は zundamon と metan の2人で会話
- [x] `speak` スキルは従来通り動作（共用スクリプトへの差し替えのみで挙動差分なし）
- [x] file モードで `queue/talk_<ms>.jsonl` / `queue/speak_<ms>.jsonl` が生成される
- [x] direct モードで `vox-actor act` 失敗時に `play-script-errors.log` に追記（末尾 200 行でローテーション）
- [x] `shellcheck plugins/vox-actor-plugin/scripts/play-script.sh` で指摘なし
- [x] README の概要／スキル一覧／詳細節に talk スキルの記載が揃っている

## Test plan

- [x] shellcheck 実行
- [x] file モード手動検証（speak / talk の basename 維持）
- [x] direct モード手動検証（エラーログ出力・一時ファイル削除）
- [ ] CI 通過確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)