### PR TITLE
feat: say コマンドに -o オプションを追加してセリフをファイル出力できるようにする #295

### DIFF
--- a/cmd/say.go
+++ b/cmd/say.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +16,10 @@ import (
 type SayDeps struct {
 	ClientFactory func(engineURL string) app.VoicevoxClient
 	Player        app.AudioPlayer
+	// WriterFactory は -o / --output 指定時のファイル書き出し用 ScriptWriter を生成する。
+	// runSay で構築したロガーを Writer に注入できるようファクトリ形式とする。
+	// nil の場合は -o オプション利用時にエラーを返す。
+	WriterFactory func(logger *slog.Logger) app.ScriptWriter
 }
 
 func makeSayCmd(deps *SayDeps) *cobra.Command {
@@ -33,31 +39,41 @@ func makeSayCmd(deps *SayDeps) *cobra.Command {
 	}
 
 	registerCommonFlags(cmd)
+	cmd.Flags().StringP("output", "o", "", "セリフをファイル出力する（指定時はVOICEVOX接続・音声再生を行わない）")
 
 	return cmd
 }
 
 func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
-	if deps == nil || deps.ClientFactory == nil || deps.Player == nil {
+	if deps == nil {
 		return fmt.Errorf("say command dependencies are not initialized")
 	}
 
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	output, _ := cmd.Flags().GetString("output")
+
+	if output != "" && dryRun {
+		return fmt.Errorf("%w: --output and --dry-run cannot be specified together", ErrUsage)
+	}
+
+	logger := buildLoggerFromFlags(cmd)
+
+	if output != "" {
+		return runSayOutput(cmd, args[0], output, deps, logger)
+	}
+
+	if deps.ClientFactory == nil || deps.Player == nil {
+		return fmt.Errorf("say command dependencies are not initialized")
+	}
+
 	engineURL, _ := cmd.Flags().GetString("engine-url")
 	speakerID, _ := cmd.Flags().GetInt("speaker")
 	speed, _ := cmd.Flags().GetFloat64("speed")
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
-	dryRun, _ := cmd.Flags().GetBool("dry-run")
-
-	logger := buildLoggerFromFlags(cmd)
-
-	client := deps.ClientFactory(engineURL)
-	if client == nil {
-		return fmt.Errorf("failed to create VoicevoxClient for %s", engineURL)
-	}
 
 	params := app.SayParams{
 		Text:       args[0],
@@ -68,6 +84,44 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 		DryRun:     dryRun,
 	}
 
+	client := deps.ClientFactory(engineURL)
+	if client == nil {
+		return fmt.Errorf("failed to create VoicevoxClient for %s", engineURL)
+	}
+
 	uc := app.NewSayUsecase(client, deps.Player, app.WithSayLogger(logger))
 	return uc.Run(ctx, params)
+}
+
+// runSayOutput は --output モードを実行する。VOICEVOX/再生は呼ばず ScriptWriter で書き出す。
+func runSayOutput(cmd *cobra.Command, text, output string, deps *SayDeps, logger *slog.Logger) error {
+	if deps.WriterFactory == nil {
+		return fmt.Errorf("ScriptWriter factory is not configured for --output")
+	}
+
+	script := entity.Script{Text: text, IsEmpty: text == ""}
+	if cmd.Flags().Changed("speaker") {
+		v, _ := cmd.Flags().GetInt("speaker")
+		script.SpeakerID = &v
+	}
+	if cmd.Flags().Changed("speed") {
+		v, _ := cmd.Flags().GetFloat64("speed")
+		script.SpeedScale = &v
+	}
+	if cmd.Flags().Changed("pitch") {
+		v, _ := cmd.Flags().GetFloat64("pitch")
+		script.PitchScale = &v
+	}
+	if cmd.Flags().Changed("intonation") {
+		v, _ := cmd.Flags().GetFloat64("intonation")
+		script.IntonationScale = &v
+	}
+
+	writer := deps.WriterFactory(logger)
+	written, err := writer.Write(output, script)
+	if err != nil {
+		return err
+	}
+	logger.Info("output completed", "path", written)
+	return nil
 }

--- a/cmd/say_test.go
+++ b/cmd/say_test.go
@@ -2,23 +2,31 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"log/slog"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
 	"github.com/spf13/cobra"
 )
 
 // say コマンド テストリスト
 // DONE: sayサブコマンドがrootに登録されている
 // DONE: 引数なしでErrUsageを返す
