### PR TITLE
feat: 配信画面のE2Eテストを追加する #294

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,5 +33,31 @@ jobs:
     - name: Install frontend dependencies
       run: cd frontend && npm ci
 
-    - name: E2E Test
+    - name: Cache Playwright browsers
+      id: cache-playwright
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
+
+    - name: Install Playwright browsers
+      if: steps.cache-playwright.outputs.cache-hit != 'true'
+      run: cd frontend && npx playwright install --with-deps chromium
+
+    - name: Install Playwright system deps
+      if: steps.cache-playwright.outputs.cache-hit == 'true'
+      run: cd frontend && npx playwright install-deps chromium
+
+    - name: E2E Test (Go)
       run: make test-e2e
+
+    - name: E2E Test (Frontend / Playwright)
+      run: make test-frontend-e2e
+
+    - name: Upload Playwright report on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: frontend/playwright-report/
+        retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ go.work.sum
 frontend/dist/*
 !frontend/dist/.gitkeep
 frontend/node_modules/
+
+# Playwright
+frontend/test-results/
+frontend/playwright-report/
+frontend/playwright/.cache/

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ depcheck: build-frontend
 test-e2e: build-frontend
 	go test -tags=e2e ./test/e2e/...
 
+# Playwright による配信画面のE2Eテスト。
+# `npx playwright install --with-deps chromium` 済みを前提とする（dev container では post-create.sh で導入済み）。
+test-frontend-e2e: frontend/node_modules
+	cd frontend && npm run test:e2e
+
 run-stream: build-frontend
 	go run . watch --engine-url http://voicevox:50021 --stream --stream-addr 0.0.0.0:8080 --queue
 
@@ -63,4 +68,4 @@ install: build-frontend
 
 all: build
 
-.PHONY: all setup build build-frontend clean test test-e2e fmt lint typecheck depcheck run-stream dev dev-frontend dev-backend install
+.PHONY: all setup build build-frontend clean test test-e2e test-frontend-e2e fmt lint typecheck depcheck run-stream dev dev-frontend dev-backend install

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -19,8 +19,11 @@ make build
 # テスト
 make test
 
-# E2Eテスト
+# E2Eテスト（Go: CLI レイヤー）
 make test-e2e
+
+# 配信画面の E2E テスト（Playwright + Chromium）
+make test-frontend-e2e
 
 # フォーマット
 make fmt
@@ -101,6 +104,40 @@ make dev-frontend
 | `frontend/src/types/api.ts` | サーバー（`internal/infra/http_stream_player.go`）と対応する JSON 型と型ガード |
 
 状態は原則 `App` で集中管理し、子コンポーネントは props で受け取る。`localStorage` のキーは `usePersistedState` に集約され、既存キー（`vox-actor.stream.*`）と互換です。
+
+## 配信画面の E2E テスト（Playwright）
+
+`frontend/test/e2e/` 以下に Playwright + Chromium による配信画面の E2E テストがあります。実バックエンド（`vox-actor watch --stream`）の代わりに `frontend/test/stub-server.mjs` のスタブを使い、SSE / `/api/status` / `/test-clip` / `/clips/*.wav` を決定的にエミュレートします。
+
+### 実行
+
+```bash
+make test-frontend-e2e
+# 直接実行する場合:
+cd frontend && npm run test:e2e
+```
+
+`playwright.config.ts` の `webServer` がスタブ（既定 `127.0.0.1:8080`）と Vite dev server（既定 `127.0.0.1:5173`）を自動起動します。`8080` が既に使われている場合（例: `make dev-backend` を起動中）は、`VOX_STUB_PORT` と `PLAYWRIGHT_BASE_URL` で別ポートに振り分けてください。
+
+```bash
+cd frontend
+VOX_STUB_PORT=18080 PLAYWRIGHT_BASE_URL=http://127.0.0.1:15173 \
+  npx playwright test --reporter=list
+```
+
+`vite.config.ts` の `server.proxy` の転送先は環境変数 `VITE_BACKEND_URL` で上書きできます（既定 `http://localhost:8080`）。`playwright.config.ts` はこれを利用してスタブのポートを Vite に伝えます。
+
+### スタブの制御エンドポイント
+
+テストは `APIRequestContext` でスタブの制御チャネルを叩き、SSE 配信内容や `/api/status` の応答を切り替えます（`frontend/test/e2e/helpers.ts`）。
+
+| メソッド・パス | 用途 |
+|---|---|
+| `POST /__stub/clip` | SSE で `clip` イベントを配信 |
+| `POST /__stub/error` | SSE で `error` イベントを配信 |
+| `POST /__stub/disconnect` | 全 SSE 接続を一斉切断（再接続テスト用） |
+| `POST /__stub/api-status` | `/api/status` の応答を上書き |
+| `POST /__stub/reset` | 内部状態を初期化 |
 
 ## アーキテクチャ
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.4",
+        "@types/node": "^25.6.0",
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react": "^4.7.0",
@@ -1442,6 +1443,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2297,6 +2308,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,11 +8,13 @@
     "build": "vite build",
     "postbuild": "touch dist/.gitkeep",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.4",
+    "@types/node": "^25.6.0",
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^4.7.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// 配信画面の E2E テスト設定。
+// webServer で「Vite dev server (5173)」と「スタブバックエンド (8080)」を順次起動し、
+// テストは Vite dev server を入口にして vite.config.ts の proxy 越しに stub と通信する。
+// CI では Chromium のみで実行する。`npx playwright install --with-deps chromium` 済みを前提。
+const FRONTEND_BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:5173";
+const FRONTEND_PORT = new URL(FRONTEND_BASE_URL).port || "5173";
+const STUB_PORT = process.env.VOX_STUB_PORT ?? "8080";
+
+export default defineConfig({
+  testDir: "./test/e2e",
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: FRONTEND_BASE_URL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        // audio.play() を user gesture 無しでも許可する。
+        // 配信画面の usePlaybackQueue は SSE 受信トリガーで再生するため、
+        // この設定が無いと CI 上で play() が reject されて無限ループに陥る。
+        launchOptions: { args: ["--autoplay-policy=no-user-gesture-required"] },
+      },
+    },
+  ],
+  webServer: [
+    {
+      command: `node test/stub-server.mjs`,
+      url: `http://127.0.0.1:${STUB_PORT}/api/status`,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { VOX_STUB_PORT: STUB_PORT },
+    },
+    {
+      command: `npm run dev -- --host 127.0.0.1 --port ${FRONTEND_PORT} --strictPort`,
+      url: FRONTEND_BASE_URL,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+      // VITE_BACKEND_URL を渡して vite.config.ts の proxy target を stub のポートに向ける。
+      env: { VITE_BACKEND_URL: `http://127.0.0.1:${STUB_PORT}` },
+    },
+  ],
+});

--- a/frontend/test/e2e/helpers.ts
+++ b/frontend/test/e2e/helpers.ts
@@ -1,0 +1,74 @@
+import { type APIRequestContext, type Page, expect } from "@playwright/test";
+
+// stub-server.mjs の制御用エンドポイントは Vite dev server (`/`) からは proxy されない。
+// テストでは APIRequestContext を使って stub の素のポートに直接叩く。
+// VOX_STUB_PORT を変えた場合は同じ値を渡すこと（playwright.config.ts と揃える）。
+const STUB_PORT = process.env.VOX_STUB_PORT ?? "8080";
+const STUB_BASE_URL = process.env.VOX_STUB_BASE_URL ?? `http://127.0.0.1:${STUB_PORT}`;
+
+export interface ClipPayload {
+  id?: number;
+  url?: string;
+  text: string;
+  speakerName?: string;
+  styleName?: string;
+  timestamp?: number;
+}
+
+export interface ErrorPayload {
+  id?: number;
+  category: "synthesis" | "file" | "connection";
+  message: string;
+  timestamp?: number;
+  path?: string;
+  text?: string;
+  speakerName?: string;
+  styleName?: string;
+}
+
+export interface ApiStatusOverride {
+  silent?: boolean;
+  silentReason?: string;
+  speakers?: Array<{ id: number; speakerName: string; styleName: string }>;
+}
+
+export async function resetStub(request: APIRequestContext): Promise<void> {
+  const resp = await request.post(`${STUB_BASE_URL}/__stub/reset`);
+  expect(resp.ok()).toBeTruthy();
+}
+
+export async function setApiStatus(
+  request: APIRequestContext,
+  override: ApiStatusOverride,
+): Promise<void> {
+  const resp = await request.post(`${STUB_BASE_URL}/__stub/api-status`, {
+    data: override,
+  });
+  expect(resp.ok()).toBeTruthy();
+}
+
+export async function pushClip(
+  request: APIRequestContext,
+  payload: ClipPayload,
+): Promise<void> {
+  const resp = await request.post(`${STUB_BASE_URL}/__stub/clip`, { data: payload });
+  expect(resp.ok()).toBeTruthy();
+}
+
+export async function pushError(
+  request: APIRequestContext,
+  payload: ErrorPayload,
+): Promise<void> {
+  const resp = await request.post(`${STUB_BASE_URL}/__stub/error`, { data: payload });
+  expect(resp.ok()).toBeTruthy();
+}
+
+export async function disconnectAll(request: APIRequestContext): Promise<void> {
+  const resp = await request.post(`${STUB_BASE_URL}/__stub/disconnect`);
+  expect(resp.ok()).toBeTruthy();
+}
+
+// localStorage を読み取るユーティリティ。永続化テストで利用する。
+export async function readLocalStorage(page: Page, key: string): Promise<string | null> {
+  return page.evaluate((k) => window.localStorage.getItem(k), key);
+}

--- a/frontend/test/e2e/persistence.spec.ts
+++ b/frontend/test/e2e/persistence.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+import { readLocalStorage, resetStub } from "./helpers";
+
+test.describe("各種設定の localStorage 永続化", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test("履歴上限・表示トグルが localStorage に保存され、リロード後も復元される", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await page.getByLabel("履歴上限").selectOption("50");
+    await page.getByRole("checkbox", { name: "話者名" }).uncheck();
+    await page.getByRole("checkbox", { name: "スタイル" }).uncheck();
+    await page.getByRole("checkbox", { name: "時刻" }).uncheck();
+
+    await expect
+      .poll(() => readLocalStorage(page, "vox-actor.stream.historySize"))
+      .toBe("50");
+    await expect
+      .poll(() => readLocalStorage(page, "vox-actor.stream.showSpeakerName"))
+      .toBe("false");
+    await expect
+      .poll(() => readLocalStorage(page, "vox-actor.stream.showStyleName"))
+      .toBe("false");
+    await expect
+      .poll(() => readLocalStorage(page, "vox-actor.stream.showTimestamp"))
+      .toBe("false");
+
+    await page.reload();
+    await expect(page.getByLabel("履歴上限")).toHaveValue("50");
+    await expect(page.getByRole("checkbox", { name: "話者名" })).not.toBeChecked();
+    await expect(page.getByRole("checkbox", { name: "スタイル" })).not.toBeChecked();
+    await expect(page.getByRole("checkbox", { name: "時刻" })).not.toBeChecked();
+  });
+});

--- a/frontend/test/e2e/silent.spec.ts
+++ b/frontend/test/e2e/silent.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+import { pushClip, resetStub, setApiStatus } from "./helpers";
+
+test.describe("無音モード", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+    await setApiStatus(request, {
+      silent: true,
+      silentReason: "VOICEVOX が起動していません",
+      speakers: [],
+    });
+  });
+
+  test("SilentBadge が表示され、音声テストタブは描画されない", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: /無音モード/ })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "配信" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "音声テスト" })).toHaveCount(0);
+  });
+
+  test("URL 空の clip イベントもタイムラインに表示される", async ({ page, request }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    await pushClip(request, {
+      id: 501,
+      url: "",
+      text: "無音モードで配信されたテキスト",
+      speakerName: "ずんだもん",
+      styleName: "ノーマル",
+    });
+
+    const item = page.locator('[data-clip-id="501"]');
+    await expect(item).toBeVisible();
+    await expect(item).toContainText("無音モードで配信されたテキスト");
+  });
+});

--- a/frontend/test/e2e/stream.spec.ts
+++ b/frontend/test/e2e/stream.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { disconnectAll, pushClip, pushError, resetStub } from "./helpers";
+
+test.describe("配信タブ: SSE と Timeline", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test("SSE 接続後、clip イベントが Timeline に反映される", async ({ page, request }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    await pushClip(request, {
+      id: 101,
+      url: "/clips/101.wav",
+      text: "こんにちはなのだ",
+      speakerName: "ずんだもん",
+      styleName: "ノーマル",
+    });
+
+    const item = page.locator('[data-clip-id="101"]');
+    await expect(item).toBeVisible();
+    await expect(item).toContainText("こんにちはなのだ");
+    await expect(item).toContainText("ずんだもん");
+  });
+
+  test("error イベントが Timeline にエラーとして表示される", async ({ page, request }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    await pushError(request, {
+      id: 1,
+      category: "synthesis",
+      message: "合成に失敗しました",
+      text: "失敗テキスト",
+      speakerName: "四国めたん",
+      styleName: "ノーマル",
+    });
+
+    const errorItem = page.locator('[data-error-id="1"]');
+    await expect(errorItem).toBeVisible();
+    await expect(errorItem).toContainText("合成エラー");
+    await expect(errorItem).toContainText("合成に失敗しました");
+  });
+
+  test("SSE 切断後、自動再接続される", async ({ page, request }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    await disconnectAll(request);
+    await expect(page.getByText("● 切断")).toBeVisible();
+    // useEventSource の再接続タイマー（2 秒）+ 初回接続待ちぶんを見込んで余裕を持たせる。
+    await expect(page.getByText("● 接続中")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/frontend/test/e2e/tabs.spec.ts
+++ b/frontend/test/e2e/tabs.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import { readLocalStorage, resetStub } from "./helpers";
+
+test.describe("タブ切替", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test("配信タブと音声テストタブを切り替えられる", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    const streamPanel = page.locator("#panel-stream");
+    const testPanel = page.locator("#panel-test");
+
+    await expect(streamPanel).toBeVisible();
+    await expect(testPanel).toBeHidden();
+
+    await page.getByRole("tab", { name: "音声テスト" }).click();
+    await expect(testPanel).toBeVisible();
+    await expect(streamPanel).toBeHidden();
+
+    await page.getByRole("tab", { name: "配信" }).click();
+    await expect(streamPanel).toBeVisible();
+    await expect(testPanel).toBeHidden();
+  });
+
+  test("選択したタブはリロード後も復元される", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("tab", { name: "音声テスト" }).click();
+
+    await expect
+      .poll(() => readLocalStorage(page, "vox-actor.stream.activeTab"))
+      .toBe("test");
+
+    await page.reload();
+    await expect(page.locator("#panel-test")).toBeVisible();
+    await expect(page.locator("#panel-stream")).toBeHidden();
+  });
+});

--- a/frontend/test/e2e/test-panel.spec.ts
+++ b/frontend/test/e2e/test-panel.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { readLocalStorage, resetStub } from "./helpers";
+
+test.describe("音声テストタブ", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test("話者選択は localStorage に保存され、リロード後も復元される", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("tab", { name: "音声テスト" }).click();
+
+    const selector = page.getByLabel("話者", { exact: true });
+    await expect(selector).toBeVisible();
+    await selector.selectOption("1");
+
+    await expect
+      .poll(() => readLocalStorage(page, "vox-actor.stream.testSpeakerId"))
+      .toBe("1");
+
+    await page.reload();
+    await page.getByRole("tab", { name: "音声テスト" }).click();
+    await expect(page.getByLabel("話者", { exact: true })).toHaveValue("1");
+  });
+
+  test("テスト再生ボタンで /test-clip にリクエストが飛び、audio.src も更新される", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.getByRole("tab", { name: "音声テスト" }).click();
+    await page.getByLabel("話者", { exact: true }).selectOption("3");
+
+    const requestPromise = page.waitForRequest(
+      (req) =>
+        req.url().includes("/test-clip") && req.url().includes("speaker=3"),
+    );
+
+    await page.getByRole("button", { name: /テスト再生/ }).click();
+    const req = await requestPromise;
+    expect(req.url()).toContain("speaker=3");
+
+    await expect(page.locator("audio")).toHaveJSProperty(
+      "src",
+      new URL("/test-clip?speaker=3", page.url()).toString(),
+    );
+  });
+});

--- a/frontend/test/e2e/volume.spec.ts
+++ b/frontend/test/e2e/volume.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { readLocalStorage, resetStub } from "./helpers";
+
+test.describe("音量・消音コントロール", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test("音量スライダーの値が localStorage に保存され、リロード後も復元される", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const slider = page.getByRole("slider", { name: "音量" });
+    await slider.fill("23");
+
+    await expect
+      .poll(() => readLocalStorage(page, "vox-actor.stream.volume"))
+      .toBe("23");
+
+    await page.reload();
+    await expect(page.getByRole("slider", { name: "音量" })).toHaveValue("23");
+  });
+
+  test("消音チェックボックスの操作で audio.muted が連動する", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.locator("audio")).toHaveJSProperty("muted", true);
+
+    await page.getByRole("checkbox", { name: "消音" }).uncheck();
+    await expect(page.locator("audio")).toHaveJSProperty("muted", false);
+
+    await page.getByRole("checkbox", { name: "消音" }).check();
+    await expect(page.locator("audio")).toHaveJSProperty("muted", true);
+  });
+});

--- a/frontend/test/stub-server.mjs
+++ b/frontend/test/stub-server.mjs
@@ -1,0 +1,233 @@
+// Playwright E2E 用スタブサーバー。
+// バックエンド (internal/infra/http_stream_player.go) の /events, /api/status,
+// /test-clip, /clips/<id>.wav を Node 標準ライブラリだけでエミュレートする。
+//
+// テスト側からの制御チャネルとして以下を追加で提供する:
+// - POST /__stub/clip       { id?, url?, text, speakerName?, styleName?, timestamp? } → SSE clip 配信
+// - POST /__stub/error      { id?, category, message, ... } → SSE error 配信
+// - POST /__stub/disconnect → 全 SSE 接続を一斉切断（再接続テスト用）
+// - POST /__stub/api-status { silent, silentReason, speakers } → /api/status の応答を切替
+// - POST /__stub/reset      → 内部状態を初期化
+//
+// VOX_STUB_PORT で待受ポートを変えられる（既定: 8080）。
+
+import http from "node:http";
+
+const PORT = Number(process.env.VOX_STUB_PORT ?? 8080);
+
+// 短い無音 WAV（44 byte ヘッダのみ、PCM mono 8000Hz 8bit、データ長 0）。
+// /test-clip /clips/*.wav が返す。テストは再生成功までは検証しない。
+const SILENT_WAV = (() => {
+  const buf = Buffer.alloc(44);
+  buf.write("RIFF", 0);
+  buf.writeUInt32LE(36, 4);
+  buf.write("WAVE", 8);
+  buf.write("fmt ", 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20);
+  buf.writeUInt16LE(1, 22);
+  buf.writeUInt32LE(8000, 24);
+  buf.writeUInt32LE(8000, 28);
+  buf.writeUInt16LE(1, 32);
+  buf.writeUInt16LE(8, 34);
+  buf.write("data", 36);
+  buf.writeUInt32LE(0, 40);
+  return buf;
+})();
+
+const DEFAULT_API_STATUS = {
+  silent: false,
+  silentReason: "",
+  speakers: [
+    { id: 1, speakerName: "四国めたん", styleName: "ノーマル" },
+    { id: 3, speakerName: "ずんだもん", styleName: "ノーマル" },
+  ],
+};
+
+let apiStatus = structuredClone(DEFAULT_API_STATUS);
+let nextClipId = 0;
+let nextErrorId = 0;
+const subscribers = new Set();
+
+function readJSON(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (raw === "") return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function writeJSON(res, status, body) {
+  const payload = Buffer.from(JSON.stringify(body), "utf8");
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": payload.length,
+    "Cache-Control": "no-store",
+  });
+  res.end(payload);
+}
+
+function broadcast(event, data) {
+  const frame = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  for (const res of subscribers) {
+    res.write(frame);
+  }
+}
+
+function handleEvents(req, res) {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  res.write(": ok\n\n");
+  subscribers.add(res);
+  req.on("close", () => {
+    subscribers.delete(res);
+  });
+}
+
+function handleApiStatus(_req, res) {
+  writeJSON(res, 200, apiStatus);
+}
+
+function handleTestClip(req, res) {
+  const url = new URL(req.url, "http://localhost");
+  const speakerStr = url.searchParams.get("speaker") ?? "";
+  if (speakerStr === "") {
+    res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("speaker parameter is required");
+    return;
+  }
+  const speakerID = Number.parseInt(speakerStr, 10);
+  if (!Number.isInteger(speakerID)) {
+    res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("speaker parameter must be an integer");
+    return;
+  }
+  if (!apiStatus.speakers.some((s) => s.id === speakerID)) {
+    res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("speaker not found");
+    return;
+  }
+  res.writeHead(200, {
+    "Content-Type": "audio/wav",
+    "Content-Length": SILENT_WAV.length,
+  });
+  res.end(SILENT_WAV);
+}
+
+function handleClipFile(_req, res) {
+  res.writeHead(200, {
+    "Content-Type": "audio/wav",
+    "Content-Length": SILENT_WAV.length,
+  });
+  res.end(SILENT_WAV);
+}
+
+async function handleStubClip(req, res) {
+  const body = await readJSON(req);
+  nextClipId += 1;
+  const payload = {
+    id: typeof body.id === "number" ? body.id : nextClipId,
+    url: typeof body.url === "string" ? body.url : `/clips/${nextClipId}.wav`,
+    text: typeof body.text === "string" ? body.text : "",
+    speakerName: typeof body.speakerName === "string" ? body.speakerName : "ずんだもん",
+    styleName: typeof body.styleName === "string" ? body.styleName : "ノーマル",
+    timestamp: typeof body.timestamp === "number" ? body.timestamp : Date.now(),
+  };
+  broadcast("clip", payload);
+  writeJSON(res, 200, { ok: true, payload });
+}
+
+async function handleStubError(req, res) {
+  const body = await readJSON(req);
+  nextErrorId += 1;
+  const payload = {
+    id: typeof body.id === "number" ? body.id : nextErrorId,
+    category: typeof body.category === "string" ? body.category : "synthesis",
+    message: typeof body.message === "string" ? body.message : "stub error",
+    timestamp: typeof body.timestamp === "number" ? body.timestamp : Date.now(),
+  };
+  if (typeof body.path === "string") payload.path = body.path;
+  if (typeof body.text === "string") payload.text = body.text;
+  if (typeof body.speakerName === "string") payload.speakerName = body.speakerName;
+  if (typeof body.styleName === "string") payload.styleName = body.styleName;
+  broadcast("error", payload);
+  writeJSON(res, 200, { ok: true, payload });
+}
+
+function handleStubDisconnect(_req, res) {
+  for (const sub of subscribers) {
+    sub.end();
+  }
+  subscribers.clear();
+  writeJSON(res, 200, { ok: true });
+}
+
+async function handleStubApiStatus(req, res) {
+  const body = await readJSON(req);
+  apiStatus = {
+    silent: typeof body.silent === "boolean" ? body.silent : DEFAULT_API_STATUS.silent,
+    silentReason:
+      typeof body.silentReason === "string" ? body.silentReason : DEFAULT_API_STATUS.silentReason,
+    speakers: Array.isArray(body.speakers) ? body.speakers : DEFAULT_API_STATUS.speakers,
+  };
+  writeJSON(res, 200, { ok: true, apiStatus });
+}
+
+function handleStubReset(_req, res) {
+  apiStatus = structuredClone(DEFAULT_API_STATUS);
+  nextClipId = 0;
+  nextErrorId = 0;
+  for (const sub of subscribers) {
+    sub.end();
+  }
+  subscribers.clear();
+  writeJSON(res, 200, { ok: true });
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const path = url.pathname;
+
+  if (req.method === "GET" && path === "/events") return handleEvents(req, res);
+  if (req.method === "GET" && path === "/api/status") return handleApiStatus(req, res);
+  if (req.method === "GET" && path === "/test-clip") return handleTestClip(req, res);
+  if (req.method === "GET" && path.startsWith("/clips/") && path.endsWith(".wav")) {
+    return handleClipFile(req, res);
+  }
+  if (req.method === "POST" && path === "/__stub/clip") return handleStubClip(req, res);
+  if (req.method === "POST" && path === "/__stub/error") return handleStubError(req, res);
+  if (req.method === "POST" && path === "/__stub/disconnect") {
+    return handleStubDisconnect(req, res);
+  }
+  if (req.method === "POST" && path === "/__stub/api-status") {
+    return handleStubApiStatus(req, res);
+  }
+  if (req.method === "POST" && path === "/__stub/reset") return handleStubReset(req, res);
+
+  res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+  res.end("not found");
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`stub-server listening on http://127.0.0.1:${PORT}`);
+});
+
+const shutdown = () => {
+  for (const sub of subscribers) sub.end();
+  subscribers.clear();
+  server.close(() => process.exit(0));
+};
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,5 +19,5 @@
     "verbatimModuleSyntax": true,
     "useDefineForClassFields": true
   },
-  "include": ["src/**/*", "vite.config.ts"]
+  "include": ["src/**/*", "vite.config.ts", "playwright.config.ts", "test/**/*"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,8 @@ import { defineConfig } from "vite";
 // 配信画面は Go バックエンド (`vox-actor watch --stream`) 提供の SSE / API と
 // 同一オリジンで通信する前提なので、dev server からバックエンドへプロキシする。
 // バックエンドの既定バインドは `--stream-addr 127.0.0.1:8080`。
-const backendTarget = "http://localhost:8080";
+// E2E テスト等でスタブを別ポートに立てる場合は VITE_BACKEND_URL でオーバーライドする。
+const backendTarget = process.env.VITE_BACKEND_URL ?? "http://localhost:8080";
 
 export default defineConfig({
   root: ".",


### PR DESCRIPTION
## Summary

- 配信画面（フロントエンド）の E2E テストを Playwright + Chromium で実装した
- `frontend/test/stub-server.mjs` でバックエンドの SSE / `/api/status` / `/test-clip` / `/clips/*` を決定的にエミュレートし、`/__stub/*` のテスト制御エンドポイントから SSE 配信内容や API 応答を切り替えられる
- `playwright.config.ts` の `webServer` でスタブと Vite dev server を自動起動。`VITE_BACKEND_URL` で proxy 先を切替可能にし、ローカルで `make dev-backend` と並走させても別ポートで実行できる
- `make test-frontend-e2e` / `npm run test:e2e` で実行できる
- `.github/workflows/e2e.yml` に Playwright ステップを追加し、`actions/cache` でブラウザバイナリをキャッシュ。失敗時は `playwright-report` をアーティファクトとしてアップロードする
- `docs/development/contributing.md` に E2E テストの実行手順・別ポート設定・スタブ制御エンドポイントの一覧を追記

### テスト観点（Issue 完了条件と対応）

| 観点 | 対応テスト |
|---|---|
| SSE 接続 → `clip` 反映 | `stream.spec.ts` |
| `error` イベント表示 | `stream.spec.ts` |
| SSE 切断後の自動再接続 | `stream.spec.ts` |
| 音量スライダー操作 + localStorage 永続化 | `volume.spec.ts` |
| 消音チェックボックス連動 | `volume.spec.ts` |
| 無音モード時の UI（テストタブ非表示・URL 空 clip 表示） | `silent.spec.ts` |
| タブ切替 + 選択タブ永続化 | `tabs.spec.ts` |
| 話者選択の永続化 | `test-panel.spec.ts` |
| `/test-clip` 経由のテスト再生 | `test-panel.spec.ts` |
| 履歴上限・表示トグルの localStorage 永続化 | `persistence.spec.ts` |

## Test plan

- [x] `npm run typecheck` が通ること
- [x] ローカルで `VOX_STUB_PORT=18080 PLAYWRIGHT_BASE_URL=http://127.0.0.1:15173 npx playwright test --reporter=list` が 12 件全 PASS
- [ ] `e2e` ワークフローが PR で緑になること

Closes #294

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
