### PR TITLE
fix: 配信画面で新規クリップ再生時に履歴が自動スクロールしない問題を修正 #282

### DIFF
--- a/frontend/src/components/TimelineItem.tsx
+++ b/frontend/src/components/TimelineItem.tsx
@@ -22,7 +22,10 @@ export function TimelineItem({
   showTimestamp,
 }: TimelineItemProps) {
   const ref = useRef<HTMLLIElement>(null);
-  const prevPlaying = useRef(playing);
+  // 初期値は false 固定。マウント時点で playing=true のケース（SSE で
+  // clip 追加と再生開始が同一レンダーにコミットされる）も立ち上がりエッジと
+  // して scrollIntoView を発火させる必要があるため。
+  const prevPlaying = useRef(false);
 
   useEffect(() => {
     if (playing && !prevPlaying.current) {


### PR DESCRIPTION
## Summary

配信画面の履歴欄で、新しいクリップの再生開始と同時に `▶` 行まで自動スクロールされないバグを修正する。

`frontend/src/components/TimelineItem.tsx` で `prevPlaying` の初期値を `useRef(playing)` から `useRef(false)` に変更。React 18 のバッチングにより SSE 由来の clip 追加と再生開始が同一レンダーでコミットされ、`TimelineItem` が `playing=true` 状態でマウントされるケースでも、マウント時の立ち上がりエッジとして `scrollIntoView` が発火するようになる。

## 動作確認

- `npm run typecheck` / `npm run build` 成功
- ブラウザでの手動検証は dev container 制約上未実施。以下の4ケースで論理的に受け入れ条件を満たすことを確認:
  - `playing=true` でマウント → `scrollIntoView` 発火（バグの主要ケース）
  - `playing=false` でマウント → `true` に遷移 → `scrollIntoView` 発火
  - `playing=true` → `false`（再生終了）→ スクロールしない
  - `playing=false` のまま → スクロールしない

`block: "nearest"` は従来通り維持されるため、再生中セリフが既に表示範囲内にある場合はブラウザがスクロールを抑制する（「見ている間は勝手にスクロールしない」挙動）。

Closes #282

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
