### PR TITLE
feat: watchに--git-common-queueとconfigサブコマンドを追加 #239

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/canpok1/vox-actor/internal/infra"
+	"github.com/spf13/cobra"
+)
+
+// supportedConfigKeys は `vox-actor config <key>` で解決可能なキーをアルファベット順で保持する。
+var supportedConfigKeys = []string{
+	"path.queue",
+}
+
+func makeConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config <key>",
+		Short: "設定値（パス等）を取得する",
+		Long:  "指定したキーの設定値を取得して標準出力に返す。現時点ではパス解決のみ対応する読み取り専用サブコマンド。",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return fmt.Errorf("%w: %s", ErrUsage, err)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConfig(cmd, args[0])
+		},
+	}
+	return cmd
+}
+
+func runConfig(cmd *cobra.Command, key string) error {
+	switch key {
+	case "path.queue":
+		path, err := infra.ResolveQueuePath()
+		if err != nil {
+			return formatConfigError(err)
+		}
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), path); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: unknown key: %s\nsupported keys:\n%s", ErrUsage, key, formatSupportedKeys())
+	}
+}
+
+// formatConfigError は infra パッケージのセンチネルエラーを日本語メッセージ付きのエラーに変換する。
+func formatConfigError(err error) error {
+	switch {
+	case errors.Is(err, infra.ErrGitNotFound):
+		return fmt.Errorf("gitコマンドが見つかりません")
+	case errors.Is(err, infra.ErrNotInGitRepo):
+		return fmt.Errorf("カレントディレクトリはgitリポジトリではありません")
+	default:
+		return err
+	}
+}
+
+func formatSupportedKeys() string {
+	var b strings.Builder
+	for _, k := range supportedConfigKeys {
+		b.WriteString("  ")
+		b.WriteString(k)
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -37,7 +36,7 @@ func runConfig(cmd *cobra.Command, key string) error {
 	case "path.queue":
 		path, err := infra.ResolveQueuePath()
 		if err != nil {
-			return formatConfigError(err)
+			return err
 		}
 		if _, err := fmt.Fprintln(cmd.OutOrStdout(), path); err != nil {
 			return err
@@ -45,18 +44,6 @@ func runConfig(cmd *cobra.Command, key string) error {
 		return nil
 	default:
 		return fmt.Errorf("%w: unknown key: %s\nsupported keys:\n%s", ErrUsage, key, formatSupportedKeys())
-	}
-}
-
-// formatConfigError は infra パッケージのセンチネルエラーを日本語メッセージ付きのエラーに変換する。
-func formatConfigError(err error) error {
-	switch {
-	case errors.Is(err, infra.ErrGitNotFound):
-		return fmt.Errorf("gitコマンドが見つかりません")
-	case errors.Is(err, infra.ErrNotInGitRepo):
-		return fmt.Errorf("カレントディレクトリはgitリポジトリではありません")
-	default:
-		return err
 	}
 }
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withTempGitRepo はテスト実行中だけカレントディレクトリを一時的なgitリポジトリに切り替える。
+func withTempGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	// 一時ディレクトリ直下に .git を作って git-common-dir が返せるようにする。
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("failed to create .git: %v", err)
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("git init failed, skipping: %v\n%s", err, out)
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(orig)
+	})
+	return dir
+}
+
+func TestConfigCmd_RegisteredAsSubcommand(t *testing.T) {
+	rootCmd := makeRootCmd()
+
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "config" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'config' subcommand to be registered")
+	}
+}
+
+func TestConfigCmd_PathQueue_InsideGitRepo_PrintsAbsolutePath(t *testing.T) {
+	repoRoot := withTempGitRepo(t)
+
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.queue"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v, stderr: %s", err, errBuf.String())
+	}
+
+	got := strings.TrimRight(outBuf.String(), "\n")
+	want := filepath.Join(repoRoot, ".vox-actor", "queue")
+	// macOS の /var → /private/var シンボリックリンクを考慮して EvalSymlinks で比較する。
+	wantEval, _ := filepath.EvalSymlinks(filepath.Dir(want))
+	gotEval, _ := filepath.EvalSymlinks(filepath.Dir(got))
+	if gotEval != wantEval || filepath.Base(got) != filepath.Base(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestConfigCmd_PathQueue_OutsideGitRepo_ReturnsErrorWithJapaneseMessage(t *testing.T) {
+	// TempDir はgitリポジトリではない
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.queue"})
+
+	err = rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when outside git repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "gitリポジトリではありません") {
+		t.Errorf("expected error to contain 'gitリポジトリではありません', got: %v", err)
+	}
+}
+
+func TestConfigCmd_UnknownKey_ReturnsErrUsageAndListsSupportedKeys(t *testing.T) {
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.unknown"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown key, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unknown key: path.unknown") {
+		t.Errorf("expected error message to contain 'unknown key: path.unknown', got: %v", err)
+	}
+	if !strings.Contains(msg, "path.queue") {
+		t.Errorf("expected error message to list supported key 'path.queue', got: %v", err)
+	}
+}
+
+func TestConfigCmd_NoArgs_ReturnsError(t *testing.T) {
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no key is given, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	cmd.AddCommand(makeActCmd(actDeps))
 	cmd.AddCommand(makeWatchCmd(watchDeps))
 	cmd.AddCommand(makeSayCmd(sayDeps))
+	cmd.AddCommand(makeConfigCmd())
 
 	return cmd
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/canpok1/vox-actor/internal/app"
 	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +28,9 @@ type WatchDeps struct {
 	// マップが空でも factory はエラーにせず player を返してよい（フォールバック表示が使われる）。
 	// client はブラウザ側の /test-clip エンドポイントから音声合成を呼ぶために渡す。
 	StreamPlayerFactory func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, client app.VoicevoxClient) (app.StreamPlayer, error)
+	// QueuePathResolver は --git-common-queue 指定時に監視対象パスを解決する関数。
+	// nil の場合は infra.ResolveQueuePath がデフォルトで使われる。
+	QueuePathResolver func() (string, error)
 }
 
 func makeWatchCmd(deps *WatchDeps) *cobra.Command {
@@ -33,12 +38,8 @@ func makeWatchCmd(deps *WatchDeps) *cobra.Command {
 		Use:   "watch <dir1> [<dir2> ...]",
 		Short: "複数ディレクトリを監視してテキストファイルを読み上げる",
 		Long:  "1つ以上のディレクトリを並列監視し、検知したファイルを順次読み上げる。",
-		Args: func(cmd *cobra.Command, args []string) error {
-			if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
-				return fmt.Errorf("%w: %s", ErrUsage, err)
-			}
-			return nil
-		},
+		// 位置引数と --git-common-queue の排他・片方必須は RunE 側で検証する。
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runWatch(cmd, args, deps)
 		},
