### PR TITLE
refactor: VOX_ACTOR_WORKSPACE解釈をvox-actor CLIに集約しpath.workspaceを追加 #246

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ claude code と `vox-actor` CLI が同じ環境で動作するケースです。
 claude code がコンテナ／リモートで動作し、音声デバイスはホスト側のみにある構成です。ホスト側で `vox-actor watch` を常駐させ、claude code側は共有ディレクトリへ通知ファイルを書き出すことで、読み上げが逐次再生されます。
 
 ```bash
-# ホスト側: 共有ディレクトリを監視
+# ホスト側: 共有ディレクトリを監視（VOX_ACTOR_WORKSPACE は vox-actor CLI が解釈する）
 export VOX_ACTOR_WORKSPACE=/path/to/shared/directory
-vox-actor watch "$VOX_ACTOR_WORKSPACE/queue"
+vox-actor watch "$(vox-actor config path.queue)"
 ```
 
 ```bash

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,6 +11,7 @@ import (
 // supportedConfigKeys は `vox-actor config <key>` で解決可能なキーをアルファベット順で保持する。
 var supportedConfigKeys = []string{
 	"path.queue",
+	"path.workspace",
 }
 
 func makeConfigCmd() *cobra.Command {
@@ -32,19 +33,25 @@ func makeConfigCmd() *cobra.Command {
 }
 
 func runConfig(cmd *cobra.Command, key string) error {
+	var (
+		path string
+		err  error
+	)
 	switch key {
 	case "path.queue":
-		path, err := infra.ResolveQueuePath()
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintln(cmd.OutOrStdout(), path); err != nil {
-			return err
-		}
-		return nil
+		path, err = infra.ResolveQueuePath()
+	case "path.workspace":
+		path, err = infra.ResolveWorkspacePath()
 	default:
 		return fmt.Errorf("%w: unknown key: %s\nsupported keys:\n%s", ErrUsage, key, formatSupportedKeys())
 	}
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), path); err != nil {
+		return err
+	}
+	return nil
 }
 
 func formatSupportedKeys() string {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -52,6 +52,7 @@ func TestConfigCmd_RegisteredAsSubcommand(t *testing.T) {
 }
 
 func TestConfigCmd_PathQueue_InsideGitRepo_PrintsAbsolutePath(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	repoRoot := withTempGitRepo(t)
 
 	rootCmd := makeRootCmd()
@@ -75,7 +76,103 @@ func TestConfigCmd_PathQueue_InsideGitRepo_PrintsAbsolutePath(t *testing.T) {
 	}
 }
 
+func TestConfigCmd_PathWorkspace_InsideGitRepo_PrintsAbsolutePath(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	repoRoot := withTempGitRepo(t)
+
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.workspace"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v, stderr: %s", err, errBuf.String())
+	}
+
+	got := strings.TrimRight(outBuf.String(), "\n")
+	want := filepath.Join(repoRoot, ".vox-actor")
+	wantEval, _ := filepath.EvalSymlinks(filepath.Dir(want))
+	gotEval, _ := filepath.EvalSymlinks(filepath.Dir(got))
+	if gotEval != wantEval || filepath.Base(got) != filepath.Base(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestConfigCmd_PathWorkspace_WithEnv_PrintsEnvValue(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", workspace)
+
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.workspace"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v, stderr: %s", err, errBuf.String())
+	}
+
+	got := strings.TrimRight(outBuf.String(), "\n")
+	if got != workspace {
+		t.Errorf("got %q, want %q", got, workspace)
+	}
+}
+
+func TestConfigCmd_PathWorkspace_OutsideGitRepo_ReturnsErrorWithJapaneseMessage(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.workspace"})
+
+	err = rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when outside git repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "gitリポジトリではありません") {
+		t.Errorf("expected error to contain 'gitリポジトリではありません', got: %v", err)
+	}
+}
+
+func TestConfigCmd_PathQueue_WithEnv_PrintsEnvValueJoinedWithQueue(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", workspace)
+
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.queue"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v, stderr: %s", err, errBuf.String())
+	}
+
+	got := strings.TrimRight(outBuf.String(), "\n")
+	want := filepath.Join(workspace, "queue")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestConfigCmd_PathQueue_OutsideGitRepo_ReturnsErrorWithJapaneseMessage(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	// TempDir はgitリポジトリではない
 	dir := t.TempDir()
 	orig, err := os.Getwd()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -161,7 +161,16 @@ vox-actor config <key>
 
 | キー | 返却値 |
 |---|---|
-| `path.queue` | gitリポジトリ直下の `.vox-actor/queue` の絶対パス |
+| `path.workspace` | vox-actor のワークスペースルート絶対パス |
+| `path.queue` | ワークスペースルート配下の `queue` ディレクトリ絶対パス |
+
+**解決順（両キー共通）:**
+
+1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその値をワークスペースルートとして扱う
+2. gitリポジトリ内であれば `git rev-parse --path-format=absolute --git-common-dir` の結果の親ディレクトリ配下の `.vox-actor` をワークスペースルートとする
+3. それ以外は非0終了
+
+`path.queue` はワークスペースルートに `queue` を結合した値を返すため、`path.workspace`/queue = `path.queue` の関係が常に成立します。
 
 **出力:**
 
@@ -175,23 +184,32 @@ vox-actor config <key>
 | 成功 | 0 | — |
 | 未知のキー | 2 (`ErrUsage`) | `unknown key: <key>` とサポートキー一覧 |
 | `git` コマンドがPATH上に無い | 1 | `Error: gitコマンドが見つかりません` |
-| カレントディレクトリがgitリポジトリ外 | 1 | `Error: カレントディレクトリはgitリポジトリではありません` |
+| カレントディレクトリがgitリポジトリ外かつ `VOX_ACTOR_WORKSPACE` 未設定 | 1 | `Error: カレントディレクトリはgitリポジトリではありません` |
 
 **使用例:**
 
 ```bash
 # gitリポジトリ内で実行
