### PR TITLE
feat: watch監視ディレクトリ削除時の自動再作成とwarnログ化 #250

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -16,7 +17,7 @@ type ActDeps struct {
 	ClientFactory     func(engineURL string) app.VoicevoxClient
 	Player            app.AudioPlayer
 	Mover             app.FileMover
-	DirWatcherFactory func() app.DirWatcher
+	DirWatcherFactory func(logger *slog.Logger) app.DirWatcher
 }
 
 func makeActCmd(deps *ActDeps) *cobra.Command {
@@ -90,7 +91,7 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 		if deps.Mover == nil || deps.DirWatcherFactory == nil {
 			return fmt.Errorf("watch mode dependencies are not initialized")
 		}
-		watcher := deps.DirWatcherFactory()
+		watcher := deps.DirWatcherFactory(logger)
 		opts := []app.WatchOption{app.WithWatchLogger(logger)}
 		if watchDelete {
 			opts = append(opts, app.WithDeleteMode())

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -21,7 +21,7 @@ type WatchDeps struct {
 	ClientFactory     func(engineURL string) app.VoicevoxClient
 	Player            app.AudioPlayer
 	Mover             app.FileMover
-	DirWatcherFactory func() app.DirWatcher
+	DirWatcherFactory func(logger *slog.Logger) app.DirWatcher
 	// StreamPlayerFactory は --stream 指定時にストリーム配信用の AudioPlayer を生成する。
 	// speakerLookup は /speakers 取得結果から構築されたマップで、配信時に話者名/スタイル名を解決する。
 	// マップが空でも factory はエラーにせず player を返してよい（フォールバック表示が使われる）。
@@ -164,7 +164,7 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 		player = sp
 	}
 
-	watcher := deps.DirWatcherFactory()
+	watcher := deps.DirWatcherFactory(logger)
 	opts := []app.WatchOption{app.WithWatchLogger(logger)}
 	if deleteMode {
 		opts = append(opts, app.WithDeleteMode())

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -274,7 +274,7 @@ func TestWatchCmd_Stream_GetSpeakersFailure_ReturnsError(t *testing.T) {
 			ClientFactory:     func(_ string) app.VoicevoxClient { return stubClient },
 			Player:            stubAudioPlayer{},
 			Mover:             stubFileMover{},
-			DirWatcherFactory: func() app.DirWatcher { return stubDirWatcher{} },
+			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
 			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				t.Error("StreamPlayerFactory should not be called when GetSpeakers fails")
 				return stubStreamPlayer{}, nil
@@ -315,7 +315,7 @@ func TestWatchCmd_Stream_PassesSpeakerLookupToFactory(t *testing.T) {
 			ClientFactory:     func(_ string) app.VoicevoxClient { return stubClient },
 			Player:            stubAudioPlayer{},
 			Mover:             stubFileMover{},
-			DirWatcherFactory: func() app.DirWatcher { return stubDirWatcher{} },
+			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
 			StreamPlayerFactory: func(_ string, _ *slog.Logger, lookup map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				captured = lookup
 				// usecase.Run まで進ませず、watch loop から確実に抜けるためにキャンセルを返す。
@@ -385,7 +385,7 @@ func makeQueueWatchDeps(resolver func() (string, error)) *Deps {
 			ClientFactory:     func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
 			Player:            stubAudioPlayer{},
 			Mover:             stubFileMover{},
-			DirWatcherFactory: func() app.DirWatcher { return stubDirWatcher{} },
+			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
 			QueuePathResolver: resolver,
 		},
 	}

--- a/internal/infra/dir_watcher.go
+++ b/internal/infra/dir_watcher.go
@@ -107,9 +107,7 @@ func (w *PollingDirWatcher) Watch(ctx context.Context, dir string) (<-chan strin
 }
 
 // handleListError は listFiles のエラーを処理する。
-// ENOENTの場合はディレクトリを自動再作成し、成功時はwarnログを出す。
-// ENOENT以外、または再作成失敗時は errCh にエラーを送る。
-// ctx.Done() でループを終了すべき場合は false を返す。
+// 戻り値 false は ctx.Done() によりループを終了すべきことを示す。
 func (w *PollingDirWatcher) handleListError(ctx context.Context, dir string, err error, errCh chan<- error) bool {
 	if errors.Is(err, fs.ErrNotExist) {
 		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {

--- a/internal/infra/dir_watcher.go
+++ b/internal/infra/dir_watcher.go
@@ -2,6 +2,9 @@ package infra
 
 import (
 	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -16,17 +19,39 @@ const PollInterval = 1 * time.Second
 // PollingDirWatcher はポーリングベースのディレクトリウォッチャー。
 type PollingDirWatcher struct {
 	interval time.Duration
+	logger   *slog.Logger
 }
 
 var _ app.DirWatcher = (*PollingDirWatcher)(nil)
 
+// PollingDirWatcherOption は PollingDirWatcher の生成時に指定するオプション。
+type PollingDirWatcherOption func(*PollingDirWatcher)
+
+// WithPollingDirWatcherLogger はロガーを設定するオプション。
+// 指定しない場合はログを破棄する。
+func WithPollingDirWatcherLogger(logger *slog.Logger) PollingDirWatcherOption {
+	return func(w *PollingDirWatcher) {
+		if logger != nil {
+			w.logger = logger
+		}
+	}
+}
+
 // NewPollingDirWatcher はPollingDirWatcherを生成する。
-func NewPollingDirWatcher(interval time.Duration) *PollingDirWatcher {
-	return &PollingDirWatcher{interval: interval}
+func NewPollingDirWatcher(interval time.Duration, opts ...PollingDirWatcherOption) *PollingDirWatcher {
+	w := &PollingDirWatcher{
+		interval: interval,
+		logger:   slog.New(slog.DiscardHandler),
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w
 }
 
 // Watch はディレクトリを監視し、新規ファイルのパスをチャネルで返す。
 // 既知のファイル（done/含む）を除外し、辞書順で通知する。
+// 監視中にディレクトリが削除された場合は自動再作成して監視を継続する。
 // コンテキストがキャンセルされると監視を停止してチャネルをクローズする。
 func (w *PollingDirWatcher) Watch(ctx context.Context, dir string) (<-chan string, <-chan error) {
 	fileCh := make(chan string)
@@ -41,9 +66,7 @@ func (w *PollingDirWatcher) Watch(ctx context.Context, dir string) (<-chan strin
 		for {
 			files, err := w.listFiles(dir)
 			if err != nil {
-				select {
-				case errCh <- err:
-				case <-ctx.Done():
+				if handled := w.handleListError(ctx, dir, err, errCh); !handled {
 					return
 				}
 				continue
@@ -81,6 +104,31 @@ func (w *PollingDirWatcher) Watch(ctx context.Context, dir string) (<-chan strin
 	}()
 
 	return fileCh, errCh
+}
+
+// handleListError は listFiles のエラーを処理する。
+// ENOENTの場合はディレクトリを自動再作成し、成功時はwarnログを出す。
+// ENOENT以外、または再作成失敗時は errCh にエラーを送る。
+// ctx.Done() でループを終了すべき場合は false を返す。
+func (w *PollingDirWatcher) handleListError(ctx context.Context, dir string, err error, errCh chan<- error) bool {
+	if errors.Is(err, fs.ErrNotExist) {
+		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+			return sendErr(ctx, errCh, mkErr)
+		}
+		w.logger.Warn("watch directory was recreated", "path", dir)
+		return true
+	}
+	return sendErr(ctx, errCh, err)
+}
+
+// sendErr は errCh にエラーを送信する。ctx.Done() が先に発生したら false を返す。
+func sendErr(ctx context.Context, errCh chan<- error, err error) bool {
+	select {
+	case errCh <- err:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // listFiles はディレクトリ内のファイルを辞書順でリストする。

--- a/internal/infra/dir_watcher_test.go
+++ b/internal/infra/dir_watcher_test.go
@@ -322,6 +322,51 @@ func TestPollingDirWatcher_NonENOENTErrorGoesToErrCh(t *testing.T) {
 	}
 }
 
+func TestPollingDirWatcher_MultipleDirsIndependentOnOneDeleted(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	watcher := infra.NewPollingDirWatcher(
+		50*time.Millisecond,
+		infra.WithPollingDirWatcherLogger(logger),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, errCh1 := watcher.Watch(ctx, dir1)
+	fileCh2, errCh2 := watcher.Watch(ctx, dir2)
+
+	// dir1 のみ削除
+	if err := os.RemoveAll(dir1); err != nil {
+		t.Fatal(err)
+	}
+
+	// dir2 に新規ファイルを置くと検知される（dir1削除の影響を受けない）
+	if err := os.WriteFile(filepath.Join(dir2, "x.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case f := <-fileCh2:
+		if filepath.Base(f) != "x.txt" {
+			t.Errorf("expected x.txt, got %s", filepath.Base(f))
+		}
+	case e := <-errCh2:
+		t.Fatalf("unexpected error on dir2 errCh: %v", e)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for dir2 detection")
+	}
+
+	// dir1 側は errCh にエラーが流れていないこと（再作成成功している）
+	select {
+	case e := <-errCh1:
+		t.Errorf("unexpected error on dir1 errCh: %v", e)
+	default:
+	}
+}
+
 func TestPollingDirWatcher_StopsOnContextCancel(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/infra/dir_watcher_test.go
+++ b/internal/infra/dir_watcher_test.go
@@ -322,16 +322,6 @@ func TestPollingDirWatcher_NonENOENTErrorGoesToErrCh(t *testing.T) {
 	}
 }
 
-func collectLogLines(logs, needle string) []string {
-	var matched []string
-	for _, line := range strings.Split(strings.TrimRight(logs, "\n"), "\n") {
-		if strings.Contains(line, needle) {
-			matched = append(matched, line)
-		}
-	}
-	return matched
-}
-
 func TestPollingDirWatcher_StopsOnContextCancel(t *testing.T) {
 	dir := t.TempDir()
 
@@ -360,4 +350,14 @@ func TestPollingDirWatcher_StopsOnContextCancel(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout: channel should be closed after context cancel")
 	}
+}
+
+func collectLogLines(logs, needle string) []string {
+	var matched []string
+	for _, line := range strings.Split(strings.TrimRight(logs, "\n"), "\n") {
+		if strings.Contains(line, needle) {
+			matched = append(matched, line)
+		}
+	}
+	return matched
 }

--- a/internal/infra/dir_watcher_test.go
+++ b/internal/infra/dir_watcher_test.go
@@ -1,9 +1,14 @@
 package infra_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -183,6 +188,148 @@ func TestPollingDirWatcher_RedetectsFileAfterRemovalAndReplacement(t *testing.T)
 	case <-ctx.Done():
 		t.Fatal("timeout waiting for re-detection of replaced file")
 	}
+}
+
+func TestPollingDirWatcher_RecreatesMissingDirectory(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "watched")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	watcher := infra.NewPollingDirWatcher(
+		50*time.Millisecond,
+		infra.WithPollingDirWatcherLogger(logger),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	fileCh, errCh := watcher.Watch(ctx, dir)
+
+	// 監視ディレクトリを削除
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// 自動再作成されるのを待つ
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		info, err := os.Stat(dir)
+		if err == nil && info.IsDir() {
+			break
+		}
+		select {
+		case e := <-errCh:
+			t.Fatalf("unexpected error from errCh: %v", e)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("directory was not recreated: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("recreated path is not a directory")
+	}
+
+	// 再作成されたディレクトリに新規ファイルを置くと検知される
+	newFile := filepath.Join(dir, "after.txt")
+	if err := os.WriteFile(newFile, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case f := <-fileCh:
+		if filepath.Base(f) != "after.txt" {
+			t.Errorf("expected after.txt, got %s", filepath.Base(f))
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for re-detection after recreation")
+	}
+
+	// warn ログが1回だけ出ていることを確認
+	warnLines := collectLogLines(buf.String(), "watch directory was recreated")
+	if len(warnLines) != 1 {
+		t.Errorf("expected 1 warn log for recreation, got %d: %s", len(warnLines), buf.String())
+	} else if !strings.Contains(warnLines[0], "level=WARN") {
+		t.Errorf("expected WARN level log, got: %s", warnLines[0])
+	}
+}
+
+func TestPollingDirWatcher_RecreateFailureGoesToErrCh(t *testing.T) {
+	parent := t.TempDir()
+
+	// 親パスをファイルにすることで、その配下のディレクトリ再作成を失敗させる
+	fileAsParent := filepath.Join(parent, "file")
+	if err := os.WriteFile(fileAsParent, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// "file/watched" は親がファイルなのでMkdirAllが失敗する
+	dir := filepath.Join(fileAsParent, "watched")
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	watcher := infra.NewPollingDirWatcher(
+		50*time.Millisecond,
+		infra.WithPollingDirWatcherLogger(logger),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, errCh := watcher.Watch(ctx, dir)
+
+	// 再作成失敗のエラーがerrChに流れることを確認
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for error on recreate failure")
+	}
+}
+
+func TestPollingDirWatcher_NonENOENTErrorGoesToErrCh(t *testing.T) {
+	parent := t.TempDir()
+
+	// 監視対象をファイル（ディレクトリではない）にする
+	// os.ReadDir は ENOTDIR を返し、ENOENTではないため従来通りerrChに流れる
+	notADir := filepath.Join(parent, "not-a-dir.txt")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	watcher := infra.NewPollingDirWatcher(50 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, errCh := watcher.Watch(ctx, notADir)
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+		if errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("expected non-ENOENT error, got ENOENT-equivalent: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for error")
+	}
+}
+
+func collectLogLines(logs, needle string) []string {
+	var matched []string
+	for _, line := range strings.Split(strings.TrimRight(logs, "\n"), "\n") {
+		if strings.Contains(line, needle) {
+			matched = append(matched, line)
+		}
+	}
+	return matched
 }
 
 func TestPollingDirWatcher_StopsOnContextCancel(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -23,8 +23,11 @@ func main() {
 		return infra.NewRetryableVoicevoxClient(infra.NewVoicevoxClient(engineURL))
 	}
 
-	dirWatcherFactory := func() app.DirWatcher {
-		return infra.NewPollingDirWatcher(infra.PollInterval)
+	dirWatcherFactory := func(logger *slog.Logger) app.DirWatcher {
+		return infra.NewPollingDirWatcher(
+			infra.PollInterval,
+			infra.WithPollingDirWatcherLogger(logger),
+		)
 	}
 
 	reader := infra.NewFileReader()


### PR DESCRIPTION
## Summary

- `vox-actor watch` の監視中に対象ディレクトリが `rm -rf` 等で削除された際、連続するerrorログ出力を止め、自動でディレクトリを再作成して監視を継続するよう修正
- 再作成成功時は warn ログを1回だけ出力（`watch directory was recreated`）
- `PollingDirWatcher` に `slog.Logger` を注入できる Option (`WithPollingDirWatcherLogger`) を追加し、`HTTPStreamPlayer` と同じ Option パターンで統一
- `DirWatcherFactory` の signature に `*slog.Logger` を追加し、`main.go` / `cmd` / 既存テストから伝搬
- ENOENT 以外のエラーや再作成失敗時は従来通り errCh 経由で error ログを出力（挙動互換）

## 変更ファイル

- `internal/infra/dir_watcher.go`: ENOENT 自動再作成ロジック、logger オプション、`handleListError` / `sendErr` ヘルパー
- `internal/infra/dir_watcher_test.go`: 再作成成功 / 再作成失敗 / 非ENOENTエラー / 複数ディレクトリ独立性のテストを追加
- `cmd/act.go` / `cmd/watch.go` / `cmd/watch_test.go` / `main.go`: `DirWatcherFactory` signature 変更

## Test plan

- [x] `make test` 通過
- [x] `gofmt -l .` 出力なし
- [x] `golangci-lint run` 指摘なし
- [x] `TestPollingDirWatcher_RecreatesMissingDirectory`: 削除→自動再作成→新規ファイル検知
- [x] `TestPollingDirWatcher_RecreateFailureGoesToErrCh`: MkdirAll 失敗時 errCh にエラー
- [x] `TestPollingDirWatcher_NonENOENTErrorGoesToErrCh`: ENOENT以外は従来通り errCh
- [x] `TestPollingDirWatcher_MultipleDirsIndependentOnOneDeleted`: 複数監視中1つだけ削除されても他は影響を受けない

Closes #250

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
