### PR TITLE
feat: run-streamターゲット追加とdevcontainer 8080ポート転送 #232

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -7,11 +7,14 @@ services:
       - .env
     volumes:
       # Forwards the local Docker socket to the container.
-      - /var/run/docker.sock:/var/run/docker-host.sock 
+      - /var/run/docker.sock:/var/run/docker-host.sock
       # Update this to wherever you want VS Code to mount the folder of your project
       - ../..:/workspaces:cached
 
-    command: sleep infinity 
+    ports:
+      - "8080:8080"
+
+    command: sleep infinity
 
   voicevox:
     image: voicevox/voicevox_engine:cpu-latest

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ depcheck:
 test-e2e:
 	go test -tags=e2e ./test/e2e/...
 
+run-stream:
+	go run . watch --stream --stream-addr 0.0.0.0:8080 .vox-actor/queue
+
 all: build
 
-.PHONY: all setup build clean test test-e2e fmt lint depcheck
+.PHONY: all setup build clean test test-e2e fmt lint depcheck run-stream


### PR DESCRIPTION
## Summary

- `Makefile` に `run-stream` ターゲットを追加し、`go run . watch --stream --stream-addr 0.0.0.0:8080 .vox-actor/queue` を実行できるようにしました
- `.PHONY` リストに `run-stream` を追加しました
- `.devcontainer/compose.yml` の `dev` サービスに `8080:8080` ポートマッピングを追加し、ホスト側ブラウザから `http://localhost:8080/` でストリーム画面にアクセスできるようにしました

## Test plan

- [x] `make -n run-stream` がIssueに記載のコマンドを出力すること
- [x] `make -n all` など既存ターゲットの挙動が変わっていないこと
- [ ] devcontainerを再起動し、`make run-stream` 実行後にホスト側ブラウザから `http://localhost:8080/` にアクセスできること（devcontainer再起動を伴うため手動確認）

Closes #232

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
