### PR TITLE
refactor: シェルスクリプトでvox-actorコマンドを必須化しワークスペース解決を簡素化 #240

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -146,13 +146,19 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 |---|---|---|
 | 読み上げ方式 | `vox-actor say` をその場で直接呼び出す | テキスト等をファイルに書き出し、別プロセスの `vox-actor watch` が読み上げる |
 | 監視プロセス | 不要 | `vox-actor watch` の常駐が必要 |
-| ファイル出力先 | エラーログのみ（`monologue` は `$VOX_ACTOR_WORKSPACE/monologue-errors.log`、`speak` / `talk` は `$VOX_ACTOR_WORKSPACE/play-script-errors.log`） | 通知ファイル（`$VOX_ACTOR_WORKSPACE/queue/monologue_*.json` / `speak_*.jsonl` / `talk_*.jsonl`）＋エラーログ |
+| ファイル出力先 | エラーログのみ（`monologue` はワークスペースルート直下の `monologue-errors.log`、`speak` / `talk` は `play-script-errors.log`） | 通知ファイル（ワークスペース配下の `queue/monologue_*.json` / `speak_*.jsonl` / `talk_*.jsonl`）＋エラーログ |
 | 同時呼び出し時 | 同一セッション内は逐次再生、複数セッション間は並列再生 | 検知順に逐次再生 |
-| 前提 | `vox-actor` コマンドが `PATH` 上にある | claude code 側と `vox-actor watch` 側で `VOX_ACTOR_WORKSPACE` を共有 |
+| 前提 | `vox-actor` コマンドが `PATH` 上にあり、音声デバイスが利用可能（`vox-actor audio-check` が成功） | claude code 側と `vox-actor watch` 側で `VOX_ACTOR_WORKSPACE` を共有 |
 
-> `VOX_ACTOR_WORKSPACE` は vox-actor 関連ファイルのルートディレクトリを指す（配下に `queue/` と `monologue-errors.log`、`speak` / `talk` 用の `play-script-errors.log` が置かれる）。未指定時のデフォルトは gitリポジトリ内なら `<gitリポジトリ直下>/.vox-actor`、gitリポジトリ外なら `$PWD/.vox-actor`。`file` モードでホストとLLM実行環境を分ける場合は、双方から参照可能な共有パスを明示的に指定する。
+> **前提**: `vox-actor` コマンドのインストールは必須です（両スクリプトは起動時に `command -v vox-actor` で存在確認し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了します）。
+>
+> **ワークスペースの解決順**:
+> 1. `VOX_ACTOR_WORKSPACE` が設定されていればその配下の `queue/` を使う
+> 2. 未設定なら `vox-actor config path.queue` の出力（gitリポジトリ直下の `.vox-actor/queue` の絶対パス）を使う
+>
+> git 管理外ディレクトリで `VOX_ACTOR_WORKSPACE` を明示しないまま実行すると `vox-actor config path.queue` が非0終了し、そのエラーがユーザーに表示されてスクリプトも終了します。git 外で利用する場合は `VOX_ACTOR_WORKSPACE` を明示してください。`file` モードでホストとLLM実行環境を分ける場合も、双方から参照可能な共有パスを明示的に指定します。
 
-モードは `VOX_ACTOR_MONOLOGUE_MODE` 環境変数で明示するか、未設定時は `vox-actor` コマンドの有無で自動判定されます（あり → `direct`、なし → `file`）。
+モードは `VOX_ACTOR_MONOLOGUE_MODE` 環境変数で明示するか、未設定時は `vox-actor audio-check` の終了コードで自動判定されます（0 → `direct`、非0 → `file`）。
 
 ### `file` モードのセットアップ（音声デバイス利用不可環境での利用）
 
@@ -216,7 +222,7 @@ vox-actor act --watch-delete /path/to/watch-dir
 
 ### エラーログ
 
-`direct` モードでの失敗は以下のログに追記されます（いずれも末尾200行でローテーション）。`tail -f` で確認できます。
+`direct` モードでの失敗は以下のログに追記されます（いずれも末尾200行でローテーション）。`tail -f` で確認できます。いずれも解決済みワークスペースルート直下に配置されます（`VOX_ACTOR_WORKSPACE` 明示時はその直下、未指定時は `vox-actor config path.queue` の出力の親ディレクトリ直下）。
 
