### PR TITLE
feat: 配信画面フロントエンドを TypeScript 化する #273

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ test: build-frontend
 fmt:
 	go fmt ./...
 
-lint: build-frontend
+typecheck: frontend/node_modules
+	cd frontend && npm run typecheck
+
+lint: build-frontend typecheck
 	golangci-lint run ./...
 
 depcheck: build-frontend
@@ -45,4 +48,4 @@ install: build-frontend
 
 all: build
 
-.PHONY: all setup build build-frontend clean test test-e2e fmt lint depcheck run-stream install
+.PHONY: all setup build build-frontend clean test test-e2e fmt lint typecheck depcheck run-stream install

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,6 +52,6 @@
   </section>
   <audio id="player" muted></audio>
 </main>
-<script type="module" src="/src/main.js"></script>
+<script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/frontend/src/dom.ts
+++ b/frontend/src/dom.ts
@@ -1,0 +1,8 @@
+// DOM 要素取得ヘルパー。id に対応する要素が無ければ例外を投げる。
+export function getElement<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (el === null) {
+    throw new Error(`element not found: #${id}`);
+  }
+  return el as T;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,23 +1,43 @@
 import "./app.css";
+import { getElement } from "./dom";
+import {
+  isClipEvent,
+  isSpeakerArray,
+  type ClipEvent,
+  type Speaker,
+} from "./types/api";
+
+interface ToggleConfig {
+  el: HTMLInputElement;
+  storageKey: string;
+  bodyClass: string;
+}
+
+interface QueueItem {
+  clip: ClipEvent;
+  item: HTMLLIElement;
+}
+
+type TabName = "stream" | "test";
 
 (() => {
-  const statusBadge = document.getElementById("status-badge");
-  const volumeEl = document.getElementById("volume");
-  const volumeIcon = document.getElementById("volume-icon");
-  const muteEl = document.getElementById("mute");
-  const timelineEl = document.getElementById("timeline");
-  const historySizeEl = document.getElementById("history-size");
-  const showSpeakerNameEl = document.getElementById("show-speaker-name");
-  const showStyleNameEl = document.getElementById("show-style-name");
-  const showTimestampEl = document.getElementById("show-timestamp");
-  const player = document.getElementById("player");
-  const tabStreamEl = document.getElementById("tab-stream");
-  const tabTestEl = document.getElementById("tab-test");
-  const panelStreamEl = document.getElementById("panel-stream");
-  const panelTestEl = document.getElementById("panel-test");
-  const testSpeakerEl = document.getElementById("test-speaker");
-  const testPlayEl = document.getElementById("test-play");
-  const testErrorEl = document.getElementById("test-error");
+  const statusBadge = getElement<HTMLSpanElement>("status-badge");
+  const volumeEl = getElement<HTMLInputElement>("volume");
+  const volumeIcon = getElement<HTMLSpanElement>("volume-icon");
+  const muteEl = getElement<HTMLInputElement>("mute");
+  const timelineEl = getElement<HTMLOListElement>("timeline");
+  const historySizeEl = getElement<HTMLSelectElement>("history-size");
+  const showSpeakerNameEl = getElement<HTMLInputElement>("show-speaker-name");
+  const showStyleNameEl = getElement<HTMLInputElement>("show-style-name");
+  const showTimestampEl = getElement<HTMLInputElement>("show-timestamp");
+  const player = getElement<HTMLAudioElement>("player");
+  const tabStreamEl = getElement<HTMLButtonElement>("tab-stream");
+  const tabTestEl = getElement<HTMLButtonElement>("tab-test");
+  const panelStreamEl = getElement<HTMLElement>("panel-stream");
+  const panelTestEl = getElement<HTMLElement>("panel-test");
+  const testSpeakerEl = getElement<HTMLSelectElement>("test-speaker");
+  const testPlayEl = getElement<HTMLButtonElement>("test-play");
+  const testErrorEl = getElement<HTMLSpanElement>("test-error");
 
   const historySizeStorageKey = "vox-actor.stream.historySize";
   const defaultHistorySize = 20;
@@ -25,37 +45,37 @@ import "./app.css";
   const defaultVolume = 50;
   const activeTabStorageKey = "vox-actor.stream.activeTab";
   const testSpeakerStorageKey = "vox-actor.stream.testSpeakerId";
-  const defaultActiveTab = "stream";
+  const defaultActiveTab: TabName = "stream";
   const testErrorDisplayMs = 4000;
 
-  const toggles = [
+  const toggles: ToggleConfig[] = [
     { el: showSpeakerNameEl, storageKey: "vox-actor.stream.showSpeakerName", bodyClass: "hide-speaker-name" },
     { el: showStyleNameEl, storageKey: "vox-actor.stream.showStyleName", bodyClass: "hide-style-name" },
     { el: showTimestampEl, storageKey: "vox-actor.stream.showTimestamp", bodyClass: "hide-timestamp" },
   ];
 
-  const queue = [];
-  let playingItem = null;
+  const queue: QueueItem[] = [];
+  let playingItem: HTMLLIElement | null = null;
   let historySize = initHistorySize();
-  let activeTab = defaultActiveTab;
-  let testErrorTimer = null;
+  let activeTab: TabName = defaultActiveTab;
+  let testErrorTimer: ReturnType<typeof setTimeout> | null = null;
 
-  function initHistorySize() {
-    const stored = parseInt(localStorage.getItem(historySizeStorageKey), 10);
+  function initHistorySize(): number {
+    const stored = parseInt(localStorage.getItem(historySizeStorageKey) ?? "", 10);
     const allowed = Array.from(historySizeEl.options).map((o) => parseInt(o.value, 10));
     const value = allowed.includes(stored) ? stored : defaultHistorySize;
     historySizeEl.value = String(value);
     return value;
   }
 
-  function initVolume() {
-    const stored = parseInt(localStorage.getItem(volumeStorageKey), 10);
+  function initVolume(): void {
+    const stored = parseInt(localStorage.getItem(volumeStorageKey) ?? "", 10);
     const value = Number.isInteger(stored) && stored >= 0 && stored <= 100 ? stored : defaultVolume;
     volumeEl.value = String(value);
     player.volume = value / 100;
   }
 
-  function initToggles() {
+  function initToggles(): void {
     toggles.forEach((t) => {
       const stored = localStorage.getItem(t.storageKey);
       const checked = stored === null ? true : stored === "true";
@@ -68,7 +88,7 @@ import "./app.css";
     });
   }
 
-  function applyToggleState(t, checked) {
+  function applyToggleState(t: ToggleConfig, checked: boolean): void {
     if (checked) {
       document.body.classList.remove(t.bodyClass);
     } else {
@@ -76,7 +96,7 @@ import "./app.css";
     }
   }
 
-  const setVolumeIcon = () => {
+  const setVolumeIcon = (): void => {
     volumeIcon.textContent = player.muted || player.volume === 0 ? "🔇" : "🔊";
   };
 
@@ -92,7 +112,7 @@ import "./app.css";
     setVolumeIcon();
   });
 
-  const trimTimeline = () => {
+  const trimTimeline = (): void => {
     while (timelineEl.children.length > historySize) {
       const first = timelineEl.firstElementChild;
       if (!first || first === playingItem) break;
@@ -108,12 +128,12 @@ import "./app.css";
     trimTimeline();
   });
 
-  const formatTimestamp = (ms) => {
-    if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) return "";
+  const formatTimestamp = (ms: number): string => {
+    if (!Number.isFinite(ms) || ms <= 0) return "";
     return new Date(ms).toLocaleTimeString("ja-JP", { hour12: false });
   };
 
-  const appendTimelineItem = (clip) => {
+  const appendTimelineItem = (clip: ClipEvent): HTMLLIElement => {
     const li = document.createElement("li");
     li.className = "timeline-item";
     li.dataset.clipId = String(clip.id);
@@ -128,7 +148,7 @@ import "./app.css";
 
     const speakerName = document.createElement("span");
     speakerName.className = "timeline-speaker-name";
-    speakerName.textContent = clip.speakerName || "";
+    speakerName.textContent = clip.speakerName;
     meta.appendChild(speakerName);
 
     const styleName = document.createElement("span");
@@ -140,7 +160,7 @@ import "./app.css";
 
     const body = document.createElement("div");
     body.className = "timeline-body";
-    body.textContent = clip.text || "";
+    body.textContent = clip.text;
     li.appendChild(body);
 
     timelineEl.appendChild(li);
@@ -149,14 +169,14 @@ import "./app.css";
     return li;
   };
 
-  const clearPlayingHighlight = () => {
+  const clearPlayingHighlight = (): void => {
     if (playingItem) {
       playingItem.classList.remove("playing");
       playingItem = null;
     }
   };
 
-  const stopPlayback = () => {
+  const stopPlayback = (): void => {
     player.pause();
     player.removeAttribute("src");
     player.load();
@@ -164,15 +184,17 @@ import "./app.css";
     clearPlayingHighlight();
   };
 
-  const playNext = () => {
+  const playNext = (): void => {
     if (activeTab !== "stream") return;
-    if (playingItem || queue.length === 0) return;
-    const { clip, item } = queue.shift();
+    if (playingItem) return;
+    const next = queue.shift();
+    if (!next) return;
+    const { clip, item } = next;
     playingItem = item;
     item.classList.add("playing");
     item.scrollIntoView({ block: "nearest" });
     player.src = clip.url;
-    player.play().catch((err) => {
+    player.play().catch((err: unknown) => {
       console.error("play failed", err);
       clearPlayingHighlight();
       playNext();
@@ -184,8 +206,8 @@ import "./app.css";
     playNext();
   });
 
-  const applyTab = (tab) => {
-    activeTab = tab === "test" ? "test" : "stream";
+  const applyTab = (tab: TabName): void => {
+    activeTab = tab;
     const isStream = activeTab === "stream";
     tabStreamEl.classList.toggle("active", isStream);
     tabStreamEl.setAttribute("aria-selected", String(isStream));
@@ -199,7 +221,7 @@ import "./app.css";
     }
   };
 
-  const setActiveTab = (tab) => {
+  const setActiveTab = (tab: TabName): void => {
     applyTab(tab);
     localStorage.setItem(activeTabStorageKey, activeTab);
   };
@@ -207,9 +229,9 @@ import "./app.css";
   tabStreamEl.addEventListener("click", () => setActiveTab("stream"));
   tabTestEl.addEventListener("click", () => setActiveTab("test"));
 
-  const showTestError = (msg) => {
+  const showTestError = (msg: string): void => {
     testErrorEl.textContent = msg;
-    if (testErrorTimer) {
+    if (testErrorTimer !== null) {
       clearTimeout(testErrorTimer);
     }
     testErrorTimer = setTimeout(() => {
@@ -218,11 +240,15 @@ import "./app.css";
     }, testErrorDisplayMs);
   };
 
-  const loadSpeakers = async () => {
+  const loadSpeakers = async (): Promise<void> => {
     try {
       const resp = await fetch("/speakers.json");
       if (!resp.ok) throw new Error(`status ${resp.status}`);
-      const speakers = await resp.json();
+      const data: unknown = await resp.json();
+      if (!isSpeakerArray(data)) {
+        throw new Error("invalid speakers payload");
+      }
+      const speakers: Speaker[] = data;
       testSpeakerEl.innerHTML = "";
       speakers.forEach((s) => {
         const opt = document.createElement("option");
@@ -232,7 +258,7 @@ import "./app.css";
         testSpeakerEl.appendChild(opt);
       });
       const stored = localStorage.getItem(testSpeakerStorageKey);
-      if (stored && Array.from(testSpeakerEl.options).some((o) => o.value === stored)) {
+      if (stored !== null && Array.from(testSpeakerEl.options).some((o) => o.value === stored)) {
         testSpeakerEl.value = stored;
       }
     } catch (err) {
@@ -254,13 +280,13 @@ import "./app.css";
     testErrorEl.textContent = "";
     player.pause();
     player.src = `/test-clip?speaker=${encodeURIComponent(speakerId)}`;
-    player.play().catch((err) => {
+    player.play().catch((err: unknown) => {
       console.error("test play failed", err);
       showTestError("合成に失敗しました");
     });
   });
 
-  const setBadge = (connected) => {
+  const setBadge = (connected: boolean): void => {
     if (connected) {
       statusBadge.textContent = "● 接続中";
       statusBadge.classList.add("badge-connected");
@@ -272,17 +298,21 @@ import "./app.css";
     }
   };
 
-  const connect = () => {
+  const connect = (): void => {
     const es = new EventSource("/events");
     es.addEventListener("open", () => {
       setBadge(true);
     });
     es.addEventListener("clip", (event) => {
       try {
-        const clip = JSON.parse(event.data);
-        const item = appendTimelineItem(clip);
+        const data: unknown = JSON.parse(event.data);
+        if (!isClipEvent(data)) {
+          console.error("invalid clip payload", data);
+          return;
+        }
+        const item = appendTimelineItem(data);
         if (activeTab === "stream") {
-          queue.push({ clip, item });
+          queue.push({ clip: data, item });
           playNext();
         }
       } catch (err) {
@@ -302,6 +332,6 @@ import "./app.css";
   setVolumeIcon();
   const storedTab = localStorage.getItem(activeTabStorageKey);
   applyTab(storedTab === "test" ? "test" : "stream");
-  loadSpeakers();
+  void loadSpeakers();
   connect();
 })();

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,58 @@
+// サーバー (internal/infra/http_stream_player.go) と対応する型定義。
+// Go 側構造体 (clipEvent / speakerJSON) の JSON タグと一致させること。
+// どちらか一方を変更した場合は両方を同時に修正する。
+
+export interface ClipEvent {
+  id: number;
+  url: string;
+  text: string;
+  speakerName: string;
+  styleName: string;
+  // Unix ms (UTC)
+  timestamp: number;
+}
+
+export interface Speaker {
+  id: number;
+  speakerName: string;
+  styleName: string;
+}
+
+// SSE の "clip" イベントを扱えるよう EventSourceEventMap を拡張する。
+// これにより es.addEventListener("clip", (ev) => ...) の ev が MessageEvent<string> になる。
+declare global {
+  interface EventSourceEventMap {
+    clip: MessageEvent<string>;
+  }
+}
+
+export function isClipEvent(value: unknown): value is ClipEvent {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === "number" &&
+    typeof v.url === "string" &&
+    typeof v.text === "string" &&
+    typeof v.speakerName === "string" &&
+    typeof v.styleName === "string" &&
+    typeof v.timestamp === "number"
+  );
+}
+
+export function isSpeaker(value: unknown): value is Speaker {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === "number" &&
+    typeof v.speakerName === "string" &&
+    typeof v.styleName === "string"
+  );
+}
+
+export function isSpeakerArray(value: unknown): value is Speaker[] {
+  return Array.isArray(value) && value.every(isSpeaker);
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "allowJs": true,


### PR DESCRIPTION
## 概要

Issue #273 の対応。配信画面フロントエンドの JavaScript コードを TypeScript に移行し、SSE / `/speakers.json` など Go バックエンドとの境界で型検証を行えるようにしました。

Closes #273

## 変更内容

### TypeScript 化

- `frontend/src/main.js` → `main.ts` に一括リネームして型付け
- `frontend/src/types/api.ts` を新規追加
  - `ClipEvent` / `Speaker` 型（Go 側 `clipEvent` / `speakerJSON` と 1:1 対応）
  - 型ガード `isClipEvent` / `isSpeaker` / `isSpeakerArray`
  - `EventSourceEventMap` の `declare global` 拡張で `"clip"` イベントを `MessageEvent<string>` に型付け（`main.ts` 側からは明示的キャスト不要）
- `frontend/src/dom.ts` を新規追加
  - `getElement<T extends HTMLElement>(id)` ヘルパー。対応要素が無ければ例外を投げる
- `frontend/index.html` の `<script>` 参照を `/src/main.ts` に張り替え

### 型安全性の担保

- `main.ts` 内に `any` 明示キャスト（`as X`）ゼロ
- DOM 要素参照は `HTMLInputElement` / `HTMLAudioElement` / `HTMLSelectElement` など具体型で取得
- SSE ペイロードは `isClipEvent` で境界検証し、不正なら `console.error` して捨てる（現行挙動維持）
- `fetch("/speakers.json")` の結果は `isSpeakerArray` で検証
- `queue` の要素型 `{ clip: ClipEvent; item: HTMLLIElement }` を明示

### ビルド基盤

- `tsconfig.json` に `noImplicitReturns: true` を追加（`strict` / `noUnusedLocals` / `noUnusedParameters` は既設）
- `frontend/package.json` に `typecheck: tsc --noEmit` スクリプトを追加
- `Makefile` に `typecheck` ターゲットを追加し、`make lint` から呼ぶ構成に変更

## 受け入れ基準の充足

- [x] `frontend/src/` 配下に `.js` ファイルが存在しない（`.d.ts` を除く）
- [x] `tsc --noEmit` がエラー・警告ゼロで通る
- [x] `main.ts` 内に `any` および明示的キャスト（`as unknown as X` を除く）が存在しない
- [x] `make build` が通り、`frontend/dist/` にビルド済みアセットが生成される
- [x] `make lint`（`golangci-lint` + `tsc --noEmit`）が通る
- [x] `make test` が通る（既存の `http_stream_player_test.go` もグリーン）

## 動作確認

devcontainer 内で `vox-actor watch --stream` を立てて HTTP 経由で配信画面のアセットを確認:

- `/` → TypeScript からビルドされたハッシュ付き JS を参照する `index.html`
- `/assets/index-<hash>.js` → 200 で配信（`size=6418 bytes`）
- `/speakers.json` → 40 話者分の JSON が正常に返却

headless dev container のため、実ブラウザでの UI 動作確認は実施していません。Issue の「手動確認項目（SSE／タイムライン／音量／ミュート／履歴サイズ／話者テスト等）」はマージ前にレビュワー環境で確認いただくか、マージ後に回帰なしを確認する形になります。

## simplify レビュー結果

3エージェント並列レビュー（reuse / quality / efficiency）実施済み:

- **Reuse**: 重複なし
- **Quality**: `main.ts` の `defaultActiveTab` 初期代入と末尾 `applyTab(... "stream")` の重複は原コードそのままの挙動なので見送り。`uint64` → `number` の 2^53 精度注記も、ストリーム ID のリングバッファサイズ（20）を考えると過剰のため見送り
- **Efficiency**: SSE ホットパスに `isClipEvent`（6 `typeof`）が追加されるのみ、`appendTimelineItem` の DOM 生成と比べれば誤差。他は原コードと同等

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