-// DONE: ヘルプ出力に全フラグが含まれる（--engine-url, --speaker, --speed, --pitch, --intonation, --verbose）
+// DONE: ヘルプ出力に全フラグが含まれる（--engine-url, --speaker, --speed, --pitch, --intonation, --verbose, --output）
 // DONE: ヘルプ出力に--watchフラグが含まれない
 // DONE: デフォルトオプション値の確認（engine-url, speaker, speed, pitch, intonation）
 // DONE: 環境変数VOX_ENGINE_URLがデフォルト値に反映される
 // DONE: 環境変数VOX_SPEAKERがデフォルト値に反映される
 // DONE: VOX_SPEAKERに不正な値が設定されている場合デフォルト値が使われる
 // DONE: --verboseフラグのデフォルト値がfalse
+// DONE: --output と --dry-run の併用は ErrUsage
+// DONE: --output 指定時、Writer.Write が呼ばれる
+// DONE: --output 指定時、ClientFactory/Player は呼ばれない
 
 // findSayCmd はrootCmdからsayサブコマンドを検索して返すテストヘルパー。
 func findSayCmd(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
@@ -75,7 +83,7 @@ func TestSayCmd_HelpContainsFlags(t *testing.T) {
 	}
 
 	output := buf.String()
-	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run"}
+	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run", "--output"}
 	for _, flag := range flags {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected help output to contain '%s'", flag)
@@ -177,4 +185,117 @@ func TestSayCmd_VerboseFlag_DefaultFalse(t *testing.T) {
 	if verbose {
 		t.Error("expected --verbose default to be false")
 	}
+}
+
+// --- --output (-o) フラグ テスト ---
+
+type fakeScriptWriter struct {
+	calls []fakeWriterCall
+}
+
+type fakeWriterCall struct {
+	path string
+	text string
+}
+
+func (w *fakeScriptWriter) Write(path string, script entity.Script) (string, error) {
+	w.calls = append(w.calls, fakeWriterCall{path: path, text: script.Text})
+	return path, nil
+}
+
+func TestSayCmd_OutputFlag_HasShortAndLong(t *testing.T) {
+	rootCmd := makeRootCmd()
+	sayCmd := findSayCmd(t, rootCmd)
+
+	if f := sayCmd.Flags().Lookup("output"); f == nil {
+		t.Fatal("expected --output flag to be registered")
+	} else if f.Shorthand != "o" {
+		t.Errorf("expected --output shorthand to be 'o', got: %q", f.Shorthand)
+	}
+}
+
+func TestSayCmd_OutputAndDryRun_ReturnsUsageError(t *testing.T) {
+	writer := &fakeScriptWriter{}
+	deps := &Deps{
+		Say: &SayDeps{
+			ClientFactory: func(_ string) app.VoicevoxClient { return nil },
+			Player:        nil,
+			WriterFactory: func(_ *slog.Logger) app.ScriptWriter { return writer },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"say", "--output", "/tmp/out.txt", "--dry-run", "hello"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --output + --dry-run, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func TestSayCmd_OutputFlag_CallsWriter_NotClient(t *testing.T) {
+	writer := &fakeScriptWriter{}
+	clientFactoryCalled := false
+
+	deps := &Deps{
+		Say: &SayDeps{
+			ClientFactory: func(_ string) app.VoicevoxClient {
+				clientFactoryCalled = true
+				return &noopClient{}
+			},
+			Player:        &noopPlayer{},
+			WriterFactory: func(_ *slog.Logger) app.ScriptWriter { return writer },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "out.txt")
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"say", "--output", dest, "hello"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(writer.calls) != 1 {
+		t.Fatalf("expected 1 Writer.Write call, got: %d", len(writer.calls))
+	}
+	if writer.calls[0].path != dest {
+		t.Errorf("expected path=%q, got %q", dest, writer.calls[0].path)
+	}
+	if writer.calls[0].text != "hello" {
+		t.Errorf("expected text=hello, got %q", writer.calls[0].text)
+	}
+	if clientFactoryCalled {
+		t.Error("expected ClientFactory NOT to be called when --output is set")
+	}
+}
+
+// noopClient / noopPlayer は --output 経路では呼ばれないことを保証するためのスタブ。
+type noopClient struct{}
+
+func (n *noopClient) HealthCheck(_ context.Context) error { return errors.New("must not be called") }
+func (n *noopClient) CreateQuery(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	return nil, errors.New("must not be called")
+}
+func (n *noopClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+	return nil, errors.New("must not be called")
+}
+func (n *noopClient) GetSpeakers(_ context.Context) ([]entity.Speaker, error) {
+	return nil, errors.New("must not be called")
+}
+
+type noopPlayer struct{}
+
+func (n *noopPlayer) Play(_ context.Context, _ []byte, _ app.PlayMeta) error {
+	return errors.New("must not be called")
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -82,8 +82,34 @@ vox-actor say <text>
 | `--speed` | — | `1.0` | 話速 |
 | `--pitch` | — | `0.0` | 音高 |
 | `--intonation` | — | `1.0` | 抑揚 |
+| `-o`, `--output` | — | （未指定） | 指定時、音声再生せずセリフをファイル出力（[詳細](#--outputモード)） |
 | `--verbose` | — | `false` | 詳細ログを出力 |
 | `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#dry-runモード)） |
+
+### --outputモード
+
+`-o <パス>` または `--output <パス>` を指定すると、**音声合成・音声再生を行わず**にセリフをファイルへ書き出します。`vox-actor watch --queue` と組み合わせ、別プロセスで再生させたいユースケースに利用できます。
+
+- `-o` 指定時は **VOICEVOX エンジンへ接続しません**（`HealthCheck` / `CreateQuery` / `Synthesize` を呼ばない）。エンジンが起動していなくても成功します。
+- 出力ファイルの拡張子で書き出し形式を自動判定します。
+  - `.json` → 1ファイル1スクリプトのJSON。`text` に加え、明示指定された `--speaker` / `--speed` / `--pitch` / `--intonation` を `speaker` / `speedScale` / `pitchScale` / `intonationScale` として保存
+  - `.jsonl` → 1行JSON（フィールドは `.json` と同じ）
+  - `.txt` および **未知の拡張子** → 本文のみのテキストファイル（拡張子はそのまま）
+    - このとき `--speaker` / `--speed` / `--pitch` / `--intonation` がコマンドラインで明示指定されていたら、これらは保存できない旨を WARN ログで通知します（処理は継続）
+- **既存ファイルとの衝突回避**: 出力先に同名ファイルが存在する場合は、`<name>_<UnixNano><ext>` の形式で連番を付与してユニーク化します。
+- **親ディレクトリの扱い**: 親ディレクトリが存在しない場合はエラーになります（任意の深さを自動作成しません）。
+- **`--dry-run` との併用は禁止**です（起動時に `ErrUsage` で終了）。
+
+```bash
+# ホスト側 / 別ターミナル: queue を監視
+vox-actor watch --queue
+
+# claude code 等から: queue にテキストを書き出すと watch が拾って読み上げる
+vox-actor say -o "$(vox-actor config path.queue)/01.txt" "こんにちは"
+
+# パラメータを保持したい場合は .json / .jsonl で書き出す
+vox-actor say -o "$(vox-actor config path.queue)/01.json" --speaker 5 --speed 1.2 "こんにちは"
+```
 
 ## `act` サブコマンド
 

--- a/internal/app/port.go
+++ b/internal/app/port.go
@@ -14,6 +14,15 @@ type ScriptReader interface {
 	Read(path string) ([]entity.Script, error)
 }
 
+// ScriptWriter は entity.Script をファイルへ書き出すインターフェース。
+type ScriptWriter interface {
+	// Write は script を path に書き出す。
+	// 拡張子で書き出し形式を判定する: .json / .jsonl は感情制御パラメータも含めて、それ以外は本文のみ書き出す。
+	// 既存ファイルがある場合はリネームしてユニーク化する。
+	// 戻り値は実際の書き出し先パス。
+	Write(path string, script entity.Script) (string, error)
+}
+
 // FileMover はファイルを処理済みディレクトリに移動または削除するインターフェース。
 type FileMover interface {
 	// MoveToDone はファイルを親ディレクトリのdone/サブディレクトリに移動する。

--- a/internal/infra/file_writer.go
+++ b/internal/infra/file_writer.go
@@ -1,0 +1,144 @@
+package infra
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+// FileWriter は entity.Script をファイルへ書き出す。
+// app.ScriptWriter インターフェースを実装する。
+type FileWriter struct {
+	logger *slog.Logger
+}
+
+var _ app.ScriptWriter = (*FileWriter)(nil)
+
+// FileWriterOption は FileWriter の生成時に指定するオプション。
+type FileWriterOption func(*FileWriter)
+
+// WithFileWriterLogger は FileWriter のロガーを設定するオプション。
+func WithFileWriterLogger(logger *slog.Logger) FileWriterOption {
+	return func(w *FileWriter) {
+		if logger != nil {
+			w.logger = logger
+		}
+	}
+}
+
+// NewFileWriter は FileWriter を生成する。
+func NewFileWriter(opts ...FileWriterOption) *FileWriter {
+	w := &FileWriter{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w
+}
+
+// Write は entity.Script を path に書き出す。
+// 拡張子で書き出し形式を判定する: .json / .jsonl / その他は本文のみ。
+// 既存ファイルがある場合は <name>_<UnixNano><ext> で連番を付与する。
+// 親ディレクトリが存在しない場合はエラーを返す。
+// 戻り値は実際の書き出し先パス。
+func (w *FileWriter) Write(path string, script entity.Script) (string, error) {
+	parent := filepath.Dir(path)
+	info, err := os.Stat(parent)
+	if err != nil {
+		return "", fmt.Errorf("parent directory does not exist: %s: %w", parent, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("parent path is not a directory: %s", parent)
+	}
+
+	dest := w.resolveDest(path)
+
+	ext := strings.ToLower(filepath.Ext(dest))
+	switch ext {
+	case ".json", ".jsonl":
+		return dest, writeJSONLine(dest, script)
+	default:
+		w.warnUnsavedParams(dest, script)
+		return dest, writeText(dest, script.Text)
+	}
+}
+
+// resolveDest は出力先パスを返す。同名ファイルが既に存在する場合は <name>_<UnixNano><ext> を付与する。
+func (w *FileWriter) resolveDest(path string) string {
+	if _, err := os.Stat(path); err != nil {
+		return path
+	}
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	return filepath.Join(dir, fmt.Sprintf("%s_%d%s", name, time.Now().UnixNano(), ext))
+}
+
+// warnUnsavedParams は .txt / 未知拡張子の出力時に保存できないパラメータが指定されていれば WARN ログを出す。
+func (w *FileWriter) warnUnsavedParams(path string, script entity.Script) {
+	var dropped []string
+	if script.SpeakerID != nil {
+		dropped = append(dropped, "speaker")
+	}
+	if script.SpeedScale != nil {
+		dropped = append(dropped, "speed")
+	}
+	if script.PitchScale != nil {
+		dropped = append(dropped, "pitch")
+	}
+	if script.IntonationScale != nil {
+		dropped = append(dropped, "intonation")
+	}
+	if len(dropped) == 0 {
+		return
+	}
+	w.logger.Warn(
+		"text-format output cannot store voice parameters",
+		"path", path,
+		"droppedParams", strings.Join(dropped, ","),
+	)
+}
+
+// jsonScriptOut は .json / .jsonl 出力用の構造体。omitempty をポインタで実現する。
+type jsonScriptOut struct {
+	Text            string   `json:"text"`
+	Speaker         *int     `json:"speaker,omitempty"`
+	SpeedScale      *float64 `json:"speedScale,omitempty"`
+	PitchScale      *float64 `json:"pitchScale,omitempty"`
+	IntonationScale *float64 `json:"intonationScale,omitempty"`
+}
+
+func toJSONScript(script entity.Script) jsonScriptOut {
+	return jsonScriptOut{
+		Text:            script.Text,
+		Speaker:         script.SpeakerID,
+		SpeedScale:      script.SpeedScale,
+		PitchScale:      script.PitchScale,
+		IntonationScale: script.IntonationScale,
+	}
+}
+
+// writeJSONLine は1行JSON（末尾改行付き）を書き出す。
+// .json / .jsonl で同じ実装。.jsonl が将来複数行追記をサポートする場合は分岐させる。
+func writeJSONLine(path string, script entity.Script) error {
+	data, err := json.Marshal(toJSONScript(script))
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}
+
+func writeText(path string, text string) error {
+	return os.WriteFile(path, []byte(text), 0o644)
+}

--- a/internal/infra/file_writer_test.go
+++ b/internal/infra/file_writer_test.go
@@ -1,0 +1,347 @@
+package infra_test
+
+// テストリスト: FileWriter
+//
+// 受け入れ条件 vs テスト関数のマッピング:
+// - 拡張子 .json で text のみ保存          → TestFileWriter_Write_JSON_TextOnly
+// - 拡張子 .json で全パラメータ保存          → TestFileWriter_Write_JSON_AllParams
+// - 拡張子 .json で nil フィールドは省略     → TestFileWriter_Write_JSON_OmitNilFields
+// - 拡張子 .jsonl は1行JSONで書き出される    → TestFileWriter_Write_JSONL_SingleLine
+// - 拡張子 .txt は本文のみ書き出される        → TestFileWriter_Write_Txt_TextOnly
+// - 未知拡張子は本文のみ書き出される           → TestFileWriter_Write_UnknownExt_TextOnly
+// - .txt + speaker指定 で WARN ログ          → TestFileWriter_Write_Txt_WithSpeaker_LogsWarn
+// - .txt で全パラメータnilなら WARN なし      → TestFileWriter_Write_Txt_NoParams_NoWarn
+// - 既存ファイル衝突時 <name>_<UnixNano><ext> → TestFileWriter_Write_CollisionAddsSuffix
+// - 親ディレクトリ未存在時はエラー             → TestFileWriter_Write_MissingParentDir_ReturnsError
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/canpok1/vox-actor/internal/infra"
+)
+
+func ptrInt(v int) *int             { return &v }
+func ptrFloat64(v float64) *float64 { return &v }
+
+func TestFileWriter_Write_JSON_TextOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.json")
+
+	w := infra.NewFileWriter()
+	written, err := w.Write(dest, entity.Script{Text: "こんにちは"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if written != dest {
+		t.Errorf("expected written=%q, got %q", dest, written)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("invalid JSON written: %v\n%s", err, string(data))
+	}
+	if got["text"] != "こんにちは" {
+		t.Errorf("expected text=こんにちは, got %v", got["text"])
+	}
+	if _, exists := got["speaker"]; exists {
+		t.Errorf("expected speaker omitted, got %v", got["speaker"])
+	}
+	if _, exists := got["speedScale"]; exists {
+		t.Errorf("expected speedScale omitted, got %v", got["speedScale"])
+	}
+	if _, exists := got["pitchScale"]; exists {
+		t.Errorf("expected pitchScale omitted, got %v", got["pitchScale"])
+	}
+	if _, exists := got["intonationScale"]; exists {
+		t.Errorf("expected intonationScale omitted, got %v", got["intonationScale"])
+	}
+}
+
+func TestFileWriter_Write_JSON_AllParams(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.json")
+
+	w := infra.NewFileWriter()
+	script := entity.Script{
+		Text:            "感情込めて",
+		SpeakerID:       ptrInt(5),
+		SpeedScale:      ptrFloat64(1.5),
+		PitchScale:      ptrFloat64(0.1),
+		IntonationScale: ptrFloat64(1.8),
+	}
+	if _, err := w.Write(dest, script); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["text"] != "感情込めて" {
+		t.Errorf("text mismatch: %v", got["text"])
+	}
+	if got["speaker"].(float64) != 5 {
+		t.Errorf("speaker mismatch: %v", got["speaker"])
+	}
+	if got["speedScale"].(float64) != 1.5 {
+		t.Errorf("speedScale mismatch: %v", got["speedScale"])
+	}
+	if got["pitchScale"].(float64) != 0.1 {
+		t.Errorf("pitchScale mismatch: %v", got["pitchScale"])
+	}
+	if got["intonationScale"].(float64) != 1.8 {
+		t.Errorf("intonationScale mismatch: %v", got["intonationScale"])
+	}
+}
+
+func TestFileWriter_Write_JSON_OmitNilFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "partial.json")
+
+	w := infra.NewFileWriter()
+	script := entity.Script{
+		Text:      "部分指定",
+		SpeakerID: ptrInt(2),
+	}
+	if _, err := w.Write(dest, script); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	contents := string(data)
+	if strings.Contains(contents, "speedScale") {
+		t.Errorf("expected speedScale omitted, got: %s", contents)
+	}
+	if strings.Contains(contents, "pitchScale") {
+		t.Errorf("expected pitchScale omitted, got: %s", contents)
+	}
+	if strings.Contains(contents, "intonationScale") {
+		t.Errorf("expected intonationScale omitted, got: %s", contents)
+	}
+	if !strings.Contains(contents, `"speaker":2`) && !strings.Contains(contents, `"speaker": 2`) {
+		t.Errorf("expected speaker:2 included, got: %s", contents)
+	}
+}
+
+func TestFileWriter_Write_JSONL_SingleLine(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.jsonl")
+
+	w := infra.NewFileWriter()
+	script := entity.Script{
+		Text:      "JSONL出力",
+		SpeakerID: ptrInt(3),
+	}
+	if _, err := w.Write(dest, script); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	// 末尾改行を許容しつつ、ファイル全体は1行JSONであること
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected single line, got %d lines: %q", len(lines), string(data))
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &got); err != nil {
+		t.Fatalf("invalid JSON line: %v\n%s", err, lines[0])
+	}
+	if got["text"] != "JSONL出力" {
+		t.Errorf("text mismatch: %v", got["text"])
+	}
+	if got["speaker"].(float64) != 3 {
+		t.Errorf("speaker mismatch: %v", got["speaker"])
+	}
+}
+
+func TestFileWriter_Write_Txt_TextOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.txt")
+
+	w := infra.NewFileWriter()
+	if _, err := w.Write(dest, entity.Script{Text: "プレーンテキスト"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(data) != "プレーンテキスト" {
+		t.Errorf("expected exact text, got: %q", string(data))
+	}
+}
+
+func TestFileWriter_Write_UnknownExt_TextOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.foo")
+
+	w := infra.NewFileWriter()
+	if _, err := w.Write(dest, entity.Script{Text: "未知拡張子"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(data) != "未知拡張子" {
+		t.Errorf("expected exact text, got: %q", string(data))
+	}
+}
+
+func TestFileWriter_Write_Txt_WithSpeaker_LogsWarn(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.txt")
+
+	w := infra.NewFileWriter(infra.WithFileWriterLogger(logger))
+	script := entity.Script{
+		Text:      "本文",
+		SpeakerID: ptrInt(5),
+	}
+	if _, err := w.Write(dest, script); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// WARN レベルのログが1行以上出ていること（JSONハンドラなので level=WARN を含む行を検出）
+	warnLines := filterLines(buf.String(), `"level":"WARN"`)
+	if len(warnLines) == 0 {
+		t.Fatalf("expected at least one WARN log, got: %s", buf.String())
+	}
+	if !strings.Contains(warnLines[0], "speaker") {
+		t.Errorf("expected WARN log to mention 'speaker', got: %s", warnLines[0])
+	}
+}
+
+func TestFileWriter_Write_Txt_NoParams_NoWarn(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.txt")
+
+	w := infra.NewFileWriter(infra.WithFileWriterLogger(logger))
+	if _, err := w.Write(dest, entity.Script{Text: "本文のみ"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if warnLines := filterLines(buf.String(), `"level":"WARN"`); len(warnLines) > 0 {
+		t.Errorf("expected no WARN log, got: %v", warnLines)
+	}
+}
+
+// filterLines は output 内で needle を含む行のみを返す。
+func filterLines(output, needle string) []string {
+	var matched []string
+	for line := range strings.SplitSeq(strings.TrimRight(output, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, needle) {
+			matched = append(matched, line)
+		}
+	}
+	return matched
+}
+
+func TestFileWriter_Write_CollisionAddsSuffix(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.txt")
+	if err := os.WriteFile(dest, []byte("既存"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := infra.NewFileWriter()
+	written, err := w.Write(dest, entity.Script{Text: "新規"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if written == dest {
+		t.Fatalf("expected renamed path, got original: %s", written)
+	}
+
+	// 末尾は .txt で、ベース名は out_<UnixNano>.txt 形式
+	if filepath.Ext(written) != ".txt" {
+		t.Errorf("expected extension .txt, got: %s", written)
+	}
+	if !strings.HasPrefix(filepath.Base(written), "out_") {
+		t.Errorf("expected basename to start with 'out_', got: %s", filepath.Base(written))
+	}
+
+	// 既存ファイルは変更されていない
+	existing, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("existing file unreadable: %v", err)
+	}
+	if string(existing) != "既存" {
+		t.Errorf("existing file changed unexpectedly: %s", string(existing))
+	}
+
+	// 新ファイルには新規内容
+	newContents, err := os.ReadFile(written)
+	if err != nil {
+		t.Fatalf("new file unreadable: %v", err)
+	}
+	if string(newContents) != "新規" {
+		t.Errorf("new file content mismatch: %s", string(newContents))
+	}
+}
+
+func TestFileWriter_Write_MissingParentDir_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "missing", "out.txt")
+
+	w := infra.NewFileWriter()
+	if _, err := w.Write(dest, entity.Script{Text: "本文"}); err == nil {
+		t.Fatal("expected error for missing parent directory, got nil")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,9 @@ func main() {
 		Say: &cmd.SayDeps{
 			ClientFactory: clientFactory,
 			Player:        player,
+			WriterFactory: func(logger *slog.Logger) app.ScriptWriter {
+				return infra.NewFileWriter(infra.WithFileWriterLogger(logger))
+			},
 		},
 		AudioCheck: &cmd.AudioCheckDeps{
 			CheckFunc: func() (string, error) {


### PR DESCRIPTION
## Summary

`vox-actor say` コマンドに `-o`（`--output`）オプションを追加し、指定時は **音声合成・音声再生を行わず**にセリフをファイルへ書き出せるようにしました。`vox-actor watch --queue` と組み合わせ、別プロセスで再生させるユースケースで音声衝突を回避できます。

- `cmd/say.go`: `-o`/`--output` フラグを追加（`StringP`）。指定時は VOICEVOX 接続せず `cmd.Flags().Changed(...)` で「明示指定された」場合のみ `entity.Script` のフィールドにセットして `ScriptWriter` を直接呼ぶ。
- `cmd/say.go`: `--output` と `--dry-run` 併用は `ErrUsage` で起動時に弾く。
- `internal/app/port.go`: `ScriptWriter` インターフェースを追加（`FileMover` / `FileReader` と対称）。
- `internal/infra/file_writer.go`: `FileWriter` を新規実装。
  - 拡張子で書き出し形式を自動判定: `.json` / `.jsonl` は感情制御パラメータ込み、それ以外は本文のみ。
  - `.txt` および未知拡張子で `--speaker` 等が明示指定された場合は WARN ログ（処理は継続）。
  - 既存ファイル衝突時は `<name>_<UnixNano><ext>` でユニーク化（`FileMover.MoveToDone` と同じ規則）。
  - 親ディレクトリが存在しない場合はエラー。
- `main.go`: `WriterFactory` を DI（runSay で構築したロガーを Writer に注入）。
- `docs/reference/cli.md`: `say` の表に `-o`/`--output` を追加し、`--outputモード` セクションで仕様を解説。

## Closes

Closes #295

## Test plan

- [x] `go test ./...` 全パス
- [x] `gofmt -l .` 出力なし
- [x] `golangci-lint run ./...` 0 issues
- [x] 手動検証（mktemp -d 上で受け入れ条件を1件ずつ実行）
  - [x] `say -o <path> <text>` で音声再生されない
  - [x] VOICEVOX 未起動でも書き出せる（`--engine-url http://invalid.invalid:9999` でも成功）
  - [x] `.json` / `.jsonl` 出力時に明示指定された `--speaker` / `--speed` / `--pitch` / `--intonation` が保存される
  - [x] `.txt` および未知拡張子は本文のみ書き出され、明示指定パラメータが指定されていれば WARN ログ
  - [x] 出力先に同名ファイルがあれば `<name>_<UnixNano><ext>` で連番付与
  - [x] 親ディレクトリが存在しない場合はエラー（exit 1）
  - [x] `--output` と `--dry-run` 同時指定で `ErrUsage`（exit 2）
- [x] `docs/reference/cli.md` に `-o` を追記

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