-- `monologue` スキル: `$VOX_ACTOR_WORKSPACE/monologue-errors.log`
-- `speak` / `talk` スキル: `$VOX_ACTOR_WORKSPACE/play-script-errors.log`
+- `monologue` スキル: `<workspace>/monologue-errors.log`
+- `speak` / `talk` スキル: `<workspace>/play-script-errors.log`

--- a/plugins/vox-actor-plugin/scripts/play-script.sh
+++ b/plugins/vox-actor-plugin/scripts/play-script.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
-if [ -z "$VOX_ACTOR_WORKSPACE" ]; then
-  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
-  if [ -n "$GIT_COMMON_DIR" ]; then
-    VOX_ACTOR_WORKSPACE="$(dirname "$GIT_COMMON_DIR")/.vox-actor"
-  else
-    VOX_ACTOR_WORKSPACE="$PWD/.vox-actor"
-  fi
+if ! command -v vox-actor >/dev/null 2>&1; then
+  echo "[ERROR] vox-actor コマンドが必要です。インストール方法は README を参照してください" >&2
+  exit 1
 fi
 
 JSONL_PATH="$1"
@@ -20,20 +16,26 @@ if [ ! -f "$JSONL_PATH" ]; then
   exit 1
 fi
 
+if [ -n "$VOX_ACTOR_WORKSPACE" ]; then
+  QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"
+else
+  QUEUE_DIR=$(vox-actor config path.queue) || exit 1
+fi
+WORKSPACE_DIR="$(dirname "$QUEUE_DIR")"
+
 MODE="${VOX_ACTOR_MONOLOGUE_MODE:-}"
 if [ -z "$MODE" ]; then
-  if command -v vox-actor >/dev/null 2>&1; then
+  if vox-actor audio-check >/dev/null 2>&1; then
     MODE="direct"
   else
     MODE="file"
   fi
 fi
 
-mkdir -p "$VOX_ACTOR_WORKSPACE"
-
 case "$MODE" in
   direct)
-    ERROR_LOG="${VOX_ACTOR_WORKSPACE}/play-script-errors.log"
+    mkdir -p "$WORKSPACE_DIR"
+    ERROR_LOG="${WORKSPACE_DIR}/play-script-errors.log"
     MAX_LOG_LINES=200
     OUTPUT=$(vox-actor act "$JSONL_PATH" 2>&1)
     STATUS=$?
@@ -53,7 +55,6 @@ case "$MODE" in
     rm -f "$JSONL_PATH"
     ;;
   file)
-    QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"
     mkdir -p "$QUEUE_DIR"
     DEST="${QUEUE_DIR}/$(basename "$JSONL_PATH")"
     mv "$JSONL_PATH" "$DEST"

--- a/plugins/vox-actor-plugin/skills/monologue/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/monologue/SKILL.md
@@ -72,17 +72,22 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 通知の実行に使用する `${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh` は以下の前提条件を必要とする:
 
-- **環境変数 `VOX_ACTOR_WORKSPACE`**: vox-actor関連ファイルのルートディレクトリを指定する。配下に `queue/`（fileモードの通知JSON出力先）および `monologue-errors.log`（directモードのエラーログ）が置かれる。未設定の場合のデフォルト値は以下のとおり
-  - gitリポジトリ内: `<gitリポジトリ直下>/.vox-actor`
-  - gitリポジトリ外: `$PWD/.vox-actor`
-- **出力先ディレクトリ**: 上記のルートディレクトリおよび配下の `queue/` はスクリプトが必要に応じて自動作成する
+- **`vox-actor` コマンドのインストール必須**: スクリプト冒頭で `command -v vox-actor` を検査し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了する
+- **ワークスペースの解決順**:
+  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその配下の `queue/` を使う
+  2. 未設定なら `vox-actor config path.queue` の出力（gitリポジトリ直下の `.vox-actor/queue` の絶対パス）を使う
+- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと `vox-actor config path.queue` が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
+- **出力先ディレクトリ**: ワークスペースルートおよび配下の `queue/` はスクリプトが必要に応じて自動作成する
+- `monologue-errors.log`（directモードのエラーログ）はワークスペースルート直下に配置される
 
 ### 通知モード
 
 通知方式は以下のルールで自動切替する:
 
 1. 環境変数 `VOX_ACTOR_MONOLOGUE_MODE` が設定されていればそれに従う（`direct` または `file`）
