### PR TITLE
feat: 配信画面にサーバー側エラーを表示する #285

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,9 +49,7 @@ const parseBool = (raw: string): boolean | null =>
 
 const passthrough = (v: string): string => v;
 
-// 履歴件数上限に合わせて古い項目から削除する。
-// 再生中のクリップ項目（kind:"clip" かつ id が playingId と一致）は削除しない。
-// エラー項目は再生対象ではないため、常に削除対象となる。
+// 再生中のクリップ項目は削除しない（playingId と一致する clip に出会ったら停止）。
 function trimTimeline(
   entries: TimelineEntry[],
   size: number,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,10 +9,11 @@ import { useEventSource } from "./hooks/useEventSource";
 import { usePersistedState } from "./hooks/usePersistedState";
 import { usePlaybackQueue } from "./hooks/usePlaybackQueue";
 import {
-  type ClipEvent,
   isApiStatus,
   isClipEvent,
+  isErrorEventPayload,
   type Speaker,
+  type TimelineEntry,
 } from "./types/api";
 
 const STORAGE_KEYS = {
@@ -48,14 +49,18 @@ const parseBool = (raw: string): boolean | null =>
 
 const passthrough = (v: string): string => v;
 
-function trimClips(
-  clips: ClipEvent[],
+// 履歴件数上限に合わせて古い項目から削除する。
+// 再生中のクリップ項目（kind:"clip" かつ id が playingId と一致）は削除しない。
+// エラー項目は再生対象ではないため、常に削除対象となる。
+function trimTimeline(
+  entries: TimelineEntry[],
   size: number,
   playingId: number | null,
-): ClipEvent[] {
-  let next = clips;
+): TimelineEntry[] {
+  let next = entries;
   while (next.length > size) {
-    if (next[0].id === playingId) break;
+    const head = next[0];
+    if (head.kind === "clip" && head.id === playingId) break;
     next = next.slice(1);
   }
   return next;
@@ -111,7 +116,7 @@ export function App() {
   const [speakers, setSpeakers] = useState<Speaker[]>([]);
   const [silent, setSilent] = useState(false);
   const [silentReason, setSilentReason] = useState("");
-  const [clips, setClips] = useState<ClipEvent[]>([]);
+  const [entries, setEntries] = useState<TimelineEntry[]>([]);
   const [testError, setTestError] = useState<string>("");
   const testErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -135,7 +140,7 @@ export function App() {
   // 履歴上限の変更時のみトリム。再生状態の変化ではトリムしない
   // （再生終了直後の playingClipId=null 経由で過去のハイライト対象が消えるのを防ぐ）。
   useEffect(() => {
-    setClips((prev) => trimClips(prev, historySize, playingClipIdRef.current));
+    setEntries((prev) => trimTimeline(prev, historySize, playingClipIdRef.current));
   }, [historySize]);
 
   const showTestError = useCallback((msg: string): void => {
@@ -212,8 +217,12 @@ export function App() {
         return;
       }
       const clip = parsed;
-      setClips((prev) =>
-        trimClips([...prev, clip], historySize, playingClipIdRef.current),
+      setEntries((prev) =>
+        trimTimeline(
+          [...prev, { kind: "clip", ...clip }],
+          historySize,
+          playingClipIdRef.current,
+        ),
       );
       // clip.url が空の場合は無音モード配信なのでタイムラインには載せつつ再生キューには積まない。
       if (clip.url !== "") {
@@ -223,7 +232,31 @@ export function App() {
     [historySize, enqueue],
   );
 
-  const connected = useEventSource("/events", handleClip);
+  const handleServerError = useCallback(
+    (data: string): void => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data);
+      } catch (err) {
+        console.error("invalid error payload", err);
+        return;
+      }
+      if (!isErrorEventPayload(parsed)) {
+        console.error("invalid error payload", parsed);
+        return;
+      }
+      setEntries((prev) =>
+        trimTimeline(
+          [...prev, { kind: "error", ...parsed }],
+          historySize,
+          playingClipIdRef.current,
+        ),
+      );
+    },
+    [historySize],
+  );
+
+  const connected = useEventSource("/events", handleClip, handleServerError);
 
   const handleTestPlay = useCallback((): void => {
     if (!testSpeakerId) {
@@ -257,7 +290,7 @@ export function App() {
       <Tabs active={activeTab} onChange={setActiveTab} hideTest={silent} />
       <StreamPanel
         hidden={activeTab !== "stream"}
-        clips={clips}
+        entries={entries}
         playingClipId={playingClipId}
         historySize={historySize}
         historySizeOptions={HISTORY_SIZE_OPTIONS}

--- a/frontend/src/components/StreamPanel.tsx
+++ b/frontend/src/components/StreamPanel.tsx
@@ -1,10 +1,10 @@
-import type { ClipEvent } from "../types/api";
+import type { TimelineEntry } from "../types/api";
 import { Timeline } from "./Timeline";
 import { TimelineControls } from "./TimelineControls";
 
 interface StreamPanelProps {
   hidden: boolean;
-  clips: ClipEvent[];
+  entries: TimelineEntry[];
   playingClipId: number | null;
   historySize: number;
   historySizeOptions: readonly number[];
@@ -20,7 +20,7 @@ interface StreamPanelProps {
 export function StreamPanel(props: StreamPanelProps) {
   const {
     hidden,
-    clips,
+    entries,
     playingClipId,
     historySize,
     historySizeOptions,
@@ -52,7 +52,7 @@ export function StreamPanel(props: StreamPanelProps) {
         onShowTimestampChange={onShowTimestampChange}
       />
       <Timeline
-        clips={clips}
+        entries={entries}
         playingClipId={playingClipId}
         showSpeakerName={showSpeakerName}
         showStyleName={showStyleName}

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,8 +1,8 @@
-import type { ClipEvent } from "../types/api";
+import type { TimelineEntry } from "../types/api";
 import { TimelineItem } from "./TimelineItem";
 
 interface TimelineProps {
-  clips: ClipEvent[];
+  entries: TimelineEntry[];
   playingClipId: number | null;
   showSpeakerName: boolean;
   showStyleName: boolean;
@@ -10,7 +10,7 @@ interface TimelineProps {
 }
 
 export function Timeline({
-  clips,
+  entries,
   playingClipId,
   showSpeakerName,
   showStyleName,
@@ -22,11 +22,11 @@ export function Timeline({
         aria-live="polite"
         className="m-0 max-h-[65vh] list-none overflow-y-auto p-0 md:max-h-[60vh]"
       >
-        {clips.map((clip) => (
+        {entries.map((entry) => (
           <TimelineItem
-            key={clip.id}
-            clip={clip}
-            playing={clip.id === playingClipId}
+            key={`${entry.kind}-${entry.id}`}
+            entry={entry}
+            playing={entry.kind === "clip" && entry.id === playingClipId}
             showSpeakerName={showSpeakerName}
             showStyleName={showStyleName}
             showTimestamp={showTimestamp}

--- a/frontend/src/components/TimelineItem.tsx
+++ b/frontend/src/components/TimelineItem.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from "react";
-import type { ClipEvent } from "../types/api";
+import type { ErrorCategory, TimelineEntry } from "../types/api";
 
 interface TimelineItemProps {
-  clip: ClipEvent;
+  entry: TimelineEntry;
   playing: boolean;
   showSpeakerName: boolean;
   showStyleName: boolean;
@@ -14,8 +14,14 @@ function formatTimestamp(ms: number): string {
   return new Date(ms).toLocaleTimeString("ja-JP", { hour12: false });
 }
 
+const ERROR_CATEGORY_LABEL: Record<ErrorCategory, string> = {
+  synthesis: "合成エラー",
+  file: "ファイルエラー",
+  connection: "接続エラー",
+};
+
 export function TimelineItem({
-  clip,
+  entry,
   playing,
   showSpeakerName,
   showStyleName,
@@ -36,25 +42,62 @@ export function TimelineItem({
 
   const base =
     "my-1 flex flex-col gap-[0.15rem] rounded break-words px-2 py-1 sm:px-[0.6rem] sm:py-[0.4rem]";
-  const playingCls = playing ? "bg-ctp-overlay font-bold" : "";
   const showMeta = showSpeakerName || showStyleName || showTimestamp;
 
+  if (entry.kind === "error") {
+    const categoryLabel = ERROR_CATEGORY_LABEL[entry.category];
+    return (
+      <li
+        ref={ref}
+        data-error-id={entry.id}
+        data-error-category={entry.category}
+        className={`${base} text-ctp-red`}
+      >
+        <div className="flex flex-wrap items-baseline gap-2 text-[0.8rem] text-ctp-red">
+          {showTimestamp && (
+            <span className="tabular-nums">{formatTimestamp(entry.timestamp)}</span>
+          )}
+          <span className="font-semibold">{categoryLabel}</span>
+          {entry.path && <span className="break-all">{entry.path}</span>}
+        </div>
+        <div className="flex items-start gap-2">
+          <span aria-hidden className="inline-block w-[1em] flex-none">
+            ⚠
+          </span>
+          <span>{entry.message}</span>
+        </div>
+        {entry.text && (
+          <div className="flex flex-wrap items-baseline gap-2 text-[0.8rem] text-ctp-subtext">
+            {showSpeakerName && entry.speakerName && (
+              <span className="font-semibold text-ctp-text">{entry.speakerName}</span>
+            )}
+            {showStyleName && entry.styleName && (
+              <span className="text-ctp-blue">[{entry.styleName}]</span>
+            )}
+            <span className="break-all">{entry.text}</span>
+          </div>
+        )}
+      </li>
+    );
+  }
+
+  const playingCls = playing ? "bg-ctp-overlay font-bold" : "";
   return (
     <li
       ref={ref}
-      data-clip-id={clip.id}
+      data-clip-id={entry.id}
       className={`${base} ${playingCls} text-ctp-text`}
     >
       {showMeta && (
         <div className="flex flex-wrap items-baseline gap-2 text-[0.8rem] text-ctp-subtext">
           {showTimestamp && (
-            <span className="tabular-nums">{formatTimestamp(clip.timestamp)}</span>
+            <span className="tabular-nums">{formatTimestamp(entry.timestamp)}</span>
           )}
           {showSpeakerName && (
-            <span className="font-semibold text-ctp-text">{clip.speakerName}</span>
+            <span className="font-semibold text-ctp-text">{entry.speakerName}</span>
           )}
-          {showStyleName && clip.styleName && (
-            <span className="text-ctp-blue">[{clip.styleName}]</span>
+          {showStyleName && entry.styleName && (
+            <span className="text-ctp-blue">[{entry.styleName}]</span>
           )}
         </div>
       )}
@@ -62,7 +105,7 @@ export function TimelineItem({
         <span aria-hidden className="inline-block w-[1em] flex-none text-ctp-blue">
           {playing ? "▶" : ""}
         </span>
-        <span>{clip.text}</span>
+        <span>{entry.text}</span>
       </div>
     </li>
   );

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -1,13 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 
-// onClip は ref 経由で呼び出されるため、呼び出し側が memo 化しなくても再接続は起きない。
+// onClip / onError は ref 経由で呼び出されるため、呼び出し側が memo 化しなくても再接続は起きない。
+// "error" イベントは EventSource ネイティブの接続失敗イベントと衝突するため、
+// MessageEvent（= サーバー送信の `event: error`）と Event（= ネイティブの接続失敗）を
+// ハンドラ内で判別する。
 export function useEventSource(
   url: string,
   onClip: (data: string) => void,
+  onError: (data: string) => void,
 ): boolean {
   const [connected, setConnected] = useState(false);
   const onClipRef = useRef(onClip);
   onClipRef.current = onClip;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
 
   useEffect(() => {
     let es: EventSource | null = null;
@@ -22,7 +28,13 @@ export function useEventSource(
       es.addEventListener("clip", (event) => {
         onClipRef.current(event.data);
       });
-      es.addEventListener("error", () => {
+      es.addEventListener("error", (event) => {
+        // サーバー送信の `event: error` は MessageEvent として配送される。
+        // ネイティブの接続失敗は通常の Event（data を持たない）。
+        if (event instanceof MessageEvent && typeof event.data === "string") {
+          onErrorRef.current(event.data);
+          return;
+        }
         setConnected(false);
         es?.close();
         es = null;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,5 +1,5 @@
 // サーバー (internal/infra/http_stream_player.go) と対応する型定義。
-// Go 側構造体 (clipEvent / speakerJSON) の JSON タグと一致させること。
+// Go 側構造体 (clipEvent / errorEvent / speakerJSON) の JSON タグと一致させること。
 // どちらか一方を変更した場合は両方を同時に修正する。
 
 export interface ClipEvent {
@@ -12,14 +12,34 @@ export interface ClipEvent {
   timestamp: number;
 }
 
+// ErrorEventPayload は SSE "error" イベントで届くサーバー側エラーのペイロード。
+// Go 側の errorEvent 構造体と対応する。synthesis/file/connection で含まれるフィールドが異なる。
+export type ErrorCategory = "synthesis" | "file" | "connection";
+
+export interface ErrorEventPayload {
+  // clipEvent.id とは独立した連番。
+  id: number;
+  category: ErrorCategory;
+  message: string;
+  // Unix ms (UTC)
+  timestamp: number;
+  // 以下はカテゴリに応じて付与される（omitempty）。
+  path?: string;
+  text?: string;
+  speakerName?: string;
+  styleName?: string;
+}
+
 export interface Speaker {
   id: number;
   speakerName: string;
   styleName: string;
 }
 
-// SSE の "clip" イベントを扱えるよう EventSourceEventMap を拡張する。
-// これにより es.addEventListener("clip", (ev) => ...) の ev が MessageEvent<string> になる。
+// SSE の "clip" / "error" イベントを扱えるよう EventSourceEventMap を拡張する。
+// これにより es.addEventListener("clip" | "error", (ev) => ...) の ev が MessageEvent<string> になる。
+// ※ "error" は EventSource ネイティブの接続失敗イベントとも衝突するため、
+//   ハンドラ側で event instanceof MessageEvent か否かで分岐する必要がある。
 declare global {
   interface EventSourceEventMap {
     clip: MessageEvent<string>;
@@ -40,6 +60,34 @@ export function isClipEvent(value: unknown): value is ClipEvent {
     typeof v.timestamp === "number"
   );
 }
+
+export function isErrorEventPayload(value: unknown): value is ErrorEventPayload {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (
+    typeof v.id !== "number" ||
+    typeof v.message !== "string" ||
+    typeof v.timestamp !== "number"
+  ) {
+    return false;
+  }
+  if (v.category !== "synthesis" && v.category !== "file" && v.category !== "connection") {
+    return false;
+  }
+  if (v.path !== undefined && typeof v.path !== "string") return false;
+  if (v.text !== undefined && typeof v.text !== "string") return false;
+  if (v.speakerName !== undefined && typeof v.speakerName !== "string") return false;
+  if (v.styleName !== undefined && typeof v.styleName !== "string") return false;
+  return true;
+}
+
+// TimelineEntry はタイムラインに表示される項目の共通型。
+// クリップとエラーを discriminated union で扱い、既存の履歴件数上限を共通の枠で適用する。
+export type TimelineEntry =
+  | ({ kind: "clip" } & ClipEvent)
+  | ({ kind: "error" } & ErrorEventPayload);
 
 export function isSpeaker(value: unknown): value is Speaker {
   if (typeof value !== "object" || value === null) {

--- a/internal/app/player.go
+++ b/internal/app/player.go
@@ -2,6 +2,37 @@ package app
 
 import "context"
 
+// StreamErrorCategory は配信画面に表示するサーバー側エラーの種別。
+type StreamErrorCategory string
+
+const (
+	// StreamErrorCategorySynthesis は CreateQuery / Synthesize / Play など合成・再生系エラー。
+	StreamErrorCategorySynthesis StreamErrorCategory = "synthesis"
+	// StreamErrorCategoryFile は監視対象スクリプトファイルの読込・移動・削除の失敗。
+	StreamErrorCategoryFile StreamErrorCategory = "file"
+	// StreamErrorCategoryConnection は VOICEVOX エンジンへの接続に関わる失敗（HealthCheck 等）。
+	StreamErrorCategoryConnection StreamErrorCategory = "connection"
+)
+
+// StreamError は配信画面に通知するサーバー側エラーの情報。
+// Category が StreamErrorCategorySynthesis の場合のみ Text / SpeakerID が使われ、
+// broadcaster 側で speakerLookup を参照して speakerName / styleName が解決される。
+// file / connection カテゴリでは該当しないフィールドは無視される。
+type StreamError struct {
+	Category  StreamErrorCategory
+	Message   string
+	Path      string
+	Text      string
+	SpeakerID int
+}
+
+// ErrorBroadcaster は配信画面向けにサーバー側エラーをブロードキャストする。
+// StreamPlayer 実装が同時に実装することを想定し、WatchUsecase からは
+// textPlayer と同じく type assertion で取得する。
+type ErrorBroadcaster interface {
+	BroadcastError(e StreamError)
+}
+
 // PlayMeta は AudioPlayer.Play に付随させる補助情報。
 // 再生の実装（ローカルスピーカー/HTTPストリーム等）によっては利用しない場合もある。
 type PlayMeta struct {

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -62,6 +62,26 @@ func (u *WatchUsecase) broadcastError(e StreamError) {
 	}
 }
 
+// broadcastSynthesisError は synthesis カテゴリのエラーを対象スクリプト情報付きで配信する。
+func (u *WatchUsecase) broadcastSynthesisError(script entity.Script, speakerID int, err error) {
+	u.broadcastError(StreamError{
+		Category:  StreamErrorCategorySynthesis,
+		Message:   err.Error(),
+		Path:      script.Path,
+		Text:      script.Text,
+		SpeakerID: speakerID,
+	})
+}
+
+// broadcastFileError は file カテゴリのエラーをファイルパス付きで配信する。
+func (u *WatchUsecase) broadcastFileError(path string, err error) {
+	u.broadcastError(StreamError{
+		Category: StreamErrorCategoryFile,
+		Message:  err.Error(),
+		Path:     path,
+	})
+}
+
 // WatchUsecase はディレクトリ監視モードのユースケース。
 type WatchUsecase struct {
 	reader     ScriptReader
@@ -209,22 +229,14 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 		if u.deleteMode {
 			if delErr := u.mover.Delete(path); delErr != nil {
 				u.logger.Error("delete error", "path", path, "error", delErr)
-				u.broadcastError(StreamError{
-					Category: StreamErrorCategoryFile,
-					Message:  delErr.Error(),
-					Path:     path,
-				})
+				u.broadcastFileError(path, delErr)
 			} else {
 				u.logger.Debug("file deleted", "path", path)
 			}
 		} else {
 			if moveErr := u.mover.MoveToDone(path); moveErr != nil {
 				u.logger.Error("move error", "path", path, "error", moveErr)
-				u.broadcastError(StreamError{
-					Category: StreamErrorCategoryFile,
-					Message:  moveErr.Error(),
-					Path:     path,
-				})
+				u.broadcastFileError(path, moveErr)
 			} else {
 				u.logger.Debug("file moved to done", "path", path)
 			}
@@ -234,11 +246,7 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 	scripts, err := u.reader.Read(path)
 	if err != nil {
 		u.logger.Error("read error (skipping)", "path", path, "error", err)
-		u.broadcastError(StreamError{
-			Category: StreamErrorCategoryFile,
-			Message:  err.Error(),
-			Path:     path,
-		})
+		u.broadcastFileError(path, err)
 		return
 	}
 
@@ -273,23 +281,11 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 		switch result.stage {
 		case synthStageQueryFailed:
 			u.logger.Error("create query error (skipping script)", "path", result.script.Path, "error", result.err)
-			u.broadcastError(StreamError{
-				Category:  StreamErrorCategorySynthesis,
-				Message:   result.err.Error(),
-				Path:      result.script.Path,
-				Text:      result.script.Text,
-				SpeakerID: speakerID,
-			})
+			u.broadcastSynthesisError(result.script, speakerID, result.err)
 			continue
 		case synthStageSynthesizeFailed:
 			u.logger.Error("synthesize error (skipping script)", "path", result.script.Path, "error", result.err)
-			u.broadcastError(StreamError{
-				Category:  StreamErrorCategorySynthesis,
-				Message:   result.err.Error(),
-				Path:      result.script.Path,
-				Text:      result.script.Text,
-				SpeakerID: speakerID,
-			})
+			u.broadcastSynthesisError(result.script, speakerID, result.err)
 			continue
 		}
 
@@ -297,13 +293,7 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 
 		if err := u.player.Play(ctx, result.wav, PlayMeta{Text: result.script.Text, SpeakerID: speakerID}); err != nil {
 			u.logger.Error("play error (skipping script)", "path", result.script.Path, "error", err)
-			u.broadcastError(StreamError{
-				Category:  StreamErrorCategorySynthesis,
-				Message:   err.Error(),
-				Path:      result.script.Path,
-				Text:      result.script.Text,
-				SpeakerID: speakerID,
-			})
+			u.broadcastSynthesisError(result.script, speakerID, err)
 			continue
 		}
 		u.logger.Info(fmt.Sprintf("[%d/%d] playback completed", result.index, total), "text", truncateAndEscapeText(result.script.Text))
@@ -337,13 +327,7 @@ func (u *WatchUsecase) processScriptsSilent(ctx context.Context, scripts []entit
 		speakerID := script.ResolveSpeakerID(params.SpeakerID)
 		if err := tp.PlayText(ctx, PlayMeta{Text: script.Text, SpeakerID: speakerID}); err != nil {
 			u.logger.Error("silent play error (skipping script)", "path", script.Path, "error", err)
-			u.broadcastError(StreamError{
-				Category:  StreamErrorCategorySynthesis,
-				Message:   err.Error(),
-				Path:      script.Path,
-				Text:      script.Text,
-				SpeakerID: speakerID,
-			})
+			u.broadcastSynthesisError(script, speakerID, err)
 			continue
 		}
 		u.logger.Info(fmt.Sprintf("[%d/%d] playback completed (silent)", current, total), "text", truncateAndEscapeText(script.Text))

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -54,6 +54,14 @@ type textPlayer interface {
 	PlayText(ctx context.Context, meta PlayMeta) error
 }
 
+// broadcastError は player が ErrorBroadcaster を実装している場合のみ、
+// 配信画面向けのエラー通知をブロードキャストする。それ以外は no-op。
+func (u *WatchUsecase) broadcastError(e StreamError) {
+	if b, ok := u.player.(ErrorBroadcaster); ok {
+		b.BroadcastError(e)
+	}
+}
+
 // WatchUsecase はディレクトリ監視モードのユースケース。
 type WatchUsecase struct {
 	reader     ScriptReader
@@ -93,6 +101,10 @@ func (u *WatchUsecase) Run(ctx context.Context, params WatchParams) error {
 
 	if !params.DryRun && !u.silent {
 		if err := u.client.HealthCheck(ctx); err != nil {
+			u.broadcastError(StreamError{
+				Category: StreamErrorCategoryConnection,
+				Message:  err.Error(),
+			})
 			return err
 		}
 		u.logger.Info("engine health check passed")
@@ -197,12 +209,22 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 		if u.deleteMode {
 			if delErr := u.mover.Delete(path); delErr != nil {
 				u.logger.Error("delete error", "path", path, "error", delErr)
+				u.broadcastError(StreamError{
+					Category: StreamErrorCategoryFile,
+					Message:  delErr.Error(),
+					Path:     path,
+				})
 			} else {
 				u.logger.Debug("file deleted", "path", path)
 			}
 		} else {
 			if moveErr := u.mover.MoveToDone(path); moveErr != nil {
 				u.logger.Error("move error", "path", path, "error", moveErr)
+				u.broadcastError(StreamError{
+					Category: StreamErrorCategoryFile,
+					Message:  moveErr.Error(),
+					Path:     path,
+				})
 			} else {
 				u.logger.Debug("file moved to done", "path", path)
 			}
@@ -212,6 +234,11 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 	scripts, err := u.reader.Read(path)
 	if err != nil {
 		u.logger.Error("read error (skipping)", "path", path, "error", err)
+		u.broadcastError(StreamError{
+			Category: StreamErrorCategoryFile,
+			Message:  err.Error(),
+			Path:     path,
+		})
 		return
 	}
 
@@ -242,20 +269,41 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 	ch := startSynthPipeline(ctx, u.client, u.logger, scripts, cfg)
 
 	for result := range ch {
+		speakerID := result.script.ResolveSpeakerID(params.SpeakerID)
 		switch result.stage {
 		case synthStageQueryFailed:
 			u.logger.Error("create query error (skipping script)", "path", result.script.Path, "error", result.err)
+			u.broadcastError(StreamError{
+				Category:  StreamErrorCategorySynthesis,
+				Message:   result.err.Error(),
+				Path:      result.script.Path,
+				Text:      result.script.Text,
+				SpeakerID: speakerID,
+			})
 			continue
 		case synthStageSynthesizeFailed:
 			u.logger.Error("synthesize error (skipping script)", "path", result.script.Path, "error", result.err)
+			u.broadcastError(StreamError{
+				Category:  StreamErrorCategorySynthesis,
+				Message:   result.err.Error(),
+				Path:      result.script.Path,
+				Text:      result.script.Text,
+				SpeakerID: speakerID,
+			})
 			continue
 		}
 
 		u.logger.Debug("processing script", "path", result.script.Path)
 
-		speakerID := result.script.ResolveSpeakerID(params.SpeakerID)
 		if err := u.player.Play(ctx, result.wav, PlayMeta{Text: result.script.Text, SpeakerID: speakerID}); err != nil {
 			u.logger.Error("play error (skipping script)", "path", result.script.Path, "error", err)
+			u.broadcastError(StreamError{
+				Category:  StreamErrorCategorySynthesis,
+				Message:   err.Error(),
+				Path:      result.script.Path,
+				Text:      result.script.Text,
+				SpeakerID: speakerID,
+			})
 			continue
 		}
 		u.logger.Info(fmt.Sprintf("[%d/%d] playback completed", result.index, total), "text", truncateAndEscapeText(result.script.Text))
@@ -289,6 +337,13 @@ func (u *WatchUsecase) processScriptsSilent(ctx context.Context, scripts []entit
 		speakerID := script.ResolveSpeakerID(params.SpeakerID)
 		if err := tp.PlayText(ctx, PlayMeta{Text: script.Text, SpeakerID: speakerID}); err != nil {
 			u.logger.Error("silent play error (skipping script)", "path", script.Path, "error", err)
+			u.broadcastError(StreamError{
+				Category:  StreamErrorCategorySynthesis,
+				Message:   err.Error(),
+				Path:      script.Path,
+				Text:      script.Text,
+				SpeakerID: speakerID,
+			})
 			continue
 		}
 		u.logger.Info(fmt.Sprintf("[%d/%d] playback completed (silent)", current, total), "text", truncateAndEscapeText(script.Text))

--- a/internal/app/watch_usecase_test.go
+++ b/internal/app/watch_usecase_test.go
@@ -1338,3 +1338,266 @@ func TestWatchUsecase_Run_SilentMode_EmptyScriptsSkipped(t *testing.T) {
 		t.Errorf("expected 1 PlayText call (empty script skipped), got: %d", player.playTextCalls)
 	}
 }
+
+// --- #285 サーバー側エラー配信 ---
+
+// recordingErrorPlayer は AudioPlayer + textPlayer + ErrorBroadcaster を実装し、
+// watch_usecase から broadcast されたエラーを記録する。
+type recordingErrorPlayer struct {
+	mu              sync.Mutex
+	playErr         error
+	playTextErr     error
+	playCalls       int
+	playTextCalls   int
+	broadcastErrors []app.StreamError
+}
+
+func (p *recordingErrorPlayer) Play(_ context.Context, _ []byte, _ app.PlayMeta) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.playCalls++
+	return p.playErr
+}
+
+func (p *recordingErrorPlayer) PlayText(_ context.Context, _ app.PlayMeta) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.playTextCalls++
+	return p.playTextErr
+}
+
+func (p *recordingErrorPlayer) BroadcastError(e app.StreamError) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.broadcastErrors = append(p.broadcastErrors, e)
+}
+
+func (p *recordingErrorPlayer) errors() []app.StreamError {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]app.StreamError, len(p.broadcastErrors))
+	copy(out, p.broadcastErrors)
+	return out
+}
+
+func findError(errs []app.StreamError, category app.StreamErrorCategory) (app.StreamError, bool) {
+	for _, e := range errs {
+		if e.Category == category {
+			return e, true
+		}
+	}
+	return app.StreamError{}, false
+}
+
+func TestWatchUsecase_Run_BroadcastsFileError_OnReadFailure(t *testing.T) {
+	reader := &mockScriptReader{err: errors.New("read denied")}
+	client := &mockVoicevoxClient{query: &entity.AudioQuery{}, wavData: []byte("w")}
+	player := &recordingErrorPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	errs := player.errors()
+	e, ok := findError(errs, app.StreamErrorCategoryFile)
+	if !ok {
+		t.Fatalf("expected file category error, got: %+v", errs)
+	}
+	if e.Path != "/tmp/watch/a.txt" {
+		t.Errorf("expected path=/tmp/watch/a.txt, got %q", e.Path)
+	}
+	if !strings.Contains(e.Message, "read denied") {
+		t.Errorf("expected message to contain underlying error, got %q", e.Message)
+	}
+}
+
+func TestWatchUsecase_Run_BroadcastsFileError_OnMoveFailure(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{{Path: "a.txt", Text: "hi", IsEmpty: false}},
+	}
+	client := &mockVoicevoxClient{query: &entity.AudioQuery{}, wavData: []byte("w")}
+	player := &recordingErrorPlayer{}
+	mover := &mockFileMover{err: errors.New("permission denied")}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	errs := player.errors()
+	e, ok := findError(errs, app.StreamErrorCategoryFile)
+	if !ok {
+		t.Fatalf("expected file category error, got: %+v", errs)
+	}
+	if e.Path != "/tmp/watch/a.txt" {
+		t.Errorf("expected path=/tmp/watch/a.txt, got %q", e.Path)
+	}
+	if !strings.Contains(e.Message, "permission denied") {
+		t.Errorf("expected message to contain underlying error, got %q", e.Message)
+	}
+}
+
+func TestWatchUsecase_Run_BroadcastsFileError_OnDeleteFailure(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{{Path: "a.txt", Text: "hi", IsEmpty: false}},
+	}
+	client := &mockVoicevoxClient{query: &entity.AudioQuery{}, wavData: []byte("w")}
+	player := &recordingErrorPlayer{}
+	mover := &mockFileMover{deleteErr: errors.New("unlink failed")}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithDeleteMode())
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	errs := player.errors()
+	e, ok := findError(errs, app.StreamErrorCategoryFile)
+	if !ok {
+		t.Fatalf("expected file category error, got: %+v", errs)
+	}
+	if !strings.Contains(e.Message, "unlink failed") {
+		t.Errorf("expected message to contain underlying error, got %q", e.Message)
+	}
+}
+
+func TestWatchUsecase_Run_BroadcastsSynthesisError_OnCreateQueryFailure(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{{Path: "a.txt", Text: "hi", IsEmpty: false}},
+	}
+	client := &mockVoicevoxClient{createQueryErr: errors.New("bad query")}
+	player := &recordingErrorPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	errs := player.errors()
+	e, ok := findError(errs, app.StreamErrorCategorySynthesis)
+	if !ok {
+		t.Fatalf("expected synthesis category error, got: %+v", errs)
+	}
+	if e.Path != "a.txt" {
+		t.Errorf("expected path=a.txt, got %q", e.Path)
+	}
+	if e.Text != "hi" {
+		t.Errorf("expected text=hi, got %q", e.Text)
+	}
+	if e.SpeakerID != 3 {
+		t.Errorf("expected speakerID=3, got %d", e.SpeakerID)
+	}
+	if !strings.Contains(e.Message, "bad query") {
+		t.Errorf("expected message to contain underlying error, got %q", e.Message)
+	}
+}
+
+func TestWatchUsecase_Run_BroadcastsSynthesisError_OnSynthesizeFailure(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{{Path: "a.txt", Text: "hi", IsEmpty: false}},
+	}
+	client := &mockVoicevoxClient{query: &entity.AudioQuery{}, synthesizeErr: errors.New("synth fail")}
+	player := &recordingErrorPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	errs := player.errors()
+	e, ok := findError(errs, app.StreamErrorCategorySynthesis)
+	if !ok {
+		t.Fatalf("expected synthesis category error, got: %+v", errs)
+	}
+	if !strings.Contains(e.Message, "synth fail") {
+		t.Errorf("expected message to contain underlying error, got %q", e.Message)
+	}
+}
+
+func TestWatchUsecase_Run_BroadcastsSynthesisError_OnPlayFailure(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{{Path: "a.txt", Text: "hi", IsEmpty: false}},
+	}
+	client := &mockVoicevoxClient{query: &entity.AudioQuery{}, wavData: []byte("w")}
+	player := &recordingErrorPlayer{playErr: errors.New("play fail")}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	errs := player.errors()
+	e, ok := findError(errs, app.StreamErrorCategorySynthesis)
+	if !ok {
+		t.Fatalf("expected synthesis category error, got: %+v", errs)
+	}
+	if !strings.Contains(e.Message, "play fail") {
+		t.Errorf("expected message to contain underlying error, got %q", e.Message)
+	}
+}
+
+func TestWatchUsecase_Run_BroadcastsSynthesisError_OnSilentPlayTextFailure(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{{Path: "a.txt", Text: "hi", IsEmpty: false}},
+	}
+	client := &mockVoicevoxClient{}
+	player := &recordingErrorPlayer{playTextErr: errors.New("silent play fail")}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithSilent())
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	errs := player.errors()
+	e, ok := findError(errs, app.StreamErrorCategorySynthesis)
+	if !ok {
+		t.Fatalf("expected synthesis category error, got: %+v", errs)
+	}
+	if !strings.Contains(e.Message, "silent play fail") {
+		t.Errorf("expected message to contain underlying error, got %q", e.Message)
+	}
+}
+
+func TestWatchUsecase_Run_BroadcastsConnectionError_OnHealthCheckFailure(t *testing.T) {
+	reader := &mockScriptReader{}
+	client := &mockVoicevoxClient{healthCheckErr: errors.New("engine unreachable")}
+	player := &recordingErrorPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+
+	if err := uc.Run(context.Background(), params); err == nil {
+		t.Fatal("expected error from HealthCheck, got nil")
+	}
+
+	errs := player.errors()
+	e, ok := findError(errs, app.StreamErrorCategoryConnection)
+	if !ok {
+		t.Fatalf("expected connection category error, got: %+v", errs)
+	}
+	if !strings.Contains(e.Message, "engine unreachable") {
+		t.Errorf("expected message to contain underlying error, got %q", e.Message)
+	}
+}

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -442,7 +442,6 @@ func (p *HTTPStreamPlayer) BroadcastError(e app.StreamError) {
 	case app.StreamErrorCategoryFile:
 		ev.Path = e.Path
 	case app.StreamErrorCategoryConnection:
-		// message / timestamp / id のみ
 	}
 
 	payload, err := json.Marshal(ev)

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -62,11 +62,15 @@ type HTTPStreamPlayer struct {
 	started     bool
 	shutdown    bool
 	nextClipID  atomic.Uint64
+	nextErrorID atomic.Uint64
 	clips       *clipRingBuffer
 	subscribers *subscriberRegistry
 }
 
-var _ app.StreamPlayer = (*HTTPStreamPlayer)(nil)
+var (
+	_ app.StreamPlayer     = (*HTTPStreamPlayer)(nil)
+	_ app.ErrorBroadcaster = (*HTTPStreamPlayer)(nil)
+)
 
 const (
 	// streamHistorySize はサーバー側 WAV リングバッファの容量（固定値）。
@@ -75,6 +79,7 @@ const (
 	clipPathPrefix      = "/clips/"
 	clipPathSuffix      = ".wav"
 	sseEventClip        = "clip"
+	sseEventError       = "error"
 	sseSubscriberBuffer = 16
 	// defaultTestPhrase は /test-clip で合成するデフォルトフレーズ。
 	defaultTestPhrase = "音量テストです"
@@ -92,6 +97,24 @@ type clipEvent struct {
 	StyleName   string `json:"styleName"`
 	// Timestamp は配信時刻の Unix ms（UTC）。ブラウザ側で HH:MM:SS に整形する。
 	Timestamp int64 `json:"timestamp"`
+}
+
+// errorEvent は SSE で配信する error イベントのペイロード。
+// Category に応じて一部フィールドは省略される（omitempty）。
+type errorEvent struct {
+	// ID はエラーイベントの連番（1 始まり、clipEvent とは独立）。
+	ID       uint64 `json:"id"`
+	Category string `json:"category"`
+	Message  string `json:"message"`
+	// Timestamp は配信時刻の Unix ms（UTC）。
+	Timestamp int64 `json:"timestamp"`
+	// Path は synthesis / file カテゴリで対象ファイル情報を伝える。
+	Path string `json:"path,omitempty"`
+	// Text は synthesis カテゴリでの読み上げテキスト。
+	Text string `json:"text,omitempty"`
+	// SpeakerName / StyleName は synthesis カテゴリで speakerLookup から解決される。
+	SpeakerName string `json:"speakerName,omitempty"`
+	StyleName   string `json:"styleName,omitempty"`
 }
 
 // HTTPStreamOption は HTTPStreamPlayer の生成時に指定するオプション。
@@ -397,6 +420,42 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// BroadcastError はサーバー側エラーを SSE "error" イベントとして購読者に配信する。
+// Category が StreamErrorCategorySynthesis のときのみ speakerLookup を参照して
+// speakerName / styleName を解決する。それ以外のカテゴリでは該当フィールドを空にする。
+// Start 前の呼び出しは no-op となる（subscribers は空、clip と同様）。
+func (p *HTTPStreamPlayer) BroadcastError(e app.StreamError) {
+	id := p.nextErrorID.Add(1)
+	ev := errorEvent{
+		ID:        id,
+		Category:  string(e.Category),
+		Message:   e.Message,
+		Timestamp: p.nowFunc().UnixMilli(),
+	}
+	switch e.Category {
+	case app.StreamErrorCategorySynthesis:
+		ev.Path = e.Path
+		ev.Text = e.Text
+		ev.SpeakerName, ev.StyleName = p.resolveSpeaker(e.SpeakerID)
+	case app.StreamErrorCategoryFile:
+		ev.Path = e.Path
+	case app.StreamErrorCategoryConnection:
+		// message / timestamp / id のみ
+	}
+
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		p.logger.Error("failed to marshal error payload", "error", err, "category", ev.Category)
+		return
+	}
+
+	n, dropped := p.subscribers.broadcast(sseEventError, payload)
+	if dropped > 0 {
+		p.logger.Warn("stream error event dropped for slow subscribers", "errorId", id, "dropped", dropped)
+	}
+	p.logger.Debug("stream error event delivered", "errorId", id, "category", ev.Category, "subscribers", n)
 }
 
 func (p *HTTPStreamPlayer) handleClip(w http.ResponseWriter, r *http.Request) {

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -64,6 +64,14 @@ package infra
 // DONE: PlayText が url="" で clipEvent を配信し silentInterval ぶん待機する
 // DONE: PlayText はキャンセル済み ctx で即エラー
 // DONE: PlayText は Start 前だとエラー
+//
+// #285 サーバー側エラー配信:
+// TODO: BroadcastError が SSE "error" イベントで errorEvent を配信する（synthesis カテゴリ）
+// TODO: synthesis カテゴリは path/text/speakerName/styleName を含み lookup から解決される
+// TODO: file カテゴリは path を含み text/speakerName/styleName を省略する
+// TODO: connection カテゴリは message のみを含む
+// TODO: errorEvent.id はクリップIDと独立に 1 から単調増加する
+// TODO: BroadcastError は複数購読者にブロードキャストされる
 
 import (
 	"bufio"
@@ -365,6 +373,12 @@ func TestHTTPStreamPlayer_Play_CancelledContext(t *testing.T) {
 // テスト終了時にクリーンアップされる。
 func subscribeSSE(t *testing.T, baseURL string) <-chan string {
 	t.Helper()
+	return subscribeSSEByEvent(t, baseURL, "clip")
+}
+
+// subscribeSSEByEvent は /events に接続し、指定したイベント名の data のみをチャネルに流す。
+func subscribeSSEByEvent(t *testing.T, baseURL, wantEvent string) <-chan string {
+	t.Helper()
 
 	req, err := http.NewRequest(http.MethodGet, baseURL+"/events", nil)
 	if err != nil {
@@ -401,7 +415,7 @@ func subscribeSSE(t *testing.T, baseURL string) <-chan string {
 				eventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
 			case strings.HasPrefix(line, "data:"):
 				data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-				if eventName == "clip" {
+				if eventName == wantEvent {
 					select {
 					case events <- data:
 					case <-ctx.Done():
@@ -1342,4 +1356,229 @@ func TestHTTPStreamPlayer_TestClip_CreateQueryFailureReturns502(t *testing.T) {
 	if resp.StatusCode != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d", resp.StatusCode)
 	}
+}
+
+// --- #285 サーバー側エラー配信 ---
+
+func TestHTTPStreamPlayer_BroadcastError_SynthesisCategory(t *testing.T) {
+	t.Parallel()
+	lookup := map[int]entity.SpeakerStyleInfo{
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	fixed := time.Date(2026, 4, 24, 12, 0, 0, 456_000_000, time.UTC)
+	p := newStartedPlayerWithOpts(t,
+		WithSpeakerLookup(lookup),
+		withNowFunc(func() time.Time { return fixed }),
+	)
+	baseURL := "http://" + p.Addr()
+
+	events := subscribeSSEByEvent(t, baseURL, "error")
+	time.Sleep(50 * time.Millisecond)
+
+	p.BroadcastError(app.StreamError{
+		Category:  app.StreamErrorCategorySynthesis,
+		Message:   "synthesize failed",
+		Path:      "/tmp/script.txt",
+		Text:      "こんにちは",
+		SpeakerID: 3,
+	})
+
+	select {
+	case data := <-events:
+		var ev errorEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			t.Fatalf("unmarshal: %v data=%s", err, data)
+		}
+		if ev.ID != 1 {
+			t.Errorf("expected id=1, got %d", ev.ID)
+		}
+		if ev.Category != "synthesis" {
+			t.Errorf("expected category=synthesis, got %q", ev.Category)
+		}
+		if ev.Message != "synthesize failed" {
+			t.Errorf("unexpected message: %q", ev.Message)
+		}
+		if ev.Path != "/tmp/script.txt" {
+			t.Errorf("unexpected path: %q", ev.Path)
+		}
+		if ev.Text != "こんにちは" {
+			t.Errorf("unexpected text: %q", ev.Text)
+		}
+		if ev.SpeakerName != "ずんだもん" {
+			t.Errorf("expected speakerName=ずんだもん, got %q", ev.SpeakerName)
+		}
+		if ev.StyleName != "ノーマル" {
+			t.Errorf("expected styleName=ノーマル, got %q", ev.StyleName)
+		}
+		if ev.Timestamp != fixed.UnixMilli() {
+			t.Errorf("expected timestamp=%d, got %d", fixed.UnixMilli(), ev.Timestamp)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for error event")
+	}
+}
+
+func TestHTTPStreamPlayer_BroadcastError_FileCategory(t *testing.T) {
+	t.Parallel()
+	p := newStartedPlayer(t)
+	baseURL := "http://" + p.Addr()
+
+	events := subscribeSSEByEvent(t, baseURL, "error")
+	time.Sleep(50 * time.Millisecond)
+
+	p.BroadcastError(app.StreamError{
+		Category: app.StreamErrorCategoryFile,
+		Message:  "failed to read script",
+		Path:     "/tmp/script.txt",
+	})
+
+	select {
+	case data := <-events:
+		var ev errorEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			t.Fatalf("unmarshal: %v data=%s", err, data)
+		}
+		if ev.Category != "file" {
+			t.Errorf("expected category=file, got %q", ev.Category)
+		}
+		if ev.Path != "/tmp/script.txt" {
+			t.Errorf("unexpected path: %q", ev.Path)
+		}
+		if ev.Text != "" {
+			t.Errorf("expected empty text, got %q", ev.Text)
+		}
+		if ev.SpeakerName != "" {
+			t.Errorf("expected empty speakerName, got %q", ev.SpeakerName)
+		}
+		if ev.StyleName != "" {
+			t.Errorf("expected empty styleName, got %q", ev.StyleName)
+		}
+		// 省略フィールドは JSON 上に出現しないこと（omitempty の確認）
+		if strings.Contains(data, `"text":`) {
+			t.Errorf("expected text to be omitted for file category, got: %s", data)
+		}
+		if strings.Contains(data, `"speakerName":`) {
+			t.Errorf("expected speakerName to be omitted for file category, got: %s", data)
+		}
+		if strings.Contains(data, `"styleName":`) {
+			t.Errorf("expected styleName to be omitted for file category, got: %s", data)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for error event")
+	}
+}
+
+func TestHTTPStreamPlayer_BroadcastError_ConnectionCategory(t *testing.T) {
+	t.Parallel()
+	p := newStartedPlayer(t)
+	baseURL := "http://" + p.Addr()
+
+	events := subscribeSSEByEvent(t, baseURL, "error")
+	time.Sleep(50 * time.Millisecond)
+
+	p.BroadcastError(app.StreamError{
+		Category: app.StreamErrorCategoryConnection,
+		Message:  "VOICEVOX unreachable",
+	})
+
+	select {
+	case data := <-events:
+		var ev errorEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			t.Fatalf("unmarshal: %v data=%s", err, data)
+		}
+		if ev.Category != "connection" {
+			t.Errorf("expected category=connection, got %q", ev.Category)
+		}
+		if ev.Message != "VOICEVOX unreachable" {
+			t.Errorf("unexpected message: %q", ev.Message)
+		}
+		if strings.Contains(data, `"path":`) {
+			t.Errorf("expected path to be omitted for connection category, got: %s", data)
+		}
+		if strings.Contains(data, `"text":`) {
+			t.Errorf("expected text to be omitted for connection category, got: %s", data)
+		}
+		if strings.Contains(data, `"speakerName":`) {
+			t.Errorf("expected speakerName to be omitted for connection category, got: %s", data)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for error event")
+	}
+}
+
+func TestHTTPStreamPlayer_BroadcastError_IDMonotonicAndIndependentFromClip(t *testing.T) {
+	t.Parallel()
+	p := newStartedPlayer(t)
+	baseURL := "http://" + p.Addr()
+
+	clipEvents := subscribeSSEByEvent(t, baseURL, "clip")
+	errorEvents := subscribeSSEByEvent(t, baseURL, "error")
+	time.Sleep(80 * time.Millisecond)
+
+	// clip を 2 回、error を 3 回交互に配信して、それぞれが独立に 1 始まりで連番になること
+	if err := p.Play(context.Background(), []byte("RIFFa"), app.PlayMeta{}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+	p.BroadcastError(app.StreamError{Category: app.StreamErrorCategoryFile, Message: "e1"})
+	p.BroadcastError(app.StreamError{Category: app.StreamErrorCategoryFile, Message: "e2"})
+	if err := p.Play(context.Background(), []byte("RIFFb"), app.PlayMeta{}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+	p.BroadcastError(app.StreamError{Category: app.StreamErrorCategoryFile, Message: "e3"})
+
+	for i := 1; i <= 2; i++ {
+		select {
+		case data := <-clipEvents:
+			needle := fmt.Sprintf(`"id":%d`, i)
+			if !strings.Contains(data, needle) {
+				t.Errorf("clip event #%d: expected %s, got %s", i, needle, data)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for clip #%d", i)
+		}
+	}
+	for i := 1; i <= 3; i++ {
+		select {
+		case data := <-errorEvents:
+			needle := fmt.Sprintf(`"id":%d`, i)
+			if !strings.Contains(data, needle) {
+				t.Errorf("error event #%d: expected %s, got %s", i, needle, data)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for error #%d", i)
+		}
+	}
+}
+
+func TestHTTPStreamPlayer_BroadcastError_MultipleSubscribers(t *testing.T) {
+	t.Parallel()
+	p := newStartedPlayer(t)
+	baseURL := "http://" + p.Addr()
+
+	const subscribers = 3
+	channels := make([]<-chan string, subscribers)
+	for i := range subscribers {
+		channels[i] = subscribeSSEByEvent(t, baseURL, "error")
+	}
+	time.Sleep(80 * time.Millisecond)
+
+	p.BroadcastError(app.StreamError{Category: app.StreamErrorCategoryFile, Message: "oh"})
+
+	for i, ch := range channels {
+		select {
+		case data := <-ch:
+			if !strings.Contains(data, `"id":1`) {
+				t.Errorf("subscriber %d got %s", i, data)
+			}
+		case <-time.After(2 * time.Second):
+			t.Errorf("subscriber %d timeout", i)
+		}
+	}
+}
+
+// HTTPStreamPlayer は app.ErrorBroadcaster を実装する。
+func TestHTTPStreamPlayer_ImplementsErrorBroadcaster(t *testing.T) {
+	t.Parallel()
+	var _ app.ErrorBroadcaster = (*HTTPStreamPlayer)(nil)
 }


### PR DESCRIPTION
## Summary

- 配信画面（Stream Panel）のタイムラインに、サーバー側で発生したエラー（合成 / ファイル読込系 / VOICEVOX接続）をリアルタイム表示する機能を追加。
- SSE に新規イベント種別 `error` を追加し、既存の `clip` と同じ broadcaster を経由して配信。`errorEvent.id` は `clipEvent` と独立した連番。
- フロントエンドは `TimelineEntry = ClipEntry | ErrorEntry` の discriminated union に変更し、既存の履歴件数上限（10/20/30/50/100/200）を clip/error 合算で適用。
- `useEventSource` は `"error"` SSE イベントを受け取りつつ、ネイティブの接続失敗イベントとは `event instanceof MessageEvent` で区別して従来通り再接続フローへ流す。

## 実装内容

### サーバー側 (Go)
- `app.ErrorBroadcaster` / `app.StreamError` / `StreamErrorCategory`（`synthesis` / `file` / `connection`）を追加
- `HTTPStreamPlayer.BroadcastError` で SSE `error` イベントを配信し、synthesis カテゴリのみ `speakerLookup` から `speakerName` / `styleName` を解決
- `WatchUsecase` から以下でブロードキャスト:
  - HealthCheck 失敗 → `connection`
  - read / move / delete 失敗 → `file`（path 付き）
  - CreateQuery / Synthesize / Play / PlayText 失敗 → `synthesis`（path / text / speakerID 付き）
- `broadcastSynthesisError` / `broadcastFileError` ヘルパーで生成箇所を集約

### フロントエンド (React / TypeScript)
- `ErrorEventPayload` / `ErrorCategory` / `TimelineEntry` を追加
- `useEventSource` を `onClip` + `onError` に拡張
- `TimelineItem` にエラー表示バリアント（`text-ctp-red` + 警告アイコン ⚠ + category label）を追加
- `trimClips` → `trimTimeline` に一般化し、再生中の clip 項目のみ削除を止める

## Test plan

- [x] `go test ./...` 全パス
- [x] `gofmt -l .` 指摘なし
- [x] `golangci-lint run` 0 issues
- [x] `npm run typecheck`（frontend）パス
- [x] `npm run build`（frontend）成功
- [x] ローカルで `watch --stream` 起動し、以下を目視確認:
  - [x] SSE `/events` が `event: error` ペイロードを正しく配信する（file カテゴリ）
  - [x] 既存の `event: clip` 配信が従来通り動作する

Closes #285

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
