### PR TITLE
feat: 配信画面のローカル開発で Vite dev server + HMR を使えるように整備 #276

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,12 +33,14 @@ go.work.sum
 /vox-actor
 
 # GoReleaser
-dist/
+/dist/
 
 # 一時ファイル（作業メモ・通知・ロック等）
 .tmp/
 .vox-actor/
 
 # フロントエンド（Vite）
-frontend/dist/
+# ビルド成果物は無視するが、//go:embed のために空ディレクトリを維持する .gitkeep は例外的にコミットする
+frontend/dist/*
+!frontend/dist/.gitkeep
 frontend/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,24 @@ test-e2e: build-frontend
 run-stream: build-frontend
 	go run . watch --engine-url http://voicevox:50021 --stream --stream-addr 0.0.0.0:8080 --queue
 
+# 配信画面のローカル開発用ターゲット。
+# dev-backend は frontend/dist を参照せず起動できる前提（assets.go の //go:embed all: と frontend/dist/.gitkeep でビルド可）。
+# dev-frontend の Vite dev server (既定 :5173) は vite.config.ts の proxy で /events, /speakers.json, /test-clip, /clips/ を :8080 に中継する。
+# 詳細な起動フローは docs/development/contributing.md の「配信画面のローカル開発フロー」を参照。
+dev-frontend: frontend/node_modules
+	cd frontend && npm run dev
+
+# VOICEVOX エンジン URL は CLI 既定値（http://localhost:50021）または環境変数 VOX_ENGINE_URL に従う。
+# dev container 等で voicevox:50021 を使う場合は `VOX_ENGINE_URL=http://voicevox:50021 make dev-backend` のように指定する。
+dev-backend:
+	go run . watch --stream --stream-addr 127.0.0.1:8080 --queue
+
+dev:
+	$(MAKE) -j2 dev-backend dev-frontend
+
 install: build-frontend
 	go install .
 
 all: build
 
-.PHONY: all setup build build-frontend clean test test-e2e fmt lint typecheck depcheck run-stream install
+.PHONY: all setup build build-frontend clean test test-e2e fmt lint typecheck depcheck run-stream dev dev-frontend dev-backend install

--- a/assets.go
+++ b/assets.go
@@ -5,7 +5,11 @@ import (
 	"io/fs"
 )
 
-//go:embed frontend/dist
+// all: プレフィックスにより、dot-prefix のファイル（.gitkeep 等）も埋め込み対象にする。
+// これにより frontend/dist が未ビルドでも .gitkeep だけで embed 制約を満たし、
+// `go run` / `go build` がフロントエンド未ビルドの状態で通るようになる。
+//
+//go:embed all:frontend/dist
 var streamAssetsRoot embed.FS
 
 // streamAssetsFS は frontend/dist を剥がしたビルド成果物の読み取り専用 FS を返す。

--- a/assets_test.go
+++ b/assets_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"io/fs"
+	"testing"
+)
+
+func TestStreamAssetsFS_Embeds(t *testing.T) {
+	assetsFS, err := streamAssetsFS()
+	if err != nil {
+		t.Fatalf("streamAssetsFS returned error: %v", err)
+	}
+	if assetsFS == nil {
+		t.Fatal("streamAssetsFS returned nil FS")
+	}
+	entries, err := fs.ReadDir(assetsFS, ".")
+	if err != nil {
+		t.Fatalf("fs.ReadDir failed: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one embedded entry in frontend/dist (e.g. .gitkeep or built assets), got 0")
+	}
+}

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -35,6 +35,47 @@ make depcheck
 make clean
 ```
 
+## 配信画面のローカル開発フロー
+
+`frontend/` 配下の配信画面（Vite + TypeScript）を HMR 付きで開発するためのフローです。`make build-frontend` → Go 再起動のサイクルなしで、TS/CSS の編集が即時にブラウザへ反映されます。
+
+### 前提
+
+- Go のビルドが通る状態であること（`make setup` 済み、`frontend/node_modules` 導入済み）
+- VOICEVOX エンジンが起動していること（既定: `http://localhost:50021`、環境変数 `VOX_ENGINE_URL` で上書き可）
+
+### 起動
+
+`make dev` でバックエンドと Vite dev server を並列起動できます。
+
+```bash
+make dev
+```
+
+個別に起動したい場合は、2 つのターミナルで以下を実行します。
+
+```bash
+# ターミナル1: Go バックエンド（ストリーム配信モード、127.0.0.1:8080 でリッスン）
+make dev-backend
+
+# ターミナル2: Vite dev server（既定で http://localhost:5173）
+make dev-frontend
+```
+
+ブラウザで **Vite の URL（例: `http://localhost:5173`）** を開きます。`/events`（SSE）, `/speakers.json`, `/test-clip`, `/clips/*` は `frontend/vite.config.ts` の `server.proxy` 経由で Go バックエンド（`localhost:8080`）に中継されます。
+
+### 動作確認ポイント
+
+- `● 接続中` バッジが表示され続ける（SSE が proxy 経由で届いている）
+- 「音声テスト」タブで話者一覧が読み込まれ、テスト再生できる
+- `queue` ディレクトリに台本を置くと、配信タブに clip が追加される（再生される）
+- `frontend/src/*.ts` / `frontend/src/*.css` を編集すると、リロード無しで反映される
+
+### 仕組みメモ
+
+- `assets.go` の `//go:embed all:frontend/dist` と `frontend/dist/.gitkeep` の組み合わせにより、`frontend/dist` が未ビルドでも Go のビルドが通ります。本番配信では `make build-frontend` が生成する `index.html` / `assets/` が埋め込まれます。
+- Vite dev server 自体は SSE のストリーミングを中断しません（Node 組み込みの http-proxy がデフォルトでレスポンスを逐次転送するため、追加設定は不要）。
+
 ## アーキテクチャ
 
 レイヤー構成と責務ルールは [layer-rules.md](./layer-rules.md) を参照してください。

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "postbuild": "touch dist/.gitkeep",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit"
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from "vite";
 
+// 配信画面は Go バックエンド (`vox-actor watch --stream`) 提供の SSE / API と
+// 同一オリジンで通信する前提なので、dev server からバックエンドへプロキシする。
+// バックエンドの既定バインドは `--stream-addr 127.0.0.1:8080`。
+const backendTarget = "http://localhost:8080";
+
 export default defineConfig({
   root: ".",
   base: "/",
@@ -7,5 +12,27 @@ export default defineConfig({
     outDir: "dist",
     emptyOutDir: true,
     assetsDir: "assets",
+  },
+  server: {
+    proxy: {
+      // SSE エンドポイント。Vite (http-proxy) はデフォルトでストリーミングを維持するため
+      // バッファリング無効化の明示設定は不要。changeOrigin でバックエンド側 Host を合わせる。
+      "/events": {
+        target: backendTarget,
+        changeOrigin: true,
+      },
+      "/speakers.json": {
+        target: backendTarget,
+        changeOrigin: true,
+      },
+      "/test-clip": {
+        target: backendTarget,
+        changeOrigin: true,
+      },
+      "/clips": {
+        target: backendTarget,
+        changeOrigin: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

配信画面（`frontend/`）のローカル開発で Vite dev server + HMR を使えるように整備する。従来の `make build-frontend` → Go 再起動サイクルを省略し、TS/CSS の編集がブラウザへ即時反映されるようにする。

### 主な変更

- **Vite proxy**: `frontend/vite.config.ts` に `server.proxy` を追加。`/events`（SSE）, `/speakers.json`, `/test-clip`, `/clips/*` を Go バックエンド（`localhost:8080`）へ中継。
- **embed 対応**: `assets.go` を `//go:embed all:frontend/dist` に変更し、リポジトリに `frontend/dist/.gitkeep` をコミット。これにより `frontend/dist` 未ビルド状態でも `go build` / `go run` が通る。`.gitignore` は `/dist/` アンカー化（GoReleaser 成果物）＋ `frontend/dist/*` 例外で `.gitkeep` のみ追跡。
- **postbuild**: `frontend/package.json` の `postbuild` で `emptyOutDir` 後も `.gitkeep` を再生成。
- **Makefile**: `make dev-frontend` / `make dev-backend` / `make dev`（並列）を追加。`dev-backend` はエンジン URL を CLI 既定値（`http://localhost:50021`）もしくは `VOX_ENGINE_URL` に委譲する。
- **docs**: `docs/development/contributing.md` に「配信画面のローカル開発フロー」節を追加。

## Test plan

- [x] `go build .` が `frontend/dist/.gitkeep` のみの状態で成功する
- [x] `go test ./...` 全 pass（新規 `assets_test.go` を含む）
- [x] `gofmt -l .` / `golangci-lint run` クリーン
- [x] `cd frontend && npm run typecheck` / `npm run build` が成功し、ビルド後も `frontend/dist/.gitkeep` が残る
- [x] `vox-actor watch --stream --stream-addr 127.0.0.1:8090 --queue` を起動し、Vite dev server（5174）経由で以下を確認
  - [x] `/` → Vite が HMR 付き index を配信（`/src/main.ts` 参照）
  - [x] `/speakers.json` → 200（proxy 経由で話者配列）
  - [x] `/events` → 200, `text/event-stream`, chunked, `subscribers=1` で clip 受信
  - [x] `/test-clip?speaker=3` → 200, `audio/wav`, 68KB 合成音
  - [x] `/clips/<存在しないid>.wav` → 404（proxy 経由で正しく 404）
- [ ] TS/CSS 編集時の HMR 反映（ブラウザでの目視確認）

Closes #276

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