-2. 未設定なら `vox-actor` コマンドの有無で判定する（あり → `direct`、なし → `file`）
+2. 未設定なら `vox-actor audio-check` の終了コードで自動判定する
+   - 終了コード 0（音声デバイス open 成功）→ `direct`
+   - 非0（音声デバイス open 失敗）→ `file`
 
 #### `direct` モード
 
@@ -91,11 +96,11 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 - VOICEVOXエンジンのURLは `vox-actor` 側の環境変数 `VOX_ENGINE_URL` で解決する（非デフォルトポート時はユーザーが設定）
 - 監視プロセス（`vox-actor watch`）の常駐は不要
 - 同期実行のため、同一セッション内で連続して呼び出した場合は先の発話が完了してから次が再生される。ただし複数セッションから並列に呼ばれた場合はエンジンへの並列リクエストと音声再生の重なりが発生しうる。複数セッション間でも逐次再生したい場合は `VOX_ACTOR_MONOLOGUE_MODE=file` + 監視プロセス構成に切り替える
-- `vox-actor say` 失敗時もスクリプト本体はエラー終了せず、標準出力/標準エラーの内容を `${VOX_ACTOR_WORKSPACE}/monologue-errors.log` にタイムスタンプ付きで追記する。ログは末尾200行でローテーションされる。失敗検知は `tail -f ${VOX_ACTOR_WORKSPACE}/monologue-errors.log` で行える
+- `vox-actor say` 失敗時もスクリプト本体はエラー終了せず、標準出力/標準エラーの内容をワークスペースルート直下の `monologue-errors.log` にタイムスタンプ付きで追記する。ログは末尾200行でローテーションされる。失敗検知は `tail -f <workspace>/monologue-errors.log` で行える
 
 #### `file` モード
 
-`${VOX_ACTOR_WORKSPACE}/queue/` に通知ファイルを書き出す。ファイル名は `monologue_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする
+解決された queue ディレクトリ（`VOX_ACTOR_WORKSPACE` 明示時は `${VOX_ACTOR_WORKSPACE}/queue/`、未指定時は `vox-actor config path.queue` の出力先）に通知ファイルを書き出す。ファイル名は `monologue_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする
 
 ## キャラクター設定ファイルについて
 

--- a/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
+++ b/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
-if [ -z "$VOX_ACTOR_WORKSPACE" ]; then
-  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
-  if [ -n "$GIT_COMMON_DIR" ]; then
-    VOX_ACTOR_WORKSPACE="$(dirname "$GIT_COMMON_DIR")/.vox-actor"
-  else
-    VOX_ACTOR_WORKSPACE="$PWD/.vox-actor"
-  fi
+if ! command -v vox-actor >/dev/null 2>&1; then
+  echo "[ERROR] vox-actor コマンドが必要です。インストール方法は README を参照してください" >&2
+  exit 1
 fi
 
 PROBABILITY="$1"
@@ -53,20 +49,26 @@ if [ "$ROLL" -gt "$PROBABILITY" ]; then
   exit 0
 fi
 
+if [ -n "$VOX_ACTOR_WORKSPACE" ]; then
+  QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"
+else
+  QUEUE_DIR=$(vox-actor config path.queue) || exit 1
+fi
+WORKSPACE_DIR="$(dirname "$QUEUE_DIR")"
+
 MODE="${VOX_ACTOR_MONOLOGUE_MODE:-}"
 if [ -z "$MODE" ]; then
-  if command -v vox-actor >/dev/null 2>&1; then
+  if vox-actor audio-check >/dev/null 2>&1; then
     MODE="direct"
   else
     MODE="file"
   fi
 fi
 
-mkdir -p "$VOX_ACTOR_WORKSPACE"
-
 case "$MODE" in
   direct)
