### PR TITLE
test: watch サブコマンドの e2e テストを追加 #256

### DIFF
--- a/test/e2e/watch_test.go
+++ b/test/e2e/watch_test.go
@@ -1,0 +1,301 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type lineAccumulator struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (a *lineAccumulator) append(line string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.lines = append(a.lines, line)
+}
+
+func (a *lineAccumulator) snapshot() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]string, len(a.lines))
+	copy(out, a.lines)
+	return out
+}
+
+func (a *lineAccumulator) String() string {
+	return strings.Join(a.snapshot(), "\n")
+}
+
+type watchProcess struct {
+	t        *testing.T
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+	stderr   *lineAccumulator
+	done     chan struct{}
+	waitErr  error // done が close された後にのみ参照してよい
+	stopOnce sync.Once
+}
+
+// startWatch はビルド済み vox-actor を別プロセスで起動し、watch サブコマンドを実行する。
+// t.Cleanup でプロセスの停止・killが登録されるため呼び出し側での後始末は不要。
+func startWatch(t *testing.T, env map[string]string, args ...string) *watchProcess {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	fullArgs := append([]string{"watch"}, args...)
+	cmd := exec.CommandContext(ctx, binaryPath, fullArgs...)
+	if len(env) > 0 {
+		base := os.Environ()
+		for k, v := range env {
+			base = append(base, k+"="+v)
+		}
+		cmd.Env = base
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("failed to start watch: %v", err)
+	}
+
+	acc := &lineAccumulator{}
+	go readLinesInto(stderrPipe, acc)
+
+	wp := &watchProcess{
+		t:      t,
+		cmd:    cmd,
+		cancel: cancel,
+		stderr: acc,
+		done:   make(chan struct{}),
+	}
+	go func() {
+		wp.waitErr = cmd.Wait()
+		close(wp.done)
+	}()
+
+	t.Cleanup(func() {
+		wp.stop(3 * time.Second)
+	})
+
+	return wp
+}
+
+func readLinesInto(r io.Reader, acc *lineAccumulator) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		acc.append(scanner.Text())
+	}
+}
+
+// waitForStderr は stderr に needle を含む行が出るまで最大 timeout だけポーリングし、
+// 見つかった行を返す。見つからない／プロセスが先に終了した場合は t.Fatalf を呼ぶ。
+func (w *watchProcess) waitForStderr(needle string, timeout time.Duration) string {
+	w.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		for _, line := range w.stderr.snapshot() {
+			if strings.Contains(line, needle) {
+				return line
+			}
+		}
+		select {
+		case <-w.done:
+			w.t.Fatalf("watch exited before %q appeared: err=%v\nstderr:\n%s",
+				needle, w.waitErr, w.stderr.String())
+		default:
+		}
+		if time.Now().After(deadline) {
+			w.t.Fatalf("timed out after %s waiting for stderr to contain %q\nstderr:\n%s",
+				timeout, needle, w.stderr.String())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// stop は watch プロセスに SIGTERM を送り終了を待機する。timeout 以内に終了しなければ
+// SIGKILL で強制終了する。二回目以降の呼び出しは no-op で初回の終了結果を返す。
+func (w *watchProcess) stop(timeout time.Duration) (exitCode int, err error) {
+	w.stopOnce.Do(func() {
+		_ = w.cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case <-w.done:
+		case <-time.After(timeout):
+			_ = w.cmd.Process.Kill()
+			<-w.done
+		}
+		w.cancel()
+	})
+	return exitCodeFromErr(w.waitErr), w.waitErr
+}
+
+func exitCodeFromErr(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+// assertCleanExit は SIGTERM による正常停止（exit code 0）を検証する。
+func (w *watchProcess) assertCleanExit(timeout time.Duration) {
+	w.t.Helper()
+	exitCode, _ := w.stop(timeout)
+	if exitCode != 0 {
+		w.t.Fatalf("expected clean exit (0), got %d\nstderr:\n%s",
+			exitCode, w.stderr.String())
+	}
+}
+
+func waitUntil(t *testing.T, timeout time.Duration, msg string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %s: %s", timeout, msg)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// assertMovedToDone は src が消えて done/<basename> に移動したことをポーリングで確認する。
+func assertMovedToDone(t *testing.T, src string, timeout time.Duration) {
+	t.Helper()
+	doneFile := filepath.Join(filepath.Dir(src), "done", filepath.Base(src))
+	waitUntil(t, timeout,
+		"expected "+src+" to be moved to "+doneFile,
+		func() bool {
+			if _, err := os.Stat(src); !os.IsNotExist(err) {
+				return false
+			}
+			_, err := os.Stat(doneFile)
+			return err == nil
+		})
+}
+
+func TestWatchE2E_DryRun_DoneMove(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	src := writeTempFile(t, dir, "a.jsonl", `{"text":"テストイチ"}`+"\n")
+
+	line := wp.waitForStderr("playback completed", 10*time.Second)
+	if !strings.Contains(line, "[dry run]") {
+		t.Errorf("expected playback completion line to contain '[dry run]', got: %s", line)
+	}
+
+	assertMovedToDone(t, src, 3*time.Second)
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_DryRun_DeleteMode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", "--delete", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	src := writeTempFile(t, dir, "a.jsonl", `{"text":"デリート"}`+"\n")
+
+	wp.waitForStderr("playback completed", 10*time.Second)
+
+	waitUntil(t, 3*time.Second,
+		"expected "+src+" to be removed",
+		func() bool {
+			_, err := os.Stat(src)
+			return os.IsNotExist(err)
+		})
+
+	doneDir := filepath.Join(dir, "done")
+	if _, err := os.Stat(doneDir); !os.IsNotExist(err) {
+		t.Errorf("expected done/ NOT to be created in --delete mode, got err=%v", err)
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_Queue_AutoCreatesAndProcesses(t *testing.T) {
+	t.Parallel()
+	workspace := t.TempDir()
+	env := map[string]string{"VOX_ACTOR_WORKSPACE": workspace}
+
+	wp := startWatch(t, env, "--queue", "--dry-run")
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	queueDir := filepath.Join(workspace, "queue")
+	info, err := os.Stat(queueDir)
+	if err != nil {
+		t.Fatalf("expected queue dir to be auto-created at %s: %v", queueDir, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %s to be a directory", queueDir)
+	}
+
+	src := writeTempFile(t, queueDir, "a.jsonl", `{"text":"キュー"}`+"\n")
+
+	wp.waitForStderr("playback completed", 10*time.Second)
+	assertMovedToDone(t, src, 3*time.Second)
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_UsageError_ExitCode2(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "queue with positional arg", args: []string{"watch", "--queue", "--dry-run", dir}},
+		{name: "stream with dry-run", args: []string{"watch", "--stream", "--dry-run", dir}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, stderr, exitCode := runCLI(t, nil, tc.args...)
+			if exitCode != 2 {
+				t.Fatalf("expected exit code 2 (usage error), got %d\nstderr:\n%s", exitCode, stderr)
+			}
+			if strings.TrimSpace(stderr) == "" {
+				t.Error("expected non-empty stderr for usage error")
+			}
+		})
+	}
+}
+
+func TestWatchE2E_NoArgs_NonZero(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runCLI(t, nil, "watch")
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for 'watch' without args, got 0\nstderr:\n%s", stderr)
+	}
+}


### PR DESCRIPTION
## Summary

`vox-actor watch` サブコマンドの e2e テストを追加する。別プロセスで常駐させて `--dry-run` で動作させ、ディレクトリ監視フロー・後処理・`--queue` の解決・排他バリデーションを CI で継続的に保証する。

## 追加テスト

| 受け入れ条件 | テスト関数 |
|---|---|
| 基本フロー(done 移動) + SIGTERM 正常停止 | `TestWatchE2E_DryRun_DoneMove` |
| `--delete` モード（done/ 未作成） | `TestWatchE2E_DryRun_DeleteMode` |
| `--queue` で `queue/` 自動作成・検知 | `TestWatchE2E_Queue_AutoCreatesAndProcesses` |
| 排他: `--queue` + 位置引数 / `--stream` + `--dry-run` | `TestWatchE2E_UsageError_ExitCode2` |
| 引数ゼロ | `TestWatchE2E_NoArgs_NonZero` |

## 実装ポイント

- watch は常駐プロセスのため、`runCLI` とは別に `startWatch` / `watchProcess` / `waitForStderr` / `stop` ヘルパーを追加
- 検知待ちは stderr の「目印ログ行」出現を50msポーリング（最大10秒）
- プロセス停止は SIGTERM → 3秒待機 → SIGKILL フォールバック、`stop` は `sync.Once` で二重呼び出しを防止
- `--queue` は `VOX_ACTOR_WORKSPACE` を一時ディレクトリにして git 依存を回避
- 全テスト `t.Parallel()` で並列化（実行時間 約1.6秒）

## Test plan

- [x] `make test-e2e` 成功（`ok 1.573s`）
- [x] `golangci-lint run --build-tags e2e ./...` 指摘なし
- [x] 音声デバイス／VOICEVOXエンジン無しで動作（全テスト `--dry-run`）
- [x] 検証観点の各項目を最低1件ずつカバー

Closes #256

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