@@ -48,11 +49,55 @@ func makeWatchCmd(deps *WatchDeps) *cobra.Command {
 	cmd.Flags().Bool("delete", false, "処理済みファイルを削除する（未指定時は各ディレクトリの done/ に移動）")
 	cmd.Flags().Bool("stream", false, "HTTPサーバーを起動し、SSE経由でブラウザに音声配信する")
 	cmd.Flags().String("stream-addr", "127.0.0.1:8080", "ストリーム配信用のバインドアドレス")
+	cmd.Flags().Bool("git-common-queue", false, "gitリポジトリ直下の .vox-actor/queue を監視対象に自動選択する（位置引数と併用不可、起動時に自動作成）")
 
 	return cmd
 }
 
+// resolveWatchPaths は watch の監視対象パスを確定する。
+// --git-common-queue が指定されていればキュー解決・自動作成を行い、
+// それ以外は与えられた位置引数をそのまま返す。
+func resolveWatchPaths(args []string, useGitCommonQueue bool, deps *WatchDeps) ([]string, error) {
+	switch {
+	case useGitCommonQueue && len(args) > 0:
+		return nil, fmt.Errorf("%w: --git-common-queue と位置引数は併用できません", ErrUsage)
+	case !useGitCommonQueue && len(args) == 0:
+		return nil, fmt.Errorf("%w: requires at least 1 arg(s), only received 0", ErrUsage)
+	}
+
+	if !useGitCommonQueue {
+		return args, nil
+	}
+
+	resolver := infra.ResolveQueuePath
+	if deps != nil && deps.QueuePathResolver != nil {
+		resolver = deps.QueuePathResolver
+	}
+	queuePath, err := resolver()
+	if err != nil {
+		switch {
+		case errors.Is(err, infra.ErrGitNotFound):
+			return nil, fmt.Errorf("gitコマンドが見つかりません")
+		case errors.Is(err, infra.ErrNotInGitRepo):
+			return nil, fmt.Errorf("カレントディレクトリはgitリポジトリではありません")
+		default:
+			return nil, err
+		}
+	}
+	if err := os.MkdirAll(queuePath, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create queue directory %s: %w", queuePath, err)
+	}
+	return []string{queuePath}, nil
+}
+
 func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