-    ERROR_LOG="${VOX_ACTOR_WORKSPACE}/monologue-errors.log"
+    mkdir -p "$WORKSPACE_DIR"
+    ERROR_LOG="${WORKSPACE_DIR}/monologue-errors.log"
     MAX_LOG_LINES=200
     OUTPUT=$(vox-actor say --speaker "$SPEAKER" --speed "$SPEED_SCALE" "$TEXT" 2>&1)
     STATUS=$?
@@ -85,7 +87,6 @@ case "$MODE" in
     fi
     ;;
   file)
-    QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"
     mkdir -p "$QUEUE_DIR"
     jq -cn --argjson speaker "$SPEAKER" --arg text "$TEXT" --argjson speedScale "$SPEED_SCALE" \
       '{speaker: $speaker, text: $text, speedScale: $speedScale}' > "${QUEUE_DIR}/monologue_$(($(date +%s%N)/1000000)).json"

--- a/plugins/vox-actor-plugin/skills/speak/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/speak/SKILL.md
@@ -73,17 +73,22 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 再生の実行に使用する `${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh` は以下の前提条件を必要とする:
 
-- **環境変数 `VOX_ACTOR_WORKSPACE`**: vox-actor関連ファイルのルートディレクトリを指定する。配下に `tmp/`（JSONL台本の一時格納先）、`queue/`（fileモードの通知ファイル出力先）、`play-script-errors.log`（directモードのエラーログ）が置かれる。未設定の場合のデフォルト値は以下のとおり
-  - gitリポジトリ内: `<gitリポジトリ直下>/.vox-actor`
-  - gitリポジトリ外: `$PWD/.vox-actor`
-- **出力先ディレクトリ**: 上記のルートディレクトリおよび配下の `queue/` は `play-script.sh` が必要に応じて自動作成する。`tmp/` ディレクトリは Claude が Write する前に `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で作成する
+- **`vox-actor` コマンドのインストール必須**: スクリプト冒頭で `command -v vox-actor` を検査し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了する
+- **ワークスペースの解決順**:
+  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその配下の `queue/` を使う
+  2. 未設定なら `vox-actor config path.queue` の出力（gitリポジトリ直下の `.vox-actor/queue` の絶対パス）を使う
+- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと `vox-actor config path.queue` が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
+- **出力先ディレクトリ**: ワークスペースルートおよび配下の `queue/` は `play-script.sh` が必要に応じて自動作成する。`tmp/` ディレクトリは Claude が Write する前に `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で作成する（`tmp/` 利用時は `VOX_ACTOR_WORKSPACE` の明示が前提）
+- `play-script-errors.log`（directモードのエラーログ）はワークスペースルート直下に配置される
 
 ### 通知モード
 
 通知方式は以下のルールで自動切替する:
 
 1. 環境変数 `VOX_ACTOR_MONOLOGUE_MODE` が設定されていればそれに従う（`direct` または `file`）
-2. 未設定なら `vox-actor` コマンドの有無で判定する（あり → `direct`、なし → `file`）
+2. 未設定なら `vox-actor audio-check` の終了コードで自動判定する
+   - 終了コード 0（音声デバイス open 成功）→ `direct`
+   - 非0（音声デバイス open 失敗）→ `file`
 
 #### `direct` モード
 
@@ -93,11 +98,11 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 - 監視プロセス（`vox-actor watch`）の常駐は不要
 - 再生完了後、渡された一時ファイルを `rm -f` で削除する
 - 同期実行のため、同一セッション内で連続して呼び出した場合は先の再生が完了してから次が再生される。ただし複数セッションから並列に呼ばれた場合はエンジンへの並列リクエストと音声再生の重なりが発生しうる。複数セッション間でも逐次再生したい場合は `VOX_ACTOR_MONOLOGUE_MODE=file` + 監視プロセス構成に切り替える
