### PR TITLE
fix: run-streamでvoicevoxエンジンのURLを指定

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test-e2e:
 	go test -tags=e2e ./test/e2e/...
 
 run-stream:
-	go run . watch --stream --stream-addr 0.0.0.0:8080 .vox-actor/queue
+	go run . watch --engine-url http://voicevox:50021 --stream --stream-addr 0.0.0.0:8080 .vox-actor/queue
 
 all: build
 


### PR DESCRIPTION
## Summary

- devcontainer環境で `make run-stream` を実行すると VOICEVOX エンジンを見つけられず起動に失敗するバグを修正
- `run-stream` ターゲットに `--engine-url http://voicevox:50021` オプションを追加し、devcontainer内のvoicevoxサービスを参照するようにした

## 背景

- #232 で追加された `run-stream` ターゲットは、デフォルトのengine URL（`http://localhost:50021`）を使用していた
- devcontainer環境では VOICEVOX は別サービスとして `voicevox` ホスト名で起動しているため、localhostでは接続できなかった

🤖 Generated with [Claude Code](https://claude.ai/code)
