### PR TITLE
feat: ストリーム画面のレスポンシブ対応 #235

### DIFF
--- a/internal/infra/stream_assets/app.css
+++ b/internal/infra/stream_assets/app.css
@@ -17,6 +17,7 @@ h1 { margin-top: 0; font-size: 1.4rem; }
 .volume-row {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 1rem;
   margin: 1rem 0 0.25rem;
 }
@@ -118,3 +119,30 @@ h1 { margin-top: 0; font-size: 1.4rem; }
 body.hide-speaker-name .timeline-speaker-name { display: none; }
 body.hide-style-name .timeline-style-name { display: none; }
 body.hide-timestamp .timeline-timestamp { display: none; }
+
+@media (max-width: 768px) {
+  .container {
+    margin: 1rem auto;
+    padding: 1rem;
+  }
+  .timeline-controls {
+    gap: 0.35rem 0.6rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    margin: 0.5rem auto;
+    padding: 0.75rem;
+    border-radius: 6px;
+  }
+  h1 {
+    font-size: 1.1rem;
+  }
+  .timeline {
+    max-height: 65vh;
+  }
+  .timeline-item {
+    padding: 0.35rem 0.5rem;
+  }
+}

--- a/internal/infra/stream_assets/index.html
+++ b/internal/infra/stream_assets/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>vox-actor stream</title>
 <link rel="stylesheet" href="/app.css">
 </head>


### PR DESCRIPTION
## Summary

Issue #235 の対応として、`vox-actor watch --stream` のストリーム配信画面をスマホ・タブレット・PCのいずれでも自然に閲覧できるようレスポンシブ対応しました。

## 変更内容

- `internal/infra/stream_assets/index.html`
  - `<meta name="viewport" content="width=device-width, initial-scale=1">` を追加
- `internal/infra/stream_assets/app.css`
  - `.volume-row` に `flex-wrap: wrap` を追加（狭い画面で音量スライダーと消音チェックボックスが折り返せるように）
  - `@media (max-width: 768px)`: `.container` の padding/margin を縮小、`.timeline-controls` の gap を詰める
  - `@media (max-width: 480px)`: `.container` をさらに圧縮、`h1` を `1.1rem` に、`.timeline` を `max-height: 65vh` に、`.timeline-item` の padding を調整

JavaScript・Go側の変更はありません。

## 受け入れ条件

- [x] `index.html` に viewport メタタグが追加されている
- [x] `app.css` にスマホ向けとタブレット向けのメディアクエリが追加されている
- [x] スマホ幅（375px程度）で表示したとき、横スクロールが発生しない想定（`box-sizing: border-box` + `margin: 0`）
- [x] スマホ幅で音量スライダー・消音チェックボックス・履歴上限セレクト・3つの表示トグルが重ならず操作できる想定（`flex-wrap: wrap`）
- [x] タイムラインの各発話項目がスマホ幅でも読みやすく折り返される（既存の `flex-wrap: wrap` / `word-break: break-word` を維持）
- [x] タブレット幅・PC幅のリグレッションなし（`max-width` メディアクエリのみ使用）
- [x] 再生中アイテムのハイライト（`.playing`）のスタイルは変更なし

## Test plan

- [ ] PC幅（1200px以上）で既存レイアウトが維持されていることを確認
- [ ] タブレット幅（768px程度）で表示が崩れないことを確認
- [ ] スマホ幅（375px程度）で横スクロールが発生しないこと、音量/トグル類が操作できること、タイムライン項目が読みやすく折り返されることを確認
- [ ] 再生中アイテムのハイライトが各画面幅で正しく機能することを確認

Closes #235

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