-- `vox-actor act` 失敗時もスクリプト本体はエラー終了せず、標準出力/標準エラーの内容を `${VOX_ACTOR_WORKSPACE}/play-script-errors.log` にタイムスタンプ付きで追記する。ログは末尾200行でローテーションされる。失敗検知は `tail -f ${VOX_ACTOR_WORKSPACE}/play-script-errors.log` で行える
+- `vox-actor act` 失敗時もスクリプト本体はエラー終了せず、標準出力/標準エラーの内容をワークスペースルート直下の `play-script-errors.log` にタイムスタンプ付きで追記する。ログは末尾200行でローテーションされる。失敗検知は `tail -f <workspace>/play-script-errors.log` で行える
 
 #### `file` モード
 
-一時ファイルを `${VOX_ACTOR_WORKSPACE}/queue/$(basename <jsonl_path>)` へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`speak_<ms>.jsonl` なら `queue/speak_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
+一時ファイルを解決された queue ディレクトリ（`VOX_ACTOR_WORKSPACE` 明示時は `${VOX_ACTOR_WORKSPACE}/queue/`、未指定時は `vox-actor config path.queue` の出力先）配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`speak_<ms>.jsonl` なら `queue/speak_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
 
 ## JSONL 出力例
 

--- a/plugins/vox-actor-plugin/skills/talk/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/talk/SKILL.md
@@ -75,17 +75,22 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 再生の実行に使用する `${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh` は以下の前提条件を必要とする:
 
-- **環境変数 `VOX_ACTOR_WORKSPACE`**: vox-actor関連ファイルのルートディレクトリを指定する。配下に `tmp/`（JSONL台本の一時格納先）、`queue/`（fileモードの通知ファイル出力先）、`play-script-errors.log`（directモードのエラーログ）が置かれる。未設定の場合のデフォルト値は以下のとおり
-  - gitリポジトリ内: `<gitリポジトリ直下>/.vox-actor`
-  - gitリポジトリ外: `$PWD/.vox-actor`
-- **出力先ディレクトリ**: 上記のルートディレクトリおよび配下の `queue/` は `play-script.sh` が必要に応じて自動作成する。`tmp/` ディレクトリは Claude が Write する前に `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で作成する
+- **`vox-actor` コマンドのインストール必須**: スクリプト冒頭で `command -v vox-actor` を検査し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了する
+- **ワークスペースの解決順**:
+  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその配下の `queue/` を使う
+  2. 未設定なら `vox-actor config path.queue` の出力（gitリポジトリ直下の `.vox-actor/queue` の絶対パス）を使う
+- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと `vox-actor config path.queue` が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
+- **出力先ディレクトリ**: ワークスペースルートおよび配下の `queue/` は `play-script.sh` が必要に応じて自動作成する。`tmp/` ディレクトリは Claude が Write する前に `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で作成する（`tmp/` 利用時は `VOX_ACTOR_WORKSPACE` の明示が前提）
+- `play-script-errors.log`（directモードのエラーログ）はワークスペースルート直下に配置される
 
 ### 通知モード
 
 通知方式は以下のルールで自動切替する:
 
 1. 環境変数 `VOX_ACTOR_MONOLOGUE_MODE` が設定されていればそれに従う（`direct` または `file`）
-2. 未設定なら `vox-actor` コマンドの有無で判定する（あり → `direct`、なし → `file`）
+2. 未設定なら `vox-actor audio-check` の終了コードで自動判定する
+   - 終了コード 0（音声デバイス open 成功）→ `direct`
+   - 非0（音声デバイス open 失敗）→ `file`
 
 #### `direct` モード
 
@@ -95,11 +100,11 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 - 監視プロセス（`vox-actor watch`）の常駐は不要
 - 再生完了後、渡された一時ファイルを `rm -f` で削除する
 - 同期実行のため、同一セッション内で連続して呼び出した場合は先の再生が完了してから次が再生される。ただし複数セッションから並列に呼ばれた場合はエンジンへの並列リクエストと音声再生の重なりが発生しうる。複数セッション間でも逐次再生したい場合は `VOX_ACTOR_MONOLOGUE_MODE=file` + 監視プロセス構成に切り替える
