### PR TITLE
feat: audio-checkサブコマンドを追加 #241

### DIFF
--- a/cmd/audio_check.go
+++ b/cmd/audio_check.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// ErrAudioCheckFailed はaudio-checkがデバイス初期化に失敗した場合のセンチネルエラー。
+// main側で終了コード1にマップされる（usageエラーではないため2にはならない）。
+var ErrAudioCheckFailed = errors.New("audio device check failed")
+
+// AudioCheckDeps はaudio-checkコマンドの依存を保持する。
+type AudioCheckDeps struct {
+	// CheckFunc はデバイス可用性を判定する関数。
+	// 成功時はバックエンド名を返し、失敗時はエラーを返す。
+	CheckFunc func() (string, error)
+}
+
+func makeAudioCheckCmd(deps *AudioCheckDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "audio-check",
+		Short: "音声出力デバイスの可用性を確認する",
+		Long: "音声出力デバイスを open → 即 close のみ行い、可用性を終了コードで返す診断サブコマンド。\n" +
+			"通常実行時は標準出力・標準エラー出力ともに空で、--verbose 指定時のみ stderr に診断メッセージを出す。",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return fmt.Errorf("%w: %s", ErrUsage, err)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAudioCheck(cmd, deps)
+		},
+	}
+	cmd.Flags().BoolP("verbose", "v", false, "診断メッセージを標準エラー出力に出力する")
+	// 失敗時も stderr を汚さないため、cobraの自動エラー表示を抑制する。
+	cmd.SilenceErrors = true
+	return cmd
+}
+
+func runAudioCheck(cmd *cobra.Command, deps *AudioCheckDeps) error {
+	if deps == nil || deps.CheckFunc == nil {
+		return fmt.Errorf("audio-check command dependencies are not initialized")
+	}
+
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	backend, err := deps.CheckFunc()
+	if err != nil {
+		if verbose {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+		}
+		return ErrAudioCheckFailed
+	}
+
+	if verbose {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "audio backend: %s\n", backend)
+	}
+	return nil
+}

