### PR TITLE
refactor: queueファイル名をタイムスタンプ始まりに変更 #264

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -146,7 +146,7 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 |---|---|---|
 | 読み上げ方式 | `vox-actor say` をその場で直接呼び出す | テキスト等をファイルに書き出し、別プロセスの `vox-actor watch` が読み上げる |
 | 監視プロセス | 不要 | `vox-actor watch` の常駐が必要 |
-| ファイル出力先 | エラーログのみ（`monologue` はワークスペースルート直下の `monologue-errors.log`、`speak` / `talk` は `play-script-errors.log`） | 通知ファイル（ワークスペース配下の `queue/monologue_*.json` / `speak_*.jsonl` / `talk_*.jsonl`）＋エラーログ |
+| ファイル出力先 | エラーログのみ（`monologue` はワークスペースルート直下の `monologue-errors.log`、`speak` / `talk` は `play-script-errors.log`） | 通知ファイル（ワークスペース配下の `queue/*_monologue.json` / `*_speak.jsonl` / `*_talk.jsonl`）＋エラーログ |
 | 同時呼び出し時 | 同一セッション内は逐次再生、複数セッション間は並列再生 | 検知順に逐次再生 |
 | 前提 | `vox-actor` コマンドが `PATH` 上にあり、音声デバイスが利用可能（`vox-actor audio-check` が成功） | claude code 側と `vox-actor watch` 側で `VOX_ACTOR_WORKSPACE` を共有 |
 

--- a/plugins/vox-actor-plugin/skills/monologue/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/monologue/SKILL.md
@@ -100,7 +100,7 @@ ${CLAUDE_PLUGIN_ROOT}/skills/monologue/scripts/monologue.sh 通知確率 "（キ
 
 #### `file` モード
 
-`vox-actor config path.queue` で解決された queue ディレクトリに通知ファイルを書き出す。ファイル名は `monologue_{ミリ秒タイムスタンプ}.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする
+`vox-actor config path.queue` で解決された queue ディレクトリに通知ファイルを書き出す。ファイル名は `{ミリ秒タイムスタンプ}_monologue.json`、形式は `{"speaker": スピーカーID, "text": "セリフ", "speedScale": 話速}`。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする
 
 ## キャラクター設定ファイルについて
 

--- a/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
+++ b/plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh
@@ -85,7 +85,7 @@ case "$MODE" in
   file)
     mkdir -p "$QUEUE_DIR"
     jq -cn --argjson speaker "$SPEAKER" --arg text "$TEXT" --argjson speedScale "$SPEED_SCALE" \
-      '{speaker: $speaker, text: $text, speedScale: $speedScale}' > "${QUEUE_DIR}/monologue_$(($(date +%s%N)/1000000)).json"
+      '{speaker: $speaker, text: $text, speedScale: $speedScale}' > "${QUEUE_DIR}/$(($(date +%s%N)/1000000))_monologue.json"
     ;;
   *)
     echo "[ERROR] VOX_ACTOR_MONOLOGUE_MODE は 'direct' または 'file' で指定してください: '$MODE'"

--- a/plugins/vox-actor-plugin/skills/speak/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/speak/SKILL.md
@@ -20,7 +20,7 @@ allowed-tools:
    - 冒頭の挨拶／つかみ → 本題 → まとめの流れを意識する
    - セリフ毎に内容の感情に合う `speaker` と `speedScale` を選定する
 5. `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で一時ディレクトリを作成する
-6. 一時ファイル `${VOX_ACTOR_WORKSPACE}/tmp/speak_<unix_ms>.jsonl` に Write する
+6. 一時ファイル `${VOX_ACTOR_WORKSPACE}/tmp/<unix_ms>_speak.jsonl` に Write する
 7. `play-script.sh <path>` を呼び出す
 
 ```bash
@@ -102,7 +102,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 #### `file` モード
 
-一時ファイルを `vox-actor config path.queue` で解決された queue ディレクトリ配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`speak_<ms>.jsonl` なら `queue/speak_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
+一時ファイルを `vox-actor config path.queue` で解決された queue ディレクトリ配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`<ms>_speak.jsonl` なら `queue/<ms>_speak.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
 
 ## JSONL 出力例
 

--- a/plugins/vox-actor-plugin/skills/talk/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/talk/SKILL.md
@@ -22,7 +22,7 @@ allowed-tools:
    - 本題ではキャラ同士の掛け合い・質問応答・補足などで会話を展開する
    - セリフ毎に担当キャラの `speakers` から感情に合うIDを選定し、`speedScale` も感情に合わせる
 6. `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で一時ディレクトリを作成する
-7. 一時ファイル `${VOX_ACTOR_WORKSPACE}/tmp/talk_<unix_ms>.jsonl` に Write する
+7. 一時ファイル `${VOX_ACTOR_WORKSPACE}/tmp/<unix_ms>_talk.jsonl` に Write する
 8. `play-script.sh <path>` を呼び出す
 
 ```bash
@@ -104,7 +104,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/play-script.sh <jsonl_path>
 
 #### `file` モード
 
-一時ファイルを `vox-actor config path.queue` で解決された queue ディレクトリ配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`talk_<ms>.jsonl` なら `queue/talk_<ms>.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
+一時ファイルを `vox-actor config path.queue` で解決された queue ディレクトリ配下へ `mv` で移動する（渡された一時ファイル名がそのまま使われるため、`<ms>_talk.jsonl` なら `queue/<ms>_talk.jsonl` となる）。外部の通知監視プロセス（`vox-actor watch` 等）はこの `queue/` ディレクトリを監視対象として検知・読み上げする。
 
 ## JSONL 出力例
 


### PR DESCRIPTION
## Summary

- `monologue` / `speak` / `talk` スキルが queue に書き出すファイル名を `<kind>_<unix_ms>` から `<unix_ms>_<kind>` 形式に変更し、`vox-actor watch` の辞書順ソート=生成時刻順となるようにしました
- `plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh` の queue 書き出し部分を更新
- 関連ドキュメント（monologue/speak/talk の SKILL.md、`docs/reference/plugins.md`）の記述を新形式に統一
- `play-script.sh` は `basename` で移動するため tmp 側の名前変更のみで自動追従、`internal/infra/dir_watcher.go` のソートロジックは変更なし

## 動作確認

- `shellcheck plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh` → 指摘なし
- `VOX_ACTOR_WORKSPACE=$(mktemp -d) VOX_ACTOR_MONOLOGUE_MODE=file` で monologue → speak → talk → monologue の順に連続実行し、queue 配下を `ls | sort` で確認。`<unix_ms>_<kind>.<ext>` 形式で辞書順=生成時刻順に並ぶことを確認済み

## 受け入れ条件

- [x] `monologue.sh` が書き出すファイル名が `<unix_ms>_monologue.json` 形式
- [x] `speak` / `talk` の SKILL.md に記載された一時ファイル名パスが `<unix_ms>_speak.jsonl` / `<unix_ms>_talk.jsonl` 形式
- [x] `speak` / `talk` / `monologue` を連続実行したとき、queue 配下のファイルが辞書順（= 生成時刻順）で watch によって再生される
- [x] 関連ドキュメント（SKILL.md 3 件、`docs/reference/plugins.md`）の記述が新形式で統一
- [x] `shellcheck plugins/vox-actor-plugin/skills/monologue/scripts/monologue.sh` で新規指摘がない

Closes #264

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