-- `vox-actor act` 失敗時もスクリプト本体はエラー終了せず、標準出力/標準エラーの内容を `${VOX_ACTOR_WORKSPACE}/play-script-errors.log` にタイムスタンプ付きで追記する。ログは末尾200行でローテーションされる。失敗検知は `tail -f ${VOX_ACTOR_WORKSPACE}/play-script-errors.log` で行える
+- `vox-actor act` 失敗時もスクリプト本体はエラー終了せず、標準出力/標準エラーの内容をワークスペースルート直下の `play-script-errors.log` にタイムスタンプ付きで追記する。ログは末尾200行でローテーションされる。失敗検知は `tail -f <workspace>/play-script-errors.log` で行える
 
 #### `file` モード
 
-一時ファイルを `${VOX_ACTOR_WORKSPACE}/queue/$(basename <jsonl_path>)` へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`talk_<ms>.jsonl` なら `queue/talk_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
+一時ファイルを解決された queue ディレクトリ（`VOX_ACTOR_WORKSPACE` 明示時は `${VOX_ACTOR_WORKSPACE}/queue/`、未指定時は `vox-actor config path.queue` の出力先）配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`talk_<ms>.jsonl` なら `queue/talk_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
 
 ## JSONL 出力例
 


### PR DESCRIPTION
## Summary

- `monologue.sh` / `play-script.sh` 冒頭で `command -v vox-actor` を検査し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了するよう変更
- `VOX_ACTOR_WORKSPACE` 未指定時のワークスペース解決を `vox-actor config path.queue` の呼び出しに統一し、`git rev-parse --git-common-dir` ベースのシェル側フォールバックを廃止
- モード自動判定を `vox-actor audio-check` の終了コードベースに切替（0 → `direct` / 非0 → `file`）。`command -v vox-actor` によるモード自動切替は廃止
- 通知スキップ時のサブプロセス起動を避けるため、`monologue.sh` では確率ロール（ROLL gate）を workspace 解決より前に移動。`mkdir -p "$WORKSPACE_DIR"` は `direct` ケース内に限定（file モードでは `mkdir -p "$QUEUE_DIR"` が親を作るため不要）
- `monologue` / `speak` / `talk` の SKILL.md と `docs/reference/plugins.md` の前提条件・通知モード・エラーログ節を新仕様に沿って書き直し（`vox-actor` 必須化、`vox-actor config path.queue` 利用、`audio-check` ベースのモード判定、git 管理外での明示運用を追記）

## 挙動変更点

| シナリオ | 変更前 | 変更後 |
|---|---|---|
| CLI なし + git 内 | シェルで git-common-dir 計算 → file モード | **ERROR 終了**（CLI 必須） |
| CLI あり + git 外 + `VOX_ACTOR_WORKSPACE` 未指定 | `$PWD/.vox-actor` にフォールバック | **ERROR 終了**（`vox-actor config` が非0） |
| モード未指定 + CLI あり + 音声デバイスなし | `direct` （再生失敗して無音になりがち） | **`file`** （`audio-check` 失敗で file を選択） |

`VOX_ACTOR_MONOLOGUE_MODE` を明示した場合はこれまで通り指定値が優先される。git 管理外での利用は `VOX_ACTOR_WORKSPACE` 明示に誘導する旨を SKILL.md / docs に追記。

## Test plan

- [x] `shellcheck` を `monologue.sh` / `play-script.sh` に対してパス
- [x] CLI 未インストール時に両スクリプトが `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了
- [x] `VOX_ACTOR_WORKSPACE` 明示時は指定配下の `queue/` が使われる
- [x] `VOX_ACTOR_WORKSPACE` 未指定 + git リポジトリ内で `vox-actor config path.queue` の出力先に書き出される（worktree 内実行でも本体リポジトリ直下の `.vox-actor/queue` が使われる）
- [x] `VOX_ACTOR_WORKSPACE` 未指定 + git 外で `vox-actor config` のエラーメッセージを表示して非0終了
- [x] モック `vox-actor` で audio-check 成功 → `direct`、失敗 → `file` の自動判定を確認
- [x] `VOX_ACTOR_MONOLOGUE_MODE=direct` は audio-check 失敗時でも `direct` 優先
- [x] 確率1%設定で50回呼び出した際、`vox-actor config` / `audio-check` のサブプロセス起動は ROLL 通過分のみ（効率改善）

Closes #240

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