+	useGitCommonQueue, _ := cmd.Flags().GetBool("git-common-queue")
+
+	args, err := resolveWatchPaths(args, useGitCommonQueue, deps)
+	if err != nil {
+		return err
+	}
+
 	for _, path := range args {
 		info, err := os.Stat(path)
 		if err != nil {

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -75,14 +74,7 @@ func resolveWatchPaths(args []string, useGitCommonQueue bool, deps *WatchDeps) (
 	}
 	queuePath, err := resolver()
 	if err != nil {
-		switch {
-		case errors.Is(err, infra.ErrGitNotFound):
-			return nil, fmt.Errorf("gitコマンドが見つかりません")
-		case errors.Is(err, infra.ErrNotInGitRepo):
-			return nil, fmt.Errorf("カレントディレクトリはgitリポジトリではありません")
-		default:
-			return nil, err
-		}
+		return nil, err
 	}
 	if err := os.MkdirAll(queuePath, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create queue directory %s: %w", queuePath, err)

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/canpok1/vox-actor/internal/app"
 	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
 
@@ -370,5 +371,152 @@ func TestWatchCmd_EnvVarVOXSpeaker(t *testing.T) {
 	speaker, _ := watchCmd.Flags().GetInt("speaker")
 	if speaker != 42 {
 		t.Errorf("expected speaker to be 42, got: %d", speaker)
+	}
+}
+
+// --- #239 --git-common-queue オプション ---
+
+// makeGitCommonQueueWatchDeps は --git-common-queue のテストで共通利用する WatchDeps を組み立てる。
+// resolver は呼び出された回数と返却パスを captured を通じて観測できる。
+func makeGitCommonQueueWatchDeps(resolver func() (string, error)) *Deps {
+	return &Deps{
+		Watch: &WatchDeps{
+			Reader:            stubScriptReader{},
+			ClientFactory:     func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+			Player:            stubAudioPlayer{},
+			Mover:             stubFileMover{},
+			DirWatcherFactory: func() app.DirWatcher { return stubDirWatcher{} },
+			QueuePathResolver: resolver,
+		},
+	}
+}
+
+func TestWatchCmd_GitCommonQueue_ResolvesAndCreatesQueueDir(t *testing.T) {
+	baseDir := t.TempDir()
+	queueDir := baseDir + "/.vox-actor/queue"
+
+	resolverCalled := 0
+	deps := makeGitCommonQueueWatchDeps(func() (string, error) {
+		resolverCalled++
+		return queueDir, nil
+	})
+
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rootCmd.SetContext(ctx)
+	rootCmd.SetArgs([]string{"watch", "--git-common-queue"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolverCalled != 1 {
+		t.Errorf("expected QueuePathResolver to be called once, got %d", resolverCalled)
+	}
+
+	info, err := os.Stat(queueDir)
+	if err != nil {
+		t.Fatalf("expected queue directory to be auto-created at %s: %v", queueDir, err)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected %s to be a directory", queueDir)
+	}
+}
+
+func TestWatchCmd_GitCommonQueue_WithPositionalArg_ReturnsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	deps := makeGitCommonQueueWatchDeps(func() (string, error) {
+		t.Error("resolver should not be called when usage error occurs")
+		return "", nil
+	})
+
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"watch", "--git-common-queue", dir})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --git-common-queue is combined with a positional arg")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--git-common-queue") {
+		t.Errorf("expected error to mention --git-common-queue, got: %v", err)
+	}
+}
+
+func TestWatchCmd_NoArgsAndNoGitCommonQueue_ReturnsUsageError(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"watch"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when neither args nor --git-common-queue is given")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func TestWatchCmd_GitCommonQueue_ResolverReturnsNotInRepo_ReturnsError(t *testing.T) {
+	deps := makeGitCommonQueueWatchDeps(func() (string, error) {
+		return "", infra.ErrNotInGitRepo
+	})
+
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"watch", "--git-common-queue"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when resolver fails with not-in-git-repo")
+	}
+	if !strings.Contains(err.Error(), "gitリポジトリではありません") {
+		t.Errorf("expected error message to contain 'gitリポジトリではありません', got: %v", err)
+	}
+}
+
+func TestWatchCmd_GitCommonQueue_ResolverReturnsGitNotFound_ReturnsError(t *testing.T) {
+	deps := makeGitCommonQueueWatchDeps(func() (string, error) {
+		return "", infra.ErrGitNotFound
+	})
+
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"watch", "--git-common-queue"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when resolver fails with git-not-found")
+	}
+	if !strings.Contains(err.Error(), "gitコマンドが見つかりません") {
+		t.Errorf("expected error message to contain 'gitコマンドが見つかりません', got: %v", err)
+	}
+}
+
+func TestWatchCmd_HelpContainsGitCommonQueueFlag(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"watch", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error for --help, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "--git-common-queue") {
+		t.Errorf("expected help output to contain '--git-common-queue'")
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -109,6 +109,7 @@ vox-actor act <path>
 
 ```
 vox-actor watch <dir1> [<dir2> ...]
+vox-actor watch --git-common-queue
 ```
 
 1つ以上のディレクトリを並列監視し、配置されたファイルを検知順に逐次再生する。
@@ -123,8 +124,74 @@ vox-actor watch <dir1> [<dir2> ...]
 | `--delete` | — | `false` | 処理済みファイルを削除（未指定時は各ディレクトリの `done/` に移動） |
 | `--stream` | — | `false` | HTTPサーバーを起動し、SSE経由でブラウザに音声を配信（[詳細](#ストリーム配信モード)） |
 | `--stream-addr` | — | `127.0.0.1:8080` | ストリーム配信用のバインドアドレス |
+| `--git-common-queue` | — | `false` | gitリポジトリ直下の `.vox-actor/queue` を監視対象に自動選択（[詳細](#git-common-queueオプション)） |
 | `--verbose` | — | `false` | 詳細ログを出力 |
 | `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#dry-runモード)） |
+
+### `--git-common-queue`オプション
+
+`vox-actor watch --git-common-queue` を指定すると、`vox-actor config path.queue` と同じロジックで解決される「gitリポジトリ直下の `.vox-actor/queue`」を監視対象として自動選択します。
+
+- 位置引数（ディレクトリパス）との**併用はエラー**になります。
+- カレントディレクトリがgitリポジトリ外、または `git` コマンドがPATH上に無い場合は起動時にエラー終了します。
+- `.vox-actor/queue` が存在しない場合は起動時に自動作成されます（`os.MkdirAll(..., 0o755)`）。
+- worktree 上で実行した場合でも、`git rev-parse --git-common-dir` で本体リポジトリの `.git` を参照するため、**本体リポジトリ直下**の `.vox-actor/queue` が選ばれます。
+- `--delete` / `--stream` / `--stream-addr` / `--dry-run` などの既存オプションとは自由に併用できます。
+
+```bash
+# gitリポジトリ直下の .vox-actor/queue を監視（done/ 移動モード）
+vox-actor watch --git-common-queue
+
+# 削除モードで監視
+vox-actor watch --git-common-queue --delete
+
+# ストリーム配信モード
+vox-actor watch --git-common-queue --stream
+```
+
+## `config` サブコマンド
+
+```
+vox-actor config <key>
+```
+
+指定したキーの設定値を取得して標準出力に返す、読み取り専用のサブコマンド。`git config` 風のインターフェースで、初期リリースではパス解決のみをサポートする。
+
+**サポートキー:**
+
+| キー | 返却値 |
+|---|---|
+| `path.queue` | gitリポジトリ直下の `.vox-actor/queue` の絶対パス |
+
+**出力:**
+
+- 成功時: 標準出力に絶対パスを1行出力（末尾LFあり）
+- 失敗時: 標準エラーに日本語メッセージを出力
+
+**エラー条件:**
+
+| 状況 | 終了コード | エラー出力 |
+|---|---|---|
+| 成功 | 0 | — |
+| 未知のキー | 2 (`ErrUsage`) | `unknown key: <key>` とサポートキー一覧 |
+| `git` コマンドがPATH上に無い | 1 | `Error: gitコマンドが見つかりません` |
+| カレントディレクトリがgitリポジトリ外 | 1 | `Error: カレントディレクトリはgitリポジトリではありません` |
+
+**使用例:**
+
+```bash
+# gitリポジトリ内で実行
+$ cd /path/to/repo && vox-actor config path.queue
+/path/to/repo/.vox-actor/queue
+
+# 未知のキー
+$ vox-actor config path.unknown
+Error: unknown key: path.unknown
+supported keys:
+  path.queue
+```
+
+`path.queue` の解決は `git rev-parse --path-format=absolute --git-common-dir` の結果の親ディレクトリに `.vox-actor/queue` を結合したパスを返します。worktree 上で実行しても本体リポジトリ直下のパスが返るため、外部スクリプトから共通のキューディレクトリを参照できます。`config` サブコマンド自体は**パスの返却のみ**を行い、ディレクトリ作成は行いません。
 
 ## ストリーム配信モード
 

--- a/internal/infra/git_workspace.go
+++ b/internal/infra/git_workspace.go
@@ -1,0 +1,44 @@
+package infra
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ErrGitNotFound は git コマンドが PATH 上に見つからない場合のエラー。
+var ErrGitNotFound = errors.New("gitコマンドが見つかりません")
+
+// ErrNotInGitRepo はカレントディレクトリが git リポジトリ外であることを示すエラー。
+var ErrNotInGitRepo = errors.New("カレントディレクトリはgitリポジトリではありません")
+
+// gitRunner はテスト差し替え可能な git コマンド実行関数。
+var gitRunner = exec.Command
+
+// ResolveQueuePath は `git rev-parse --path-format=absolute --git-common-dir` の
+// 結果の親ディレクトリに `.vox-actor/queue` を結合したパスを返す。
+//
+// worktree 上で実行しても `--git-common-dir` により本体リポジトリ直下の
+// `.vox-actor/queue` が選ばれる。ディレクトリの作成は行わない。
+func ResolveQueuePath() (string, error) {
+	cmd := gitRunner("git", "rev-parse", "--path-format=absolute", "--git-common-dir")
+	out, err := cmd.Output()
+	if err != nil {
+		// ExitError（非0終了）は git 外で rev-parse を呼んだ想定に寄せて
+		// ErrNotInGitRepo に分類する。それ以外（バイナリ不在など）は ErrGitNotFound。
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", ErrNotInGitRepo
+		}
+		return "", ErrGitNotFound
+	}
+
+	gitCommonDir := strings.TrimSpace(string(out))
+	if gitCommonDir == "" {
+		return "", ErrNotInGitRepo
+	}
+
+	repoRoot := filepath.Dir(gitCommonDir)
+	return filepath.Join(repoRoot, ".vox-actor", "queue"), nil
+}

--- a/internal/infra/git_workspace_test.go
+++ b/internal/infra/git_workspace_test.go
@@ -1,0 +1,96 @@
+package infra
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withGitRunner はテスト中の gitRunner を一時的に差し替えるヘルパー。
+func withGitRunner(t *testing.T, runner func(name string, args ...string) *exec.Cmd) {
+	t.Helper()
+	orig := gitRunner
+	gitRunner = runner
+	t.Cleanup(func() {
+		gitRunner = orig
+	})
+}
+
+func TestResolveQueuePath_ReturnsGitCommonDirParentJoinedWithVoxActorQueue(t *testing.T) {
+	repoRoot := t.TempDir()
+	gitCommonDir := filepath.Join(repoRoot, ".git")
+
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		// echo コマンドで git-common-dir の出力を模倣する。
+		return exec.Command("echo", gitCommonDir)
+	})
+
+	got, err := ResolveQueuePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(repoRoot, ".vox-actor", "queue")
+	if got != want {
+		t.Errorf("ResolveQueuePath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveQueuePath_ReturnsErrNotInGitRepo_WhenGitCommonDirEmpty(t *testing.T) {
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		// 空文字列を標準出力に出すだけのコマンド（=gitリポジトリ外の想定）
+		return exec.Command("true")
+	})
+
+	_, err := ResolveQueuePath()
+	if !errors.Is(err, ErrNotInGitRepo) {
+		t.Errorf("expected ErrNotInGitRepo, got: %v", err)
+	}
+}
+
+func TestResolveQueuePath_ReturnsErrNotInGitRepo_WhenGitRunnerFailsWithNonZeroExit(t *testing.T) {
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		// 非0終了（gitリポジトリ外で git rev-parse した時の挙動を模倣）
+		return exec.Command("false")
+	})
+
+	_, err := ResolveQueuePath()
+	if !errors.Is(err, ErrNotInGitRepo) {
+		t.Errorf("expected ErrNotInGitRepo, got: %v", err)
+	}
+}
+
+func TestResolveQueuePath_ReturnsErrGitNotFound_WhenRunnerReportsCommandMissing(t *testing.T) {
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		// PATHに存在しないバイナリを指定することで exec 失敗を再現する。
+		return exec.Command("/nonexistent/definitely-no-such-binary-xyz")
+	})
+
+	_, err := ResolveQueuePath()
+	if !errors.Is(err, ErrGitNotFound) {
+		t.Errorf("expected ErrGitNotFound, got: %v", err)
+	}
+}
+
+func TestResolveQueuePath_TrimsTrailingWhitespaceFromOutput(t *testing.T) {
+	repoRoot := t.TempDir()
+	gitCommonDir := filepath.Join(repoRoot, ".git")
+
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		// printf に末尾改行と空白が含まれる出力を渡す（trim 確認）
+		return exec.Command("printf", "%s\n", gitCommonDir)
+	})
+
+	got, err := ResolveQueuePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(repoRoot, ".vox-actor", "queue")
+	if got != want {
+		t.Errorf("ResolveQueuePath() = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("ResolveQueuePath() should not contain newline: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `vox-actor config <key>` 読み取り専用サブコマンドを追加し、`path.queue` キーで**gitリポジトリ直下の `.vox-actor/queue`** の絶対パスを取得できるようにした
- `vox-actor watch` に `--git-common-queue` フラグを追加し、同じロジックで解決されるキューを監視対象に自動選択・自動作成できるようにした（位置引数との併用不可）
- パス解決ロジックを `internal/infra.ResolveQueuePath` に集約し、今後のCLI内利用（および将来のシェルスクリプト委譲）から再利用できるようにした
- `docs/reference/cli.md` に `config` 節と `--git-common-queue` の説明を追記した

## 実装メモ

- `internal/infra/git_workspace.go`: `git rev-parse --path-format=absolute --git-common-dir` を介してキューパスを解決するヘルパー。`ErrGitNotFound` / `ErrNotInGitRepo` をセンチネルエラーとして公開。テストのために `gitRunner` を package var で差し替え可能にした
- `cmd/config.go`: 初期サポートキーは `path.queue` のみ、`supportedConfigKeys` にハードコードしアルファベット順で出力
- `cmd/watch.go`:
  - `Args` を `cobra.ArbitraryArgs` に緩め、位置引数と `--git-common-queue` の排他・片方必須検証を RunE 側で行う
  - DI 用に `WatchDeps.QueuePathResolver` を追加（nil の場合 `infra.ResolveQueuePath` がデフォルトで使われる）
  - `.vox-actor/queue` 未作成時は起動時に `os.MkdirAll(..., 0o755)` で自動作成
  - `infra.Err*` のメッセージは既に日本語なので cmd 層で再変換せずそのまま返す（重複排除、simplify で確認済み）

## 動作確認

- [x] `vox-actor config path.queue` が git リポジトリ内で絶対パスを標準出力に返す
- [x] worktree 上で実行すると本体リポジトリ直下のパスが返る
- [x] `vox-actor config path.queue` が git 管理外で `Error: カレントディレクトリはgitリポジトリではありません` を出して exit=1
- [x] `vox-actor config path.unknown` が ErrUsage でサポートキー一覧を出力して exit=2
- [x] `vox-actor config` が引数なしで ErrUsage で exit=2
- [x] `vox-actor watch --git-common-queue` が `.vox-actor/queue` を自動作成して監視する
- [x] `vox-actor watch --git-common-queue /some/dir` が ErrUsage で exit=2
- [x] `vox-actor watch --git-common-queue` を git 管理外で実行するとエラー終了
- [x] `go test ./...` / `golangci-lint run ./...` ともにグリーン

## スコープ外（別Issue対応予定）

- プラグインのシェルスクリプト（`monologue.sh` / `play-script.sh`）から `vox-actor config path.queue` 呼び出しへの切替
- `path.tmp` / `path.workspace` などの追加キー
- `act` サブコマンドへの同等フラグ導入

Closes #239

🤖 Generated with [Claude Code](https://claude.ai/code)
