### PR TITLE
test: ルート/CLI共通の e2e テストを追加 #253

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -28,13 +30,68 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// versionLineRegexp は `--version` の出力に1行だけ現れる `vox-actor version <文字列>` 形式を検査する。
+var versionLineRegexp = regexp.MustCompile(`(?m)^vox-actor version \S+`)
+
 func TestCLIVersion(t *testing.T) {
-	cmd := exec.Command(binaryPath, "--version")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("failed to run CLI: %v\n%s", err, out)
+	stdout, stderr, exitCode := runCLI(t, nil, "--version")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
 	}
-	if len(out) == 0 {
-		t.Fatal("expected version output, got empty")
+
+	matches := versionLineRegexp.FindAllString(stdout, -1)
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly 1 line matching %q in stdout, got %d\nstdout:\n%s",
+			versionLineRegexp.String(), len(matches), stdout)
+	}
+}
+
+func TestCLIHelp_ListsSubcommands(t *testing.T) {
+	stdout, stderr, exitCode := runCLI(t, nil, "--help")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	wants := []string{"say", "act", "watch", "config", "audio-check"}
+	for _, w := range wants {
+		if !strings.Contains(stdout, w) {
+			t.Errorf("expected help output to contain subcommand %q\nstdout:\n%s", w, stdout)
+		}
+	}
+}
+
+func TestCLINoArgs_ShowsHelp(t *testing.T) {
+	stdout, stderr, exitCode := runCLI(t, nil)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	if !strings.Contains(stdout, "vox-actor") {
+		t.Errorf("expected help output to contain 'vox-actor'\nstdout:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "Usage:") {
+		t.Errorf("expected help output to contain 'Usage:'\nstdout:\n%s", stdout)
+	}
+}
+
+func TestCLIUnknownSubcommand_NonZeroWithStderr(t *testing.T) {
+	_, stderr, exitCode := runCLI(t, nil, "unknown-cmd")
+
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for unknown subcommand, got 0")
+	}
+	if strings.TrimSpace(stderr) == "" {
+		t.Errorf("expected non-empty stderr for unknown subcommand")
+	}
+}
+
+func TestCLIUnknownFlag_NonZero(t *testing.T) {
+	_, _, exitCode := runCLI(t, nil, "--no-such-flag")
+
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for unknown flag, got 0")
 	}
 }

--- a/test/e2e/helper_test.go
+++ b/test/e2e/helper_test.go
@@ -1,0 +1,47 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// runCLI はビルド済みの vox-actor バイナリを指定の引数・環境変数で実行し、
+// stdout / stderr / 終了コードを返す。
+//
+// env に指定したキーは現在のプロセスの環境変数に上書きされる形で渡される。
+// env が nil または空の場合は現在の環境変数をそのまま引き継ぐ。
+// 呼び出し側は終了コード以外の失敗（バイナリが見つからない等）に対しては
+// t.Fatalf で停止する想定。
+func runCLI(t *testing.T, env map[string]string, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+
+	cmd := exec.Command(binaryPath, args...)
+	if len(env) > 0 {
+		base := os.Environ()
+		for k, v := range env {
+			base = append(base, k+"="+v)
+		}
+		cmd.Env = base
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err := cmd.Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("failed to run CLI: %v\nstdout:\n%s\nstderr:\n%s",
+				err, stdoutBuf.String(), stderrBuf.String())
+		}
+		exitCode = exitErr.ExitCode()
+	}
+
+	return stdoutBuf.String(), stderrBuf.String(), exitCode
+}


### PR DESCRIPTION
## Summary

`vox-actor` CLI のルート部分の挙動を、音声デバイス・VOICEVOX エンジン不要で検証する e2e テストを追加しました。
後続のサブコマンド別 e2e Issue で再利用する共通ヘルパー `runCLI` も整備しています。

## 追加内容

- `test/e2e/helper_test.go` に共通ヘルパー `runCLI(t, env, args...) (stdout, stderr, exitCode)` を新設
- `test/e2e/e2e_test.go` に以下のケースを追加
  - `--version`: 終了コード 0 / `vox-actor version <文字列>` 形式の1行出力
  - `--help`: 終了コード 0 / `say` / `act` / `watch` / `config` / `audio-check` が列挙される
  - 無引数: ヘルプ表示 + 終了コード 0
  - 未知サブコマンド (`unknown-cmd`): 非 0 終了 + stderr にエラーメッセージ
  - 未知フラグ (`--no-such-flag`): 非 0 終了
- 既存 `TestCLIVersion` を `runCLI` ベース + 正規表現検証に書き換え

## 検証

- `make test-e2e` で全5ケース成功
- `gofmt -l .` 差分なし、`golangci-lint run` 0 issues
- 既存 `go test ./...` への影響なし

## Test plan

- [x] `make test-e2e` がローカルで成功する
- [x] `golangci-lint run` で新規指摘がない
- [ ] GitHub Actions `e2e.yml` が成功する

Closes #253

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
