### PR TITLE
refactor: watchの--git-common-queueを--queueにリネーム #248

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test-e2e:
 	go test -tags=e2e ./test/e2e/...
 
 run-stream:
-	go run . watch --engine-url http://voicevox:50021 --stream --stream-addr 0.0.0.0:8080 --git-common-queue
+	go run . watch --engine-url http://voicevox:50021 --stream --stream-addr 0.0.0.0:8080 --queue
 
 install:
 	go install .

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -27,7 +27,7 @@ type WatchDeps struct {
 	// マップが空でも factory はエラーにせず player を返してよい（フォールバック表示が使われる）。
 	// client はブラウザ側の /test-clip エンドポイントから音声合成を呼ぶために渡す。
 	StreamPlayerFactory func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, client app.VoicevoxClient) (app.StreamPlayer, error)
-	// QueuePathResolver は --git-common-queue 指定時に監視対象パスを解決する関数。
+	// QueuePathResolver は --queue 指定時に監視対象パスを解決する関数。
 	// nil の場合は infra.ResolveQueuePath がデフォルトで使われる。
 	QueuePathResolver func() (string, error)
 }
@@ -37,7 +37,7 @@ func makeWatchCmd(deps *WatchDeps) *cobra.Command {
 		Use:   "watch <dir1> [<dir2> ...]",
 		Short: "複数ディレクトリを監視してテキストファイルを読み上げる",
 		Long:  "1つ以上のディレクトリを並列監視し、検知したファイルを順次読み上げる。",
-		// 位置引数と --git-common-queue の排他・片方必須は RunE 側で検証する。
+		// 位置引数と --queue の排他・片方必須は RunE 側で検証する。
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runWatch(cmd, args, deps)
@@ -48,23 +48,23 @@ func makeWatchCmd(deps *WatchDeps) *cobra.Command {
 	cmd.Flags().Bool("delete", false, "処理済みファイルを削除する（未指定時は各ディレクトリの done/ に移動）")
 	cmd.Flags().Bool("stream", false, "HTTPサーバーを起動し、SSE経由でブラウザに音声配信する")
 	cmd.Flags().String("stream-addr", "127.0.0.1:8080", "ストリーム配信用のバインドアドレス")
-	cmd.Flags().Bool("git-common-queue", false, "gitリポジトリ直下の .vox-actor/queue を監視対象に自動選択する（位置引数と併用不可、起動時に自動作成）")
+	cmd.Flags().Bool("queue", false, "vox-actor config path.queue で解決される queue ディレクトリを監視対象に自動選択する（位置引数と併用不可、起動時に自動作成）")
 
 	return cmd
 }
 
 // resolveWatchPaths は watch の監視対象パスを確定する。
-// --git-common-queue が指定されていればキュー解決・自動作成を行い、
+// --queue が指定されていればキュー解決・自動作成を行い、
 // それ以外は与えられた位置引数をそのまま返す。
-func resolveWatchPaths(args []string, useGitCommonQueue bool, deps *WatchDeps) ([]string, error) {
+func resolveWatchPaths(args []string, useQueue bool, deps *WatchDeps) ([]string, error) {
 	switch {
-	case useGitCommonQueue && len(args) > 0:
-		return nil, fmt.Errorf("%w: --git-common-queue と位置引数は併用できません", ErrUsage)
-	case !useGitCommonQueue && len(args) == 0:
+	case useQueue && len(args) > 0:
+		return nil, fmt.Errorf("%w: --queue と位置引数は併用できません", ErrUsage)
+	case !useQueue && len(args) == 0:
 		return nil, fmt.Errorf("%w: requires at least 1 arg(s), only received 0", ErrUsage)
 	}
 
-	if !useGitCommonQueue {
+	if !useQueue {
 		return args, nil
 	}
 
@@ -83,9 +83,9 @@ func resolveWatchPaths(args []string, useGitCommonQueue bool, deps *WatchDeps) (
 }
 
 func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
-	useGitCommonQueue, _ := cmd.Flags().GetBool("git-common-queue")
+	useQueue, _ := cmd.Flags().GetBool("queue")
 
-	args, err := resolveWatchPaths(args, useGitCommonQueue, deps)
+	args, err := resolveWatchPaths(args, useQueue, deps)
 	if err != nil {
 		return err
 	}

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -374,11 +374,11 @@ func TestWatchCmd_EnvVarVOXSpeaker(t *testing.T) {
 	}
 }
 
-// --- #239 --git-common-queue オプション ---
+// --- #239 --queue オプション ---
 
-// makeGitCommonQueueWatchDeps は --git-common-queue のテストで共通利用する WatchDeps を組み立てる。
+// makeQueueWatchDeps は --queue のテストで共通利用する WatchDeps を組み立てる。
 // resolver は呼び出された回数と返却パスを captured を通じて観測できる。
-func makeGitCommonQueueWatchDeps(resolver func() (string, error)) *Deps {
+func makeQueueWatchDeps(resolver func() (string, error)) *Deps {
 	return &Deps{
 		Watch: &WatchDeps{
 			Reader:            stubScriptReader{},
@@ -391,12 +391,12 @@ func makeGitCommonQueueWatchDeps(resolver func() (string, error)) *Deps {
 	}
 }
 
-func TestWatchCmd_GitCommonQueue_ResolvesAndCreatesQueueDir(t *testing.T) {
+func TestWatchCmd_Queue_ResolvesAndCreatesQueueDir(t *testing.T) {
 	baseDir := t.TempDir()
 	queueDir := baseDir + "/.vox-actor/queue"
 
 	resolverCalled := 0
-	deps := makeGitCommonQueueWatchDeps(func() (string, error) {
+	deps := makeQueueWatchDeps(func() (string, error) {
 		resolverCalled++
 		return queueDir, nil
 	})
@@ -408,7 +408,7 @@ func TestWatchCmd_GitCommonQueue_ResolvesAndCreatesQueueDir(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	rootCmd.SetContext(ctx)
-	rootCmd.SetArgs([]string{"watch", "--git-common-queue"})
+	rootCmd.SetArgs([]string{"watch", "--queue"})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -426,9 +426,9 @@ func TestWatchCmd_GitCommonQueue_ResolvesAndCreatesQueueDir(t *testing.T) {
 	}
 }
 
-func TestWatchCmd_GitCommonQueue_WithPositionalArg_ReturnsUsageError(t *testing.T) {
+func TestWatchCmd_Queue_WithPositionalArg_ReturnsUsageError(t *testing.T) {
 	dir := t.TempDir()
-	deps := makeGitCommonQueueWatchDeps(func() (string, error) {
+	deps := makeQueueWatchDeps(func() (string, error) {
 		t.Error("resolver should not be called when usage error occurs")
 		return "", nil
 	})
@@ -437,21 +437,21 @@ func TestWatchCmd_GitCommonQueue_WithPositionalArg_ReturnsUsageError(t *testing.
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"watch", "--git-common-queue", dir})
+	rootCmd.SetArgs([]string{"watch", "--queue", dir})
 
 	err := rootCmd.Execute()
 	if err == nil {
-		t.Fatal("expected error when --git-common-queue is combined with a positional arg")
+		t.Fatal("expected error when --queue is combined with a positional arg")
 	}
 	if !errors.Is(err, ErrUsage) {
 		t.Errorf("expected ErrUsage, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "--git-common-queue") {
-		t.Errorf("expected error to mention --git-common-queue, got: %v", err)
+	if !strings.Contains(err.Error(), "--queue") {
+		t.Errorf("expected error to mention --queue, got: %v", err)
 	}
 }
 
-func TestWatchCmd_NoArgsAndNoGitCommonQueue_ReturnsUsageError(t *testing.T) {
+func TestWatchCmd_NoArgsAndNoQueue_ReturnsUsageError(t *testing.T) {
 	rootCmd := makeRootCmd()
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -460,15 +460,15 @@ func TestWatchCmd_NoArgsAndNoGitCommonQueue_ReturnsUsageError(t *testing.T) {
 
 	err := rootCmd.Execute()
 	if err == nil {
-		t.Fatal("expected error when neither args nor --git-common-queue is given")
+		t.Fatal("expected error when neither args nor --queue is given")
 	}
 	if !errors.Is(err, ErrUsage) {
 		t.Errorf("expected ErrUsage, got: %v", err)
 	}
 }
 
-func TestWatchCmd_GitCommonQueue_ResolverReturnsNotInRepo_ReturnsError(t *testing.T) {
-	deps := makeGitCommonQueueWatchDeps(func() (string, error) {
+func TestWatchCmd_Queue_ResolverReturnsNotInRepo_ReturnsError(t *testing.T) {
+	deps := makeQueueWatchDeps(func() (string, error) {
 		return "", infra.ErrNotInGitRepo
 	})
 
@@ -476,7 +476,7 @@ func TestWatchCmd_GitCommonQueue_ResolverReturnsNotInRepo_ReturnsError(t *testin
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"watch", "--git-common-queue"})
+	rootCmd.SetArgs([]string{"watch", "--queue"})
 
 	err := rootCmd.Execute()
 	if err == nil {
@@ -487,8 +487,8 @@ func TestWatchCmd_GitCommonQueue_ResolverReturnsNotInRepo_ReturnsError(t *testin
 	}
 }
 
-func TestWatchCmd_GitCommonQueue_ResolverReturnsGitNotFound_ReturnsError(t *testing.T) {
-	deps := makeGitCommonQueueWatchDeps(func() (string, error) {
+func TestWatchCmd_Queue_ResolverReturnsGitNotFound_ReturnsError(t *testing.T) {
+	deps := makeQueueWatchDeps(func() (string, error) {
 		return "", infra.ErrGitNotFound
 	})
 
@@ -496,7 +496,7 @@ func TestWatchCmd_GitCommonQueue_ResolverReturnsGitNotFound_ReturnsError(t *test
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"watch", "--git-common-queue"})
+	rootCmd.SetArgs([]string{"watch", "--queue"})
 
 	err := rootCmd.Execute()
 	if err == nil {
@@ -507,7 +507,7 @@ func TestWatchCmd_GitCommonQueue_ResolverReturnsGitNotFound_ReturnsError(t *test
 	}
 }
 
-func TestWatchCmd_HelpContainsGitCommonQueueFlag(t *testing.T) {
+func TestWatchCmd_HelpContainsQueueFlag(t *testing.T) {
 	rootCmd := makeRootCmd()
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -516,7 +516,7 @@ func TestWatchCmd_HelpContainsGitCommonQueueFlag(t *testing.T) {
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("expected no error for --help, got: %v", err)
 	}
-	if !strings.Contains(buf.String(), "--git-common-queue") {
-		t.Errorf("expected help output to contain '--git-common-queue'")
+	if !strings.Contains(buf.String(), "--queue") {
+		t.Errorf("expected help output to contain '--queue'")
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -109,7 +109,7 @@ vox-actor act <path>
 
 ```
 vox-actor watch <dir1> [<dir2> ...]
-vox-actor watch --git-common-queue
+vox-actor watch --queue
 ```
 
 1つ以上のディレクトリを並列監視し、配置されたファイルを検知順に逐次再生する。
@@ -124,29 +124,29 @@ vox-actor watch --git-common-queue
 | `--delete` | — | `false` | 処理済みファイルを削除（未指定時は各ディレクトリの `done/` に移動） |
 | `--stream` | — | `false` | HTTPサーバーを起動し、SSE経由でブラウザに音声を配信（[詳細](#ストリーム配信モード)） |
 | `--stream-addr` | — | `127.0.0.1:8080` | ストリーム配信用のバインドアドレス |
-| `--git-common-queue` | — | `false` | gitリポジトリ直下の `.vox-actor/queue` を監視対象に自動選択（[詳細](#git-common-queueオプション)） |
+| `--queue` | — | `false` | `vox-actor config path.queue` で解決される queue ディレクトリを監視対象に自動選択（[詳細](#queueオプション)） |
 | `--verbose` | — | `false` | 詳細ログを出力 |
 | `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#dry-runモード)） |
 
-### `--git-common-queue`オプション
+### `--queue`オプション
 
-`vox-actor watch --git-common-queue` を指定すると、`vox-actor config path.queue` と同じロジックで解決される「gitリポジトリ直下の `.vox-actor/queue`」を監視対象として自動選択します。
+`vox-actor watch --queue` を指定すると、`vox-actor config path.queue` と同じロジックで解決される queue ディレクトリを監視対象として自動選択します。
 
 - 位置引数（ディレクトリパス）との**併用はエラー**になります。
-- カレントディレクトリがgitリポジトリ外、または `git` コマンドがPATH上に無い場合は起動時にエラー終了します。
-- `.vox-actor/queue` が存在しない場合は起動時に自動作成されます（`os.MkdirAll(..., 0o755)`）。
+- `VOX_ACTOR_WORKSPACE` 未設定かつカレントディレクトリがgitリポジトリ外、または `git` コマンドがPATH上に無い場合は起動時にエラー終了します。
+- queue ディレクトリが存在しない場合は起動時に自動作成されます（`os.MkdirAll(..., 0o755)`）。
 - worktree 上で実行した場合でも、`git rev-parse --git-common-dir` で本体リポジトリの `.git` を参照するため、**本体リポジトリ直下**の `.vox-actor/queue` が選ばれます。
 - `--delete` / `--stream` / `--stream-addr` / `--dry-run` などの既存オプションとは自由に併用できます。
 
 ```bash
-# gitリポジトリ直下の .vox-actor/queue を監視（done/ 移動モード）
-vox-actor watch --git-common-queue
+# config path.queue で解決される queue ディレクトリを監視（done/ 移動モード）
+vox-actor watch --queue
 
 # 削除モードで監視
-vox-actor watch --git-common-queue --delete
+vox-actor watch --queue --delete
 
 # ストリーム配信モード
-vox-actor watch --git-common-queue --stream
+vox-actor watch --queue --stream
 ```
 
 ## `config` サブコマンド


### PR DESCRIPTION
## Summary

- #246 の完了を受けて、watch サブコマンドの `--git-common-queue` を `--queue` にリネーム
- 実態が「`vox-actor config path.queue` で解決される queue ディレクトリを使う」であることに合わせ、`VOX_ACTOR_WORKSPACE` 指定時にも違和感のない名前にした
- 後方互換エイリアスは残さず即時置換（対象フラグは未リリース）

## 変更内容

- `cmd/watch.go`: フラグ登録・`GetBool` キー・変数名・エラーメッセージ・コメントを `--queue` / `useQueue` に更新
- `cmd/watch_test.go`: テスト関数名（`TestWatchCmd_Queue_*`, `TestWatchCmd_HelpContainsQueueFlag`, `TestWatchCmd_NoArgsAndNoQueue_*`）、ヘルパー名 `makeQueueWatchDeps`、`SetArgs` の `--git-common-queue` を `--queue` に更新
- `docs/reference/cli.md`: 使用例・オプション表・節タイトル・アンカーを更新。`VOX_ACTOR_WORKSPACE` 明示時の挙動も反映
- `Makefile`: `run-stream` ターゲットのフラグを更新

## Test plan

- [x] `go build ./...` 成功
- [x] `go test ./...` 全パス
- [x] `golangci-lint run ./...` 0 issues
- [x] `gofmt -l .` 出力なし
- [x] `vox-actor watch --help` に `--queue` が表示される
- [x] `vox-actor watch --git-common-queue` が unknown flag エラーになる
- [x] `grep -rln "git-common-queue"` で0件

Closes #248

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