+$ cd /path/to/repo && vox-actor config path.workspace
+/path/to/repo/.vox-actor
 $ cd /path/to/repo && vox-actor config path.queue
 /path/to/repo/.vox-actor/queue
+
+# VOX_ACTOR_WORKSPACE 明示
+$ VOX_ACTOR_WORKSPACE=/custom vox-actor config path.workspace
+/custom
+$ VOX_ACTOR_WORKSPACE=/custom vox-actor config path.queue
+/custom/queue
 
 # 未知のキー
 $ vox-actor config path.unknown
 Error: unknown key: path.unknown
 supported keys:
   path.queue
+  path.workspace
 ```
 
-`path.queue` の解決は `git rev-parse --path-format=absolute --git-common-dir` の結果の親ディレクトリに `.vox-actor/queue` を結合したパスを返します。worktree 上で実行しても本体リポジトリ直下のパスが返るため、外部スクリプトから共通のキューディレクトリを参照できます。`config` サブコマンド自体は**パスの返却のみ**を行い、ディレクトリ作成は行いません。
+`config` サブコマンド自体は**パスの返却のみ**を行い、ディレクトリ作成は行いません。worktree 上で実行した場合も本体リポジトリ直下のパスが返るため、外部スクリプトから共通のワークスペースを参照できます。
 
 ## `audio-check` サブコマンド
 

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -152,11 +152,11 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 
 > **前提**: `vox-actor` コマンドのインストールは必須です（両スクリプトは起動時に `command -v vox-actor` で存在確認し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了します）。
 >
-> **ワークスペースの解決順**:
-> 1. `VOX_ACTOR_WORKSPACE` が設定されていればその配下の `queue/` を使う
-> 2. 未設定なら `vox-actor config path.queue` の出力（gitリポジトリ直下の `.vox-actor/queue` の絶対パス）を使う
+> **ワークスペースの解決**: スクリプトは `vox-actor config path.workspace` / `vox-actor config path.queue` を呼ぶだけで、環境変数の分岐は CLI 側が担います。CLI の解決順は以下のとおりです。
+> 1. `VOX_ACTOR_WORKSPACE` が設定されていればその値をワークスペースルートとして使う（queue は `${VOX_ACTOR_WORKSPACE}/queue`）
+> 2. 未設定なら gitリポジトリ直下の `.vox-actor` をワークスペースルートとする（queue は `<repo>/.vox-actor/queue`）
 >
-> git 管理外ディレクトリで `VOX_ACTOR_WORKSPACE` を明示しないまま実行すると `vox-actor config path.queue` が非0終了し、そのエラーがユーザーに表示されてスクリプトも終了します。git 外で利用する場合は `VOX_ACTOR_WORKSPACE` を明示してください。`file` モードでホストとLLM実行環境を分ける場合も、双方から参照可能な共有パスを明示的に指定します。
+> git 管理外ディレクトリで `VOX_ACTOR_WORKSPACE` を明示しないまま実行すると CLI が非0終了し、そのエラーがユーザーに表示されてスクリプトも終了します。git 外で利用する場合は `VOX_ACTOR_WORKSPACE` を明示してください。`file` モードでホストとLLM実行環境を分ける場合も、双方から参照可能な共有パスを明示的に指定します。
 
 モードは `VOX_ACTOR_MONOLOGUE_MODE` 環境変数で明示するか、未設定時は `vox-actor audio-check` の終了コードで自動判定されます（0 → `direct`、非0 → `file`）。
 
@@ -166,10 +166,10 @@ claude code をコンテナ／リモートで動かし、音声デバイスは�
 
 1. **ホスト側で監視プロセスを常駐させる**
    ```bash