--- a/cmd/audio_check_test.go
+++ b/cmd/audio_check_test.go
@@ -1,0 +1,225 @@
+package cmd
+
+// audio-check コマンド テストリスト
+// DONE: audio-checkサブコマンドがrootに登録されている
+// DONE: 正常系 / non-verbose: 終了コード0、stdout/stderrともに空
+// DONE: 正常系 / verbose: stderrに "audio backend: <name>" が出力される
+// DONE: 異常系 / non-verbose: エラーを返すがstdout/stderrともに空
+// DONE: 異常系 / verbose: stderrに "Error: <reason>" が出力される
+// DONE: 未知のフラグはエラーを返す
+// DONE: 引数を受け付けない（位置引数がある場合エラー）
+// DONE: --help でコマンド説明が出力される
+// DONE: 依存が未設定だとエラーを返す（セーフティネット）
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func newAudioCheckDepsSuccess(backend string) *AudioCheckDeps {
+	return &AudioCheckDeps{
+		CheckFunc: func() (string, error) {
+			return backend, nil
+		},
+	}
+}
+
+func newAudioCheckDepsFailure(reason string) *AudioCheckDeps {
+	return &AudioCheckDeps{
+		CheckFunc: func() (string, error) {
+			return "", errors.New(reason)
+		},
+	}
+}
+
+func TestAudioCheckCmd_RegisteredAsSubcommand(t *testing.T) {
+	rootCmd := makeRootCmd()
+
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "audio-check" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'audio-check' subcommand to be registered")
+	}
+}
+
+func TestAudioCheckCmd_Success_NoVerbose_SilentOutput(t *testing.T) {
+	deps := &Deps{AudioCheck: newAudioCheckDepsSuccess("coreaudio")}
+	rootCmd := makeRootCmd(deps)
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"audio-check"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%q)", err, errBuf.String())
+	}
+	if got := outBuf.String(); got != "" {
+		t.Errorf("expected empty stdout, got: %q", got)
+	}
+	if got := errBuf.String(); got != "" {
+		t.Errorf("expected empty stderr, got: %q", got)
+	}
+}
+
+func TestAudioCheckCmd_Success_Verbose_StderrHasBackend(t *testing.T) {
+	deps := &Deps{AudioCheck: newAudioCheckDepsSuccess("coreaudio")}
+	rootCmd := makeRootCmd(deps)
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"audio-check", "--verbose"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%q)", err, errBuf.String())
+	}
+	if got := outBuf.String(); got != "" {
+		t.Errorf("expected empty stdout, got: %q", got)
+	}
+	want := "audio backend: coreaudio"
+	if !strings.Contains(errBuf.String(), want) {
+		t.Errorf("expected stderr to contain %q, got: %q", want, errBuf.String())
+	}
+}
+
+func TestAudioCheckCmd_Success_VerboseShortFlag(t *testing.T) {
+	deps := &Deps{AudioCheck: newAudioCheckDepsSuccess("pulseaudio")}
+	rootCmd := makeRootCmd(deps)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"audio-check", "-v"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "audio backend: pulseaudio"
+	if !strings.Contains(errBuf.String(), want) {
+		t.Errorf("expected stderr to contain %q, got: %q", want, errBuf.String())
+	}
+}
+
+func TestAudioCheckCmd_Failure_NoVerbose_SilentOutput(t *testing.T) {
+	deps := &Deps{AudioCheck: newAudioCheckDepsFailure("no output device available")}
+	rootCmd := makeRootCmd(deps)
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"audio-check"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when audio check fails, got nil")
+	}
+	if got := outBuf.String(); got != "" {
+		t.Errorf("expected empty stdout on failure, got: %q", got)
+	}
+	if got := errBuf.String(); got != "" {
+		t.Errorf("expected empty stderr on failure (non-verbose), got: %q", got)
+	}
+}
+
+func TestAudioCheckCmd_Failure_Verbose_StderrHasError(t *testing.T) {
+	reason := "no output device available"
+	deps := &Deps{AudioCheck: newAudioCheckDepsFailure(reason)}
+	rootCmd := makeRootCmd(deps)
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"audio-check", "--verbose"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when audio check fails, got nil")
+	}
+	if got := outBuf.String(); got != "" {
+		t.Errorf("expected empty stdout on failure, got: %q", got)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(errBuf.String()), "Error:") {
+		t.Errorf("expected stderr to start with 'Error:', got: %q", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), reason) {
+		t.Errorf("expected stderr to contain reason %q, got: %q", reason, errBuf.String())
+	}
+}
+
+func TestAudioCheckCmd_Failure_NotErrUsage(t *testing.T) {
+	deps := &Deps{AudioCheck: newAudioCheckDepsFailure("device busy")}
+	rootCmd := makeRootCmd(deps)
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"audio-check"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrUsage) {
+		t.Errorf("audio check failure should not be ErrUsage (runtime failure, not argument error)")
+	}
+}
+
+func TestAudioCheckCmd_UnknownFlag(t *testing.T) {
+	deps := &Deps{AudioCheck: newAudioCheckDepsSuccess("coreaudio")}
+	rootCmd := makeRootCmd(deps)
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"audio-check", "--bogus"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error for unknown flag, got nil")
+	}
+}
+
+func TestAudioCheckCmd_RejectsPositionalArgs(t *testing.T) {
+	deps := &Deps{AudioCheck: newAudioCheckDepsSuccess("coreaudio")}
+	rootCmd := makeRootCmd(deps)
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"audio-check", "unexpected"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error when positional args provided, got nil")
+	}
+}
+
+func TestAudioCheckCmd_Help(t *testing.T) {
+	deps := &Deps{AudioCheck: newAudioCheckDepsSuccess("coreaudio")}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"audio-check", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error for --help: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"audio-check", "--verbose"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected help output to contain %q, got: %s", want, out)
+		}
+	}
+}
+
+func TestAudioCheckCmd_MissingDeps_ReturnsError(t *testing.T) {
+	// Deps.AudioCheck が nil のケース
+	rootCmd := makeRootCmd(&Deps{})
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"audio-check"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when AudioCheck deps are missing, got nil")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,9 +14,10 @@ var ErrUsage = errors.New("usage error")
 
 // Deps はルートコマンドの依存を保持する。
 type Deps struct {
-	Act   *ActDeps
-	Watch *WatchDeps
-	Say   *SayDeps
+	Act        *ActDeps
+	Watch      *WatchDeps
+	Say        *SayDeps
+	AudioCheck *AudioCheckDeps
 }
 
 func makeRootCmd(deps ...*Deps) *cobra.Command {
@@ -38,15 +39,18 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	var actDeps *ActDeps
 	var watchDeps *WatchDeps
 	var sayDeps *SayDeps
+	var audioCheckDeps *AudioCheckDeps
 	if d != nil {
 		actDeps = d.Act
 		watchDeps = d.Watch
 		sayDeps = d.Say
+		audioCheckDeps = d.AudioCheck
 	}
 	cmd.AddCommand(makeActCmd(actDeps))
 	cmd.AddCommand(makeWatchCmd(watchDeps))
 	cmd.AddCommand(makeSayCmd(sayDeps))
 	cmd.AddCommand(makeConfigCmd())
+	cmd.AddCommand(makeAudioCheckCmd(audioCheckDeps))
 
 	return cmd
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -193,6 +193,73 @@ supported keys:
 
 `path.queue` の解決は `git rev-parse --path-format=absolute --git-common-dir` の結果の親ディレクトリに `.vox-actor/queue` を結合したパスを返します。worktree 上で実行しても本体リポジトリ直下のパスが返るため、外部スクリプトから共通のキューディレクトリを参照できます。`config` サブコマンド自体は**パスの返却のみ**を行い、ディレクトリ作成は行いません。
 
+## `audio-check` サブコマンド
+
+```
+vox-actor audio-check [-v|--verbose]
+```
+
+音声出力デバイスを **open → 即 close** のみ行い、実再生を伴わずに可用性を**終了コード**で返す診断用サブコマンド。シェルスクリプトから `VOX_ACTOR_MONOLOGUE_MODE` 未指定時のモード判定（direct / file）に利用できる。
+
+| オプション | 環境変数 | デフォルト値 | 説明 |
+|---|---|---|---|
+| `--verbose` / `-v` | — | `false` | 診断メッセージを標準エラー出力に出力する |
+
+**出力と終了コード:**
+
+| 状況 | 終了コード | stdout | stderr (通常) | stderr (`--verbose`) |
+|---|---|---|---|---|
+| デバイス open 成功 | `0` | 空 | 空 | `audio backend: <name>` |
+| デバイス open 失敗 | `1` | 空 | 空 | `Error: <エラー内容>` |
+| バックエンド未対応 OS | `1` | 空 | 空 | `Error: unsupported platform: <GOOS>` |
+
+- `stdout` には一切出力しない。機械可読な判定は**終了コード**で行う。
+- 失敗理由の細分化は `--verbose` 指定時の stderr 出力で確認する。
+- 呼び出しはミリ秒オーダーで完了する想定（内部に2秒のタイムアウトを持つ）。
+- 本サブコマンドは**ローカルの出力デバイスのみ**を対象とする。VOICEVOX エンジンの疎通確認は行わない。
+
+**バックエンド名:**
+
+| GOOS | backend |
+|---|---|
+| `darwin` | `coreaudio` |
+| `linux` | `pulseaudio` |
+| `windows` | `wasapi` |
+
+**使用例:**
+
+```bash
+# 直接実行（成功）
+$ vox-actor audio-check
+$ echo $?
+0
+
+# verbose 出力
+$ vox-actor audio-check -v
+audio backend: coreaudio
+$ echo $?
+0
+
+# 音声デバイスが使えない環境（例: CI コンテナ）
+$ vox-actor audio-check -v
+Error: failed to initialize audio device: no output device available
+$ echo $?
+1
+```
+
+**シェルスクリプトからのモード判定例:**
+
+```bash
+MODE="${VOX_ACTOR_MONOLOGUE_MODE:-}"
+if [ -z "$MODE" ]; then
+  if vox-actor audio-check >/dev/null 2>&1; then
+    MODE="direct"
+  else
+    MODE="file"
+  fi
+fi
+```
+
 ## ストリーム配信モード
 
 `watch --stream` を付けると、ローカルスピーカー再生の代わりにHTTPサーバーを起動し、SSE経由でブラウザに音声を配信します。音声デバイスが利用できない環境でホスト側のブラウザに再生させるケースで利用できます。

--- a/internal/infra/audio_check.go
+++ b/internal/infra/audio_check.go
@@ -6,30 +6,47 @@ import (
 	"time"
 
 	"github.com/gopxl/beep/v2"
-	"github.com/gopxl/beep/v2/speaker"
 )
 
-// audioInitFunc は音声デバイスの初期化関数。テストから差し替え可能にするためpackage変数にしている。
-var audioInitFunc = func(sampleRate beep.SampleRate, bufferSize int) error {
-	return speaker.Init(sampleRate, bufferSize)
+const (
+	defaultAudioCheckTimeout = 2 * time.Second
+	audioCheckSampleRate     = beep.SampleRate(44100)
+	audioCheckBufferSize     = 512
+)
+
+// audioCheckConfig は CheckAudioDevice の調整可能なパラメータ。
+type audioCheckConfig struct {
+	timeout time.Duration
 }
 
-// audioCheckTimeout はデバイス初期化がブロックした場合の上限。テストから短縮できる。
-var audioCheckTimeout = 2 * time.Second
+// AudioCheckOption は CheckAudioDevice の挙動をカスタマイズする関数型オプション。
+type AudioCheckOption func(*audioCheckConfig)
 
-// audioCheckSampleRate はデバイス可用性チェックに使うサンプリングレート。
-const audioCheckSampleRate = beep.SampleRate(44100)
+// WithAudioCheckTimeout は CheckAudioDevice の初期化タイムアウトを上書きする。
+func WithAudioCheckTimeout(d time.Duration) AudioCheckOption {
+	return func(c *audioCheckConfig) { c.timeout = d }
+}
 
-// audioCheckBufferSize はデバイス可用性チェックに使うバッファサイズ。
-const audioCheckBufferSize = 512
+// CheckAudioDevice は backend.Init を呼び出して音声出力デバイスの可用性を判定する。
+// 成功時はプラットフォームに対応するバックエンド名（coreaudio / pulseaudio / wasapi）を返す。
+// 失敗時・タイムアウト時は空文字列とエラーを返す。
+//
+// 設計メモ: goroutine内のbackend.Initが戻らない場合、timeoutでselectを抜けて戻るが、
+// goroutine自体はInitが戻るまで残留する。done channel は buffered (cap=1) のため、
+// レシーバが居なくても送信は成功し goroutine は正常終了する。CLIは直後に終了するため
+// 短時間なら常駐しない。
+func CheckAudioDevice(backend speakerBackend, opts ...AudioCheckOption) (string, error) {
+	if backend == nil {
+		return "", fmt.Errorf("speaker backend must not be nil")
+	}
+	cfg := audioCheckConfig{timeout: defaultAudioCheckTimeout}
+	for _, o := range opts {
+		o(&cfg)
+	}
 
-// CheckAudioDevice は音声出力デバイスを open → 即 close のみ行い、可用性を判定する。
-// 成功時はバックエンド名（coreaudio / pulseaudio / wasapi など）を返す。
-// 失敗時は空文字列とエラーを返す。
-func CheckAudioDevice() (string, error) {
 	done := make(chan error, 1)
 	go func() {
-		done <- audioInitFunc(audioCheckSampleRate, audioCheckBufferSize)
+		done <- backend.Init(audioCheckSampleRate, audioCheckBufferSize)
 	}()
 
 	select {
@@ -38,13 +55,11 @@ func CheckAudioDevice() (string, error) {
 			return "", fmt.Errorf("failed to initialize audio device: %w", err)
 		}
 		return audioBackendName()
-	case <-time.After(audioCheckTimeout):
-		return "", fmt.Errorf("audio device initialization timed out after %s", audioCheckTimeout)
+	case <-time.After(cfg.timeout):
+		return "", fmt.Errorf("audio device initialization timed out after %s", cfg.timeout)
 	}
 }
 
-// audioBackendName は現在のプラットフォームに対応するバックエンド名を返す。
-// 未対応プラットフォームではエラーを返す。
 func audioBackendName() (string, error) {
 	switch runtime.GOOS {
 	case "darwin":

--- a/internal/infra/audio_check.go
+++ b/internal/infra/audio_check.go
@@ -1,0 +1,59 @@
+package infra
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/gopxl/beep/v2"
+	"github.com/gopxl/beep/v2/speaker"
+)
+
+// audioInitFunc は音声デバイスの初期化関数。テストから差し替え可能にするためpackage変数にしている。
+var audioInitFunc = func(sampleRate beep.SampleRate, bufferSize int) error {
+	return speaker.Init(sampleRate, bufferSize)
+}
+
+// audioCheckTimeout はデバイス初期化がブロックした場合の上限。テストから短縮できる。
+var audioCheckTimeout = 2 * time.Second
+
+// audioCheckSampleRate はデバイス可用性チェックに使うサンプリングレート。
+const audioCheckSampleRate = beep.SampleRate(44100)
+
+// audioCheckBufferSize はデバイス可用性チェックに使うバッファサイズ。
+const audioCheckBufferSize = 512
+
+// CheckAudioDevice は音声出力デバイスを open → 即 close のみ行い、可用性を判定する。
+// 成功時はバックエンド名（coreaudio / pulseaudio / wasapi など）を返す。
+// 失敗時は空文字列とエラーを返す。
+func CheckAudioDevice() (string, error) {
+	done := make(chan error, 1)
+	go func() {
+		done <- audioInitFunc(audioCheckSampleRate, audioCheckBufferSize)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return "", fmt.Errorf("failed to initialize audio device: %w", err)
+		}
+		return audioBackendName()
+	case <-time.After(audioCheckTimeout):
+		return "", fmt.Errorf("audio device initialization timed out after %s", audioCheckTimeout)
+	}
+}
+
+// audioBackendName は現在のプラットフォームに対応するバックエンド名を返す。
+// 未対応プラットフォームではエラーを返す。
+func audioBackendName() (string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return "coreaudio", nil
+	case "linux":
+		return "pulseaudio", nil
+	case "windows":
+		return "wasapi", nil
+	default:
+		return "", fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+}

--- a/internal/infra/audio_check_test.go
+++ b/internal/infra/audio_check_test.go
@@ -2,12 +2,14 @@ package infra
 
 // テストリスト: CheckAudioDevice
 //
-// DONE: 正常系: audioInitFuncが成功した場合、バックエンド名を返しエラーはnil
-// DONE: 異常系: audioInitFuncが失敗した場合、バックエンド名は空・エラーを返す
-// DONE: 異常系: audioInitFuncがタイムアウトを超えてブロックした場合、エラーを返す
+// DONE: 正常系: backend.Initが成功した場合、プラットフォームに対応するバックエンド名を返す
+// DONE: 異常系: backend.Initが失敗した場合、バックエンド名は空・エラーを返す
 // DONE: 異常系: 失敗時のエラーメッセージに元のエラー原因が含まれること
+// DONE: 異常系: backend.Initがタイムアウトを超えてブロックした場合、エラーを返す
+// DONE: 異常系: backend が nil の場合、エラーを返す
 
 import (
+	"context"
 	"errors"
 	"runtime"
 	"strings"
@@ -17,31 +19,30 @@ import (
 	"github.com/gopxl/beep/v2"
 )
 
-func TestCheckAudioDevice_Success(t *testing.T) {
-	orig := audioInitFunc
-	audioInitFunc = func(_ beep.SampleRate, _ int) error { return nil }
-	t.Cleanup(func() { audioInitFunc = orig })
+// audioCheckBackend は audio_check のテスト専用 speakerBackend 実装。
+// initErr / blockDuration をセットすることで挙動を制御できる。
+type audioCheckBackend struct {
+	initErr       error
+	blockDuration time.Duration
+}
 
-	backend, err := CheckAudioDevice()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func (b *audioCheckBackend) Init(_ beep.SampleRate, _ int) error {
+	if b.blockDuration > 0 {
+		time.Sleep(b.blockDuration)
 	}
-	if backend == "" {
-		t.Error("expected non-empty backend name")
-	}
+	return b.initErr
+}
+
+func (b *audioCheckBackend) PlayAndWait(_ context.Context, _ beep.Streamer) error {
+	return errors.New("PlayAndWait should not be called in audio-check tests")
 }
 
 func TestCheckAudioDevice_Success_ReturnsPlatformBackend(t *testing.T) {
-	orig := audioInitFunc
-	audioInitFunc = func(_ beep.SampleRate, _ int) error { return nil }
-	t.Cleanup(func() { audioInitFunc = orig })
-
-	backend, err := CheckAudioDevice()
+	backend, err := CheckAudioDevice(&audioCheckBackend{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// 現在のGOOSに対応するバックエンド名が返る
 	var want string
 	switch runtime.GOOS {
 	case "darwin":
@@ -51,7 +52,6 @@ func TestCheckAudioDevice_Success_ReturnsPlatformBackend(t *testing.T) {
 	case "windows":
 		want = "wasapi"
 	default:
-		// 未対応プラットフォームでは成功でもエラー扱いになる設計のためスキップ
 		t.Skipf("unsupported platform for this test: %s", runtime.GOOS)
 	}
 	if backend != want {
@@ -60,32 +60,13 @@ func TestCheckAudioDevice_Success_ReturnsPlatformBackend(t *testing.T) {
 }
 
 func TestCheckAudioDevice_Failure(t *testing.T) {
-	orig := audioInitFunc
-	audioInitFunc = func(_ beep.SampleRate, _ int) error {
-		return errors.New("no output device available")
-	}
-	t.Cleanup(func() { audioInitFunc = orig })
-
-	backend, err := CheckAudioDevice()
+	reason := "no output device available"
+	backend, err := CheckAudioDevice(&audioCheckBackend{initErr: errors.New(reason)})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if backend != "" {
 		t.Errorf("expected empty backend on failure, got %q", backend)
-	}
-}
-
-func TestCheckAudioDevice_Failure_ErrorMessageContainsReason(t *testing.T) {
-	orig := audioInitFunc
-	reason := "no output device available"
-	audioInitFunc = func(_ beep.SampleRate, _ int) error {
-		return errors.New(reason)
-	}
-	t.Cleanup(func() { audioInitFunc = orig })
-
-	_, err := CheckAudioDevice()
-	if err == nil {
-		t.Fatal("expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), reason) {
 		t.Errorf("error message should contain reason %q, got: %v", reason, err)
@@ -93,31 +74,30 @@ func TestCheckAudioDevice_Failure_ErrorMessageContainsReason(t *testing.T) {
 }
 
 func TestCheckAudioDevice_Timeout(t *testing.T) {
-	orig := audioInitFunc
-	origTimeout := audioCheckTimeout
-	audioInitFunc = func(_ beep.SampleRate, _ int) error {
-		// タイムアウトより長くブロックする
-		time.Sleep(200 * time.Millisecond)
-		return nil
-	}
-	audioCheckTimeout = 20 * time.Millisecond
-	t.Cleanup(func() {
-		audioInitFunc = orig
-		audioCheckTimeout = origTimeout
-	})
-
 	start := time.Now()
-	_, err := CheckAudioDevice()
+	backend, err := CheckAudioDevice(
+		&audioCheckBackend{blockDuration: 200 * time.Millisecond},
+		WithAudioCheckTimeout(20*time.Millisecond),
+	)
 	elapsed := time.Since(start)
 
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
 	}
-	if !strings.Contains(strings.ToLower(err.Error()), "timeout") &&
-		!strings.Contains(strings.ToLower(err.Error()), "timed out") {
+	if backend != "" {
+		t.Errorf("expected empty backend on timeout, got %q", backend)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "timed out") {
 		t.Errorf("error should mention timeout, got: %v", err)
 	}
 	if elapsed > 150*time.Millisecond {
 		t.Errorf("CheckAudioDevice should return around timeout, took %s", elapsed)
+	}
+}
+
+func TestCheckAudioDevice_NilBackend(t *testing.T) {
+	_, err := CheckAudioDevice(nil)
+	if err == nil {
+		t.Fatal("expected error when backend is nil, got nil")
 	}
 }

--- a/internal/infra/audio_check_test.go
+++ b/internal/infra/audio_check_test.go
@@ -1,0 +1,123 @@
+package infra
+
+// テストリスト: CheckAudioDevice
+//
+// DONE: 正常系: audioInitFuncが成功した場合、バックエンド名を返しエラーはnil
+// DONE: 異常系: audioInitFuncが失敗した場合、バックエンド名は空・エラーを返す
+// DONE: 異常系: audioInitFuncがタイムアウトを超えてブロックした場合、エラーを返す
+// DONE: 異常系: 失敗時のエラーメッセージに元のエラー原因が含まれること
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gopxl/beep/v2"
+)
+
+func TestCheckAudioDevice_Success(t *testing.T) {
+	orig := audioInitFunc
+	audioInitFunc = func(_ beep.SampleRate, _ int) error { return nil }
+	t.Cleanup(func() { audioInitFunc = orig })
+
+	backend, err := CheckAudioDevice()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if backend == "" {
+		t.Error("expected non-empty backend name")
+	}
+}
+
+func TestCheckAudioDevice_Success_ReturnsPlatformBackend(t *testing.T) {
+	orig := audioInitFunc
+	audioInitFunc = func(_ beep.SampleRate, _ int) error { return nil }
+	t.Cleanup(func() { audioInitFunc = orig })
+
+	backend, err := CheckAudioDevice()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 現在のGOOSに対応するバックエンド名が返る
+	var want string
+	switch runtime.GOOS {
+	case "darwin":
+		want = "coreaudio"
+	case "linux":
+		want = "pulseaudio"
+	case "windows":
+		want = "wasapi"
+	default:
+		// 未対応プラットフォームでは成功でもエラー扱いになる設計のためスキップ
+		t.Skipf("unsupported platform for this test: %s", runtime.GOOS)
+	}
+	if backend != want {
+		t.Errorf("backend = %q, want %q", backend, want)
+	}
+}
+
+func TestCheckAudioDevice_Failure(t *testing.T) {
+	orig := audioInitFunc
+	audioInitFunc = func(_ beep.SampleRate, _ int) error {
+		return errors.New("no output device available")
+	}
+	t.Cleanup(func() { audioInitFunc = orig })
+
+	backend, err := CheckAudioDevice()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if backend != "" {
+		t.Errorf("expected empty backend on failure, got %q", backend)
+	}
+}
+
+func TestCheckAudioDevice_Failure_ErrorMessageContainsReason(t *testing.T) {
+	orig := audioInitFunc
+	reason := "no output device available"
+	audioInitFunc = func(_ beep.SampleRate, _ int) error {
+		return errors.New(reason)
+	}
+	t.Cleanup(func() { audioInitFunc = orig })
+
+	_, err := CheckAudioDevice()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), reason) {
+		t.Errorf("error message should contain reason %q, got: %v", reason, err)
+	}
+}
+
+func TestCheckAudioDevice_Timeout(t *testing.T) {
+	orig := audioInitFunc
+	origTimeout := audioCheckTimeout
+	audioInitFunc = func(_ beep.SampleRate, _ int) error {
+		// タイムアウトより長くブロックする
+		time.Sleep(200 * time.Millisecond)
+		return nil
+	}
+	audioCheckTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		audioInitFunc = orig
+		audioCheckTimeout = origTimeout
+	})
+
+	start := time.Now()
+	_, err := CheckAudioDevice()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "timeout") &&
+		!strings.Contains(strings.ToLower(err.Error()), "timed out") {
+		t.Errorf("error should mention timeout, got: %v", err)
+	}
+	if elapsed > 150*time.Millisecond {
+		t.Errorf("CheckAudioDevice should return around timeout, took %s", elapsed)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -57,7 +57,9 @@ func main() {
 			Player:        player,
 		},
 		AudioCheck: &cmd.AudioCheckDeps{
-			CheckFunc: infra.CheckAudioDevice,
+			CheckFunc: func() (string, error) {
+				return infra.CheckAudioDevice(infra.NewRealSpeakerBackend())
+			},
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -56,6 +56,9 @@ func main() {
 			ClientFactory: clientFactory,
 			Player:        player,
 		},
+		AudioCheck: &cmd.AudioCheckDeps{
+			CheckFunc: infra.CheckAudioDevice,
+		},
 	}
 
 	if err := cmd.Execute(deps); err != nil {


### PR DESCRIPTION
## Summary

- 音声出力デバイスの可用性を **open → 即 close** で判定する診断サブコマンド `vox-actor audio-check [-v|--verbose]` を追加
- シェルスクリプト（`monologue.sh` / `play-script.sh` など）が `VOX_ACTOR_MONOLOGUE_MODE` 未指定時に **実再生可否ベースでモード選択** できるようにする基盤（#240 の前段）
- 既存の `say` / `act` / `watch` / `config` には変更なし

## 仕様

| 状況 | 終了コード | stdout | stderr (通常) | stderr (`--verbose`) |
|---|---|---|---|---|
| デバイス open 成功 | `0` | 空 | 空 | `audio backend: <name>` |
| デバイス open 失敗 | `1` | 空 | 空 | `Error: <エラー内容>` |
| 未対応プラットフォーム | `1` | 空 | 空 | `Error: unsupported platform: <GOOS>` |

- バックエンド名: `darwin → coreaudio` / `linux → pulseaudio` / `windows → wasapi`
- 内部タイムアウト 2 秒（ブロック時の保険。`WithAudioCheckTimeout` で上書き可）
- 機械可読な判定は**終了コード**で行い、`--verbose` は人間向けの診断出力

## 実装メモ

- `internal/infra/audio_check.go`: 既存の `speakerBackend` 抽象（`beep_player.go`）を DI することで、テスト用 mock 差し替えを **production の package var に頼らず** 実現
- `cmd/audio_check.go`: `AudioCheckDeps.CheckFunc` を経由して infra 側の実装を注入。失敗時も `SilenceErrors` で cobra のエラー表示を抑制し、非verbose時の stderr を空に保つ
- `ErrAudioCheckFailed` はセンチネルエラー。`ErrUsage` ではないため `main.go` で終了コード 1 にマップされる
- goroutine + buffered channel (cap=1) により、`backend.Init` が戻らなくても送信側は blocking せず、CLI 終了時にプロセス回収される

## Test plan

- [x] `go test ./...` 全ケース pass
- [x] `golangci-lint run ./...` 0 issues
- [x] `gofmt -l .` 差分なし
- [x] ローカルで `vox-actor audio-check` / `vox-actor audio-check --verbose` / `vox-actor audio-check bogus` を手動実行し、終了コード・出力が仕様通りであること確認
- [x] `vox-actor audio-check --help` がヘルプを表示すること
- [x] `docs/reference/cli.md` の `audio-check` 節が実装と一致

Closes #241

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
