### PR TITLE
test: say サブコマンドの e2e テストを追加 #254

### DIFF
--- a/test/e2e/helper_test.go
+++ b/test/e2e/helper_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -44,4 +45,28 @@ func runCLI(t *testing.T, env map[string]string, args ...string) (stdout, stderr
 	}
 
 	return stdoutBuf.String(), stderrBuf.String(), exitCode
+}
+
+// extractLineContaining は s の中から needle を含む最初の行を返す。
+// 見つからない場合は t.Fatalf でテストを停止する。
+func extractLineContaining(t *testing.T, s, needle string) string {
+	t.Helper()
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	t.Fatalf("expected output to contain a line with %q\noutput:\n%s", needle, s)
+	return ""
+}
+
+// countNonEmptyLines は s の空行を除いた行数を返す。
+func countNonEmptyLines(s string) int {
+	n := 0
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n
 }

--- a/test/e2e/say_test.go
+++ b/test/e2e/say_test.go
@@ -1,0 +1,122 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSayE2E_DryRun_Basic(t *testing.T) {
+	_, stderr, exitCode := runCLI(t, nil, "say", "--dry-run", "こんにちは")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	wants := []string{
+		"[dry run] synthesis completed",
+		"[dry run] playback completed",
+		"text=こんにちは",
+	}
+	for _, w := range wants {
+		if !strings.Contains(stderr, w) {
+			t.Errorf("expected stderr to contain %q\nstderr:\n%s", w, stderr)
+		}
+	}
+}
+
+func TestSayE2E_DryRun_Flags(t *testing.T) {
+	_, stderr, exitCode := runCLI(t, nil,
+		"say", "--dry-run",
+		"--speaker", "8",
+		"--speed", "1.2",
+		"--pitch", "0.1",
+		"--intonation", "1.5",
+		"テスト",
+	)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	playbackLine := extractLineContaining(t, stderr, "[dry run] playback completed")
+	wants := []string{
+		"text=テスト",
+		"speaker=8",
+		"speed=1.2",
+		"pitch=0.1",
+		"intonation=1.5",
+	}
+	for _, w := range wants {
+		if !strings.Contains(playbackLine, w) {
+			t.Errorf("expected playback line to contain %q\nline: %s", w, playbackLine)
+		}
+	}
+}
+
+func TestSayE2E_DryRun_EnvVarVOXSpeaker(t *testing.T) {
+	env := map[string]string{"VOX_SPEAKER": "11"}
+	_, stderr, exitCode := runCLI(t, env, "say", "--dry-run", "環境変数")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	playbackLine := extractLineContaining(t, stderr, "[dry run] playback completed")
+	if !strings.Contains(playbackLine, "speaker=11") {
+		t.Errorf("expected playback line to contain 'speaker=11'\nline: %s", playbackLine)
+	}
+}
+
+// TestSayE2E_DryRun_EnvVarVOXEngineURL_NotFailing はdry-run中はエンジンへ実通信しないため、
+// 到達不能URLを指定しても異常終了しないことを検証する。
+func TestSayE2E_DryRun_EnvVarVOXEngineURL_NotFailing(t *testing.T) {
+	env := map[string]string{"VOX_ENGINE_URL": "http://example.invalid:50021"}
+	_, stderr, exitCode := runCLI(t, env, "say", "--dry-run", "エンジンURL")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 with VOX_ENGINE_URL in dry-run, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	if !strings.Contains(stderr, "[dry run] playback completed") {
+		t.Errorf("expected stderr to contain '[dry run] playback completed'\nstderr:\n%s", stderr)
+	}
+}
+
+func TestSayE2E_ArgValidation_ExitCode2(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "no args", args: []string{"say"}},
+		{name: "too many args", args: []string{"say", "a", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, stderr, exitCode := runCLI(t, nil, tc.args...)
+			if exitCode != 2 {
+				t.Fatalf("expected exit code 2, got %d\nstderr:\n%s", exitCode, stderr)
+			}
+		})
+	}
+}
+
+func TestSayE2E_Verbose_IncreasesLogs(t *testing.T) {
+	_, baseStderr, baseExit := runCLI(t, nil, "say", "--dry-run", "詳細ログ")
+	if baseExit != 0 {
+		t.Fatalf("expected exit code 0 for baseline, got %d\nstderr:\n%s", baseExit, baseStderr)
+	}
+
+	_, verboseStderr, verboseExit := runCLI(t, nil, "say", "--dry-run", "--verbose", "詳細ログ")
+	if verboseExit != 0 {
+		t.Fatalf("expected exit code 0 for --verbose, got %d\nstderr:\n%s", verboseExit, verboseStderr)
+	}
+
+	baseLines := countNonEmptyLines(baseStderr)
+	verboseLines := countNonEmptyLines(verboseStderr)
+	if verboseLines <= baseLines {
+		t.Errorf("expected --verbose to produce more log lines than baseline: base=%d verbose=%d\nbase stderr:\n%s\nverbose stderr:\n%s",
+			baseLines, verboseLines, baseStderr, verboseStderr)
+	}
+}


### PR DESCRIPTION
## Summary

- `vox-actor say --dry-run` を利用した e2e テストを `test/e2e/say_test.go` に追加し、音声デバイス・VOICEVOX エンジン無しで say サブコマンドのフラグ／環境変数／引数バリデーションを継続検証できるようにしました。
- 複数 e2e ファイルから再利用できる `extractLineContaining` / `countNonEmptyLines` を `test/e2e/helper_test.go` に共通ヘルパーとして追加しました。

## 追加したテスト

- `TestSayE2E_DryRun_Basic`: `say --dry-run "こんにちは"` で exit 0・`[dry run] synthesis completed`・`[dry run] playback completed` + `text=こんにちは` を検証
- `TestSayE2E_DryRun_Flags`: `--speaker 8 --speed 1.2 --pitch 0.1 --intonation 1.5` が `playback completed` 属性に反映されることを検証
- `TestSayE2E_DryRun_EnvVarVOXSpeaker`: `VOX_SPEAKER=11` → `speaker=11`
- `TestSayE2E_DryRun_EnvVarVOXEngineURL_NotFailing`: 到達不能な `VOX_ENGINE_URL` を指定しても dry-run なら異常終了しない
- `TestSayE2E_ArgValidation_ExitCode2`: 引数0個／2個で終了コード 2（ErrUsage）
- `TestSayE2E_Verbose_IncreasesLogs`: `--verbose` で非空ログ行数が増える

## Test plan

- [x] `make test-e2e` がローカルで全ケース PASS
- [x] `golangci-lint run ./...` で新たな指摘なし（0 issues）
- [x] `gofmt -l .` 出力なし

Closes #254

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