-   # vox-actor 関連ファイルのルートディレクトリを指定
+   # vox-actor 関連ファイルのルートディレクトリを指定（vox-actor CLI が VOX_ACTOR_WORKSPACE を解釈する）
    export VOX_ACTOR_WORKSPACE=/path/to/shared/directory
-   # 通知ファイルは $VOX_ACTOR_WORKSPACE/queue/ に配置されるためそこを監視する
-   vox-actor watch "$VOX_ACTOR_WORKSPACE/queue"
+   # 通知ファイルの配置先は vox-actor config path.queue で解決できる
+   vox-actor watch "$(vox-actor config path.queue)"
    ```
 
 2. **claude code 側で `file` モードを明示し、共有ディレクトリを指定する**
@@ -222,7 +222,7 @@ vox-actor act --watch-delete /path/to/watch-dir
 
 ### エラーログ
 
-`direct` モードでの失敗は以下のログに追記されます（いずれも末尾200行でローテーション）。`tail -f` で確認できます。いずれも解決済みワークスペースルート直下に配置されます（`VOX_ACTOR_WORKSPACE` 明示時はその直下、未指定時は `vox-actor config path.queue` の出力の親ディレクトリ直下）。
+`direct` モードでの失敗は以下のログに追記されます（いずれも末尾200行でローテーション）。`tail -f` で確認できます。いずれも `vox-actor config path.workspace` で解決されるワークスペースルート直下に配置されます。
 
 - `monologue` スキル: `<workspace>/monologue-errors.log`
 - `speak` / `talk` スキル: `<workspace>/play-script-errors.log`

--- a/internal/infra/git_workspace.go
+++ b/internal/infra/git_workspace.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -13,15 +14,23 @@ var ErrGitNotFound = errors.New("gitコマンドが見つかりません")
 // ErrNotInGitRepo はカレントディレクトリが git リポジトリ外であることを示すエラー。
 var ErrNotInGitRepo = errors.New("カレントディレクトリはgitリポジトリではありません")
 
+// envWorkspaceKey はワークスペースルートを明示指定するための環境変数名。
+const envWorkspaceKey = "VOX_ACTOR_WORKSPACE"
+
 // gitRunner はテスト差し替え可能な git コマンド実行関数。
 var gitRunner = exec.Command
 
-// ResolveQueuePath は `git rev-parse --path-format=absolute --git-common-dir` の
-// 結果の親ディレクトリに `.vox-actor/queue` を結合したパスを返す。
+// ResolveWorkspacePath は vox-actor のワークスペースルートの絶対パスを返す。
 //
-// worktree 上で実行しても `--git-common-dir` により本体リポジトリ直下の
-// `.vox-actor/queue` が選ばれる。ディレクトリの作成は行わない。
-func ResolveQueuePath() (string, error) {
+// 解決順:
+//  1. 環境変数 VOX_ACTOR_WORKSPACE が設定されていればその値
+//  2. git リポジトリ内であれば `<repoRoot>/.vox-actor`
+//  3. それ以外は ErrNotInGitRepo
+func ResolveWorkspacePath() (string, error) {
+	if v := os.Getenv(envWorkspaceKey); v != "" {
+		return v, nil
+	}
+
 	cmd := gitRunner("git", "rev-parse", "--path-format=absolute", "--git-common-dir")
 	out, err := cmd.Output()
 	if err != nil {
@@ -40,5 +49,17 @@ func ResolveQueuePath() (string, error) {
 	}
 
 	repoRoot := filepath.Dir(gitCommonDir)
-	return filepath.Join(repoRoot, ".vox-actor", "queue"), nil
+	return filepath.Join(repoRoot, ".vox-actor"), nil
+}
+
+// ResolveQueuePath はワークスペースルート配下の queue ディレクトリ絶対パスを返す。
+//
+// 実装は ResolveWorkspacePath の結果に `queue` を結合するだけで、環境変数/git解決は
+// ResolveWorkspacePath に一元化する。ディレクトリの作成は行わない。
+func ResolveQueuePath() (string, error) {
+	workspace, err := ResolveWorkspacePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(workspace, "queue"), nil
 }

--- a/internal/infra/git_workspace_test.go
+++ b/internal/infra/git_workspace_test.go
@@ -19,6 +19,7 @@ func withGitRunner(t *testing.T, runner func(name string, args ...string) *exec.
 }
 
 func TestResolveQueuePath_ReturnsGitCommonDirParentJoinedWithVoxActorQueue(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	repoRoot := t.TempDir()
 	gitCommonDir := filepath.Join(repoRoot, ".git")
 
@@ -38,6 +39,7 @@ func TestResolveQueuePath_ReturnsGitCommonDirParentJoinedWithVoxActorQueue(t *te
 }
 
 func TestResolveQueuePath_ReturnsErrNotInGitRepo_WhenGitCommonDirEmpty(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
 		// 空文字列を標準出力に出すだけのコマンド（=gitリポジトリ外の想定）
 		return exec.Command("true")
@@ -50,6 +52,7 @@ func TestResolveQueuePath_ReturnsErrNotInGitRepo_WhenGitCommonDirEmpty(t *testin
 }
 
 func TestResolveQueuePath_ReturnsErrNotInGitRepo_WhenGitRunnerFailsWithNonZeroExit(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
 		// 非0終了（gitリポジトリ外で git rev-parse した時の挙動を模倣）
 		return exec.Command("false")
@@ -62,6 +65,7 @@ func TestResolveQueuePath_ReturnsErrNotInGitRepo_WhenGitRunnerFailsWithNonZeroEx
 }
 
 func TestResolveQueuePath_ReturnsErrGitNotFound_WhenRunnerReportsCommandMissing(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
 		// PATHに存在しないバイナリを指定することで exec 失敗を再現する。
 		return exec.Command("/nonexistent/definitely-no-such-binary-xyz")
@@ -74,6 +78,7 @@ func TestResolveQueuePath_ReturnsErrGitNotFound_WhenRunnerReportsCommandMissing(
 }
 
 func TestResolveQueuePath_TrimsTrailingWhitespaceFromOutput(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	repoRoot := t.TempDir()
 	gitCommonDir := filepath.Join(repoRoot, ".git")
 
@@ -92,5 +97,97 @@ func TestResolveQueuePath_TrimsTrailingWhitespaceFromOutput(t *testing.T) {
 	}
 	if strings.Contains(got, "\n") {
 		t.Errorf("ResolveQueuePath() should not contain newline: %q", got)
+	}
+}
+
+func TestResolveQueuePath_ReturnsVoxActorWorkspaceQueue_WhenEnvIsSet(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", workspace)
+
+	// gitRunner は呼ばれない想定だが、保険として非0終了するものを設定しておく。
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	})
+
+	got, err := ResolveQueuePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(workspace, "queue")
+	if got != want {
+		t.Errorf("ResolveQueuePath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveWorkspacePath_ReturnsVoxActorWorkspace_WhenEnvIsSet(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", workspace)
+
+	// gitRunner は呼ばれない想定だが、保険として非0終了するものを設定しておく。
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	})
+
+	got, err := ResolveWorkspacePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != workspace {
+		t.Errorf("ResolveWorkspacePath() = %q, want %q", got, workspace)
+	}
+}
+
+func TestResolveWorkspacePath_ReturnsGitCommonDirParentJoinedWithVoxActor(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	repoRoot := t.TempDir()
+	gitCommonDir := filepath.Join(repoRoot, ".git")
+
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("echo", gitCommonDir)
+	})
+
+	got, err := ResolveWorkspacePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(repoRoot, ".vox-actor")
+	if got != want {
+		t.Errorf("ResolveWorkspacePath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveWorkspacePath_ReturnsErrNotInGitRepo_WhenGitCommonDirEmpty(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("true")
+	})
+
+	_, err := ResolveWorkspacePath()
+	if !errors.Is(err, ErrNotInGitRepo) {
+		t.Errorf("expected ErrNotInGitRepo, got: %v", err)
+	}
+}
+
+func TestResolveWorkspacePath_ReturnsErrNotInGitRepo_WhenGitRunnerFailsWithNonZeroExit(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	})
+
+	_, err := ResolveWorkspacePath()
+	if !errors.Is(err, ErrNotInGitRepo) {
+		t.Errorf("expected ErrNotInGitRepo, got: %v", err)
+	}
+}
+
+func TestResolveWorkspacePath_ReturnsErrGitNotFound_WhenRunnerReportsCommandMissing(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("/nonexistent/definitely-no-such-binary-xyz")
+	})
+
+	_, err := ResolveWorkspacePath()
+	if !errors.Is(err, ErrGitNotFound) {
+		t.Errorf("expected ErrGitNotFound, got: %v", err)
 	}
 }

--- a/plugins/vox-actor-plugin/scripts/play-script.sh
+++ b/plugins/vox-actor-plugin/scripts/play-script.sh
@@ -16,12 +16,8 @@ if [ ! -f "$JSONL_PATH" ]; then
   exit 1
 fi
 
-if [ -n "$VOX_ACTOR_WORKSPACE" ]; then
-  QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"
-else
-  QUEUE_DIR=$(vox-actor config path.queue) || exit 1
-fi
-WORKSPACE_DIR="$(dirname "$QUEUE_DIR")"
+QUEUE_DIR=$(vox-actor config path.queue) || exit 1
+WORKSPACE_DIR=$(vox-actor config path.workspace) || exit 1
 
 MODE="${VOX_ACTOR_MONOLOGUE_MODE:-}"
 if [ -z "$MODE" ]; then

--- a/plugins/vox-actor-plugin/skills/monologue/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/monologue/SKILL.md
@@ -73,10 +73,10 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 通知の実行に使用する `${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh` は以下の前提条件を必要とする:
 
 - **`vox-actor` コマンドのインストール必須**: スクリプト冒頭で `command -v vox-actor` を検査し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了する
-- **ワークスペースの解決順**:
-  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその配下の `queue/` を使う
-  2. 未設定なら `vox-actor config path.queue` の出力（gitリポジトリ直下の `.vox-actor/queue` の絶対パス）を使う
-- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと `vox-actor config path.queue` が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
+- **ワークスペースの解決**: スクリプトは `vox-actor config path.queue` / `vox-actor config path.workspace` を呼ぶだけで、環境変数の分岐は CLI 側が担う。CLI の解決順は以下のとおり
+  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその値をワークスペースルートとして使う（queue は `${VOX_ACTOR_WORKSPACE}/queue`）
+  2. 未設定なら gitリポジトリ直下の `.vox-actor` をワークスペースルートとする（queue は `<repo>/.vox-actor/queue`）
+- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと CLI が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
 - **出力先ディレクトリ**: ワークスペースルートおよび配下の `queue/` はスクリプトが必要に応じて自動作成する
 - `monologue-errors.log`（directモードのエラーログ）はワークスペースルート直下に配置される
 
@@ -100,7 +100,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 #### `file` モード
 
-解決された queue ディレクトリ（`VOX_ACTOR_WORKSPACE` 明示時は `${VOX_ACTOR_WORKSPACE}/queue/`、未指定時は `vox-actor config path.queue` の出力先）に通知ファイルを書き出す。ファイル名は `monologue_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする
+`vox-actor config path.queue` で解決された queue ディレクトリに通知ファイルを書き出す。ファイル名は `monologue_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする
 
 ## キャラクター設定ファイルについて
 

--- a/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
+++ b/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
@@ -49,12 +49,8 @@ if [ "$ROLL" -gt "$PROBABILITY" ]; then
   exit 0
 fi
 
-if [ -n "$VOX_ACTOR_WORKSPACE" ]; then
-  QUEUE_DIR="${VOX_ACTOR_WORKSPACE}/queue"
-else
-  QUEUE_DIR=$(vox-actor config path.queue) || exit 1
-fi
-WORKSPACE_DIR="$(dirname "$QUEUE_DIR")"
+QUEUE_DIR=$(vox-actor config path.queue) || exit 1
+WORKSPACE_DIR=$(vox-actor config path.workspace) || exit 1
 
 MODE="${VOX_ACTOR_MONOLOGUE_MODE:-}"
 if [ -z "$MODE" ]; then

--- a/plugins/vox-actor-plugin/skills/speak/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/speak/SKILL.md
@@ -74,10 +74,10 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 再生の実行に使用する `${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh` は以下の前提条件を必要とする:
 
 - **`vox-actor` コマンドのインストール必須**: スクリプト冒頭で `command -v vox-actor` を検査し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了する
-- **ワークスペースの解決順**:
-  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその配下の `queue/` を使う
-  2. 未設定なら `vox-actor config path.queue` の出力（gitリポジトリ直下の `.vox-actor/queue` の絶対パス）を使う
-- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと `vox-actor config path.queue` が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
+- **ワークスペースの解決**: スクリプトは `vox-actor config path.queue` / `vox-actor config path.workspace` を呼ぶだけで、環境変数の分岐は CLI 側が担う。CLI の解決順は以下のとおり
+  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその値をワークスペースルートとして使う（queue は `${VOX_ACTOR_WORKSPACE}/queue`）
+  2. 未設定なら gitリポジトリ直下の `.vox-actor` をワークスペースルートとする（queue は `<repo>/.vox-actor/queue`）
+- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと CLI が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
 - **出力先ディレクトリ**: ワークスペースルートおよび配下の `queue/` は `play-script.sh` が必要に応じて自動作成する。`tmp/` ディレクトリは Claude が Write する前に `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で作成する（`tmp/` 利用時は `VOX_ACTOR_WORKSPACE` の明示が前提）
 - `play-script-errors.log`（directモードのエラーログ）はワークスペースルート直下に配置される
 
@@ -102,7 +102,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 #### `file` モード
 
-一時ファイルを解決された queue ディレクトリ（`VOX_ACTOR_WORKSPACE` 明示時は `${VOX_ACTOR_WORKSPACE}/queue/`、未指定時は `vox-actor config path.queue` の出力先）配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`speak_<ms>.jsonl` なら `queue/speak_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
+一時ファイルを `vox-actor config path.queue` で解決された queue ディレクトリ配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`speak_<ms>.jsonl` なら `queue/speak_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
 
 ## JSONL 出力例
 

--- a/plugins/vox-actor-plugin/skills/talk/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/talk/SKILL.md
@@ -76,10 +76,10 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 再生の実行に使用する `${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh` は以下の前提条件を必要とする:
 
 - **`vox-actor` コマンドのインストール必須**: スクリプト冒頭で `command -v vox-actor` を検査し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了する
-- **ワークスペースの解決順**:
-  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその配下の `queue/` を使う
-  2. 未設定なら `vox-actor config path.queue` の出力（gitリポジトリ直下の `.vox-actor/queue` の絶対パス）を使う
-- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと `vox-actor config path.queue` が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
+- **ワークスペースの解決**: スクリプトは `vox-actor config path.queue` / `vox-actor config path.workspace` を呼ぶだけで、環境変数の分岐は CLI 側が担う。CLI の解決順は以下のとおり
+  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその値をワークスペースルートとして使う（queue は `${VOX_ACTOR_WORKSPACE}/queue`）
+  2. 未設定なら gitリポジトリ直下の `.vox-actor` をワークスペースルートとする（queue は `<repo>/.vox-actor/queue`）
+- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと CLI が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
 - **出力先ディレクトリ**: ワークスペースルートおよび配下の `queue/` は `play-script.sh` が必要に応じて自動作成する。`tmp/` ディレクトリは Claude が Write する前に `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で作成する（`tmp/` 利用時は `VOX_ACTOR_WORKSPACE` の明示が前提）
 - `play-script-errors.log`（directモードのエラーログ）はワークスペースルート直下に配置される
 
@@ -104,7 +104,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 #### `file` モード
 
-一時ファイルを解決された queue ディレクトリ（`VOX_ACTOR_WORKSPACE` 明示時は `${VOX_ACTOR_WORKSPACE}/queue/`、未指定時は `vox-actor config path.queue` の出力先）配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`talk_<ms>.jsonl` なら `queue/talk_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
+一時ファイルを `vox-actor config path.queue` で解決された queue ディレクトリ配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`talk_<ms>.jsonl` なら `queue/talk_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
 
 ## JSONL 出力例
 


### PR DESCRIPTION
## Summary

- `vox-actor config path.workspace` サブコマンドを追加し、`VOX_ACTOR_WORKSPACE` の解釈を `vox-actor` CLI 側1箇所に集約
- `vox-actor config path.queue` も `VOX_ACTOR_WORKSPACE` を解釈するよう変更（以前は未解釈）
- プラグインスクリプト（`play-script.sh` / `monologue.sh`）の `if-else` 分岐と `dirname` 計算を削除し、`vox-actor config` 呼び出しに置き換え
- README・`docs/reference/cli.md` / `docs/reference/plugins.md`・3つの `SKILL.md` の記述を新仕様に更新

## 挙動マトリクス

| シナリオ | path.workspace | path.queue |
|---|---|---|
| `VOX_ACTOR_WORKSPACE=/custom` 明示 | `/custom` | `/custom/queue` |
| git 内 + 環境変数未指定 | `<repo>/.vox-actor` | `<repo>/.vox-actor/queue` |
| git 外 + 環境変数未指定 | 非0終了 | 非0終了 |

`path.workspace`/queue = `path.queue` が常に成立します。

## 後方互換性

- 既存の `VOX_ACTOR_WORKSPACE` 利用シナリオは全て同一結果を返す
- `path.queue` の既存挙動は `VOX_ACTOR_WORKSPACE` 未設定時には完全に維持される

## Test plan

- [x] `go test ./...` が全てパス
- [x] `gofmt -l .` が空
- [x] `golangci-lint run ./...` が 0 issues
- [x] `shellcheck` が `play-script.sh` / `monologue.sh` でパス
- [x] 手動動作確認: git内、`VOX_ACTOR_WORKSPACE` 明示、git外 の3シナリオで期待通り

Closes #246

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
