### PR TITLE
feat: フロントエンドにBiomeを導入してリンター/フォーマッター環境を整える #300

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,10 @@ fmt:
 typecheck: frontend/node_modules
 	cd frontend && npm run typecheck
 
-lint: build-frontend typecheck
+lint-frontend: frontend/node_modules
+	cd frontend && npm run lint
+
+lint: build-frontend typecheck lint-frontend
 	golangci-lint run ./...
 
 depcheck: build-frontend
@@ -68,4 +71,4 @@ install: build-frontend
 
 all: build
 
-.PHONY: all setup build build-frontend clean test test-e2e test-frontend-e2e fmt lint typecheck depcheck run-stream dev dev-frontend dev-backend install
+.PHONY: all setup build build-frontend clean test test-e2e test-frontend-e2e fmt lint lint-frontend typecheck depcheck run-stream dev dev-frontend dev-backend install

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false
+  },
+  "files": {
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/test-results",
+      "!**/playwright-report"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.13",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.4",
         "@types/node": "^25.6.0",
@@ -303,6 +304,169 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.13",
+        "@biomejs/cli-darwin-x64": "2.4.13",
+        "@biomejs/cli-linux-arm64": "2.4.13",
+        "@biomejs/cli-linux-arm64-musl": "2.4.13",
+        "@biomejs/cli-linux-x64": "2.4.13",
+        "@biomejs/cli-linux-x64-musl": "2.4.13",
+        "@biomejs/cli-win32-arm64": "2.4.13",
+        "@biomejs/cli-win32-x64": "2.4.13"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,13 @@
     "postbuild": "touch dist/.gitkeep",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "lint": "biome lint .",
+    "format": "biome format --write .",
+    "check": "biome check ."
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.4",
     "@types/node": "^25.6.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,7 +4,8 @@ import { defineConfig, devices } from "@playwright/test";
 // webServer で「Vite dev server (5173)」と「スタブバックエンド (8080)」を順次起動し、
 // テストは Vite dev server を入口にして vite.config.ts の proxy 越しに stub と通信する。
 // CI では Chromium のみで実行する。`npx playwright install --with-deps chromium` 済みを前提。
-const FRONTEND_BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:5173";
+const FRONTEND_BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:5173";
 const FRONTEND_PORT = new URL(FRONTEND_BASE_URL).port || "5173";
 const STUB_PORT = process.env.VOX_STUB_PORT ?? "8080";
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -138,7 +138,9 @@ export function App() {
   // 履歴上限の変更時のみトリム。再生状態の変化ではトリムしない
   // （再生終了直後の playingClipId=null 経由で過去のハイライト対象が消えるのを防ぐ）。
   useEffect(() => {
-    setEntries((prev) => trimTimeline(prev, historySize, playingClipIdRef.current));
+    setEntries((prev) =>
+      trimTimeline(prev, historySize, playingClipIdRef.current),
+    );
   }, [historySize]);
 
   const showTestError = useCallback((msg: string): void => {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -21,10 +21,6 @@
   body {
     background: var(--color-ctp-base);
     color: var(--color-ctp-text);
-    font-family:
-      -apple-system,
-      BlinkMacSystemFont,
-      "Segoe UI",
-      sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   }
 }

--- a/frontend/src/components/SilentBadge.tsx
+++ b/frontend/src/components/SilentBadge.tsx
@@ -27,6 +27,7 @@ export function SilentBadge({ reason }: SilentBadgeProps) {
   }, [open]);
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: ホバー検知用ラッパー。インタラクティブな操作はネスト先の <button> が担う
     <span
       ref={rootRef}
       className="relative inline-flex"

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -16,7 +16,8 @@ interface TabButtonProps {
 }
 
 function TabButton({ id, panelId, active, label, onClick }: TabButtonProps) {
-  const base = "cursor-pointer rounded-t-md px-2 py-[0.4rem] font-inherit sm:px-[0.9rem] sm:py-[0.45rem]";
+  const base =
+    "cursor-pointer rounded-t-md px-2 py-[0.4rem] font-inherit sm:px-[0.9rem] sm:py-[0.45rem]";
   const colors = active
     ? "border border-ctp-overlay border-b-ctp-base bg-ctp-base text-ctp-text"
     : "border-0 bg-transparent text-ctp-subtext hover:text-ctp-text";
@@ -37,7 +38,10 @@ function TabButton({ id, panelId, active, label, onClick }: TabButtonProps) {
 
 export function Tabs({ active, onChange, hideTest = false }: TabsProps) {
   return (
-    <div role="tablist" className="mt-4 flex gap-[0.15rem] border-b border-ctp-overlay sm:gap-1">
+    <div
+      role="tablist"
+      className="mt-4 flex gap-[0.15rem] border-b border-ctp-overlay sm:gap-1"
+    >
       <TabButton
         id="tab-stream"
         panelId="panel-stream"

--- a/frontend/src/components/TestControls.tsx
+++ b/frontend/src/components/TestControls.tsx
@@ -41,7 +41,11 @@ export function TestControls({
       >
         ▶ テスト再生
       </button>
-      <span role="status" aria-live="polite" className="text-[0.85rem] text-ctp-red">
+      <span
+        role="status"
+        aria-live="polite"
+        className="text-[0.85rem] text-ctp-red"
+      >
         {error}
       </span>
     </div>

--- a/frontend/src/components/TimelineItem.tsx
+++ b/frontend/src/components/TimelineItem.tsx
@@ -55,7 +55,9 @@ export function TimelineItem({
       >
         <div className="flex flex-wrap items-baseline gap-2 text-[0.8rem] text-ctp-red">
           {showTimestamp && (
-            <span className="tabular-nums">{formatTimestamp(entry.timestamp)}</span>
+            <span className="tabular-nums">
+              {formatTimestamp(entry.timestamp)}
+            </span>
           )}
           <span className="font-semibold">{categoryLabel}</span>
           {entry.path && <span className="break-all">{entry.path}</span>}
@@ -69,7 +71,9 @@ export function TimelineItem({
         {entry.text && (
           <div className="flex flex-wrap items-baseline gap-2 text-[0.8rem] text-ctp-subtext">
             {showSpeakerName && entry.speakerName && (
-              <span className="font-semibold text-ctp-text">{entry.speakerName}</span>
+              <span className="font-semibold text-ctp-text">
+                {entry.speakerName}
+              </span>
             )}
             {showStyleName && entry.styleName && (
               <span className="text-ctp-blue">[{entry.styleName}]</span>
@@ -91,10 +95,14 @@ export function TimelineItem({
       {showMeta && (
         <div className="flex flex-wrap items-baseline gap-2 text-[0.8rem] text-ctp-subtext">
           {showTimestamp && (
-            <span className="tabular-nums">{formatTimestamp(entry.timestamp)}</span>
+            <span className="tabular-nums">
+              {formatTimestamp(entry.timestamp)}
+            </span>
           )}
           {showSpeakerName && (
-            <span className="font-semibold text-ctp-text">{entry.speakerName}</span>
+            <span className="font-semibold text-ctp-text">
+              {entry.speakerName}
+            </span>
           )}
           {showStyleName && entry.styleName && (
             <span className="text-ctp-blue">[{entry.styleName}]</span>
@@ -102,7 +110,10 @@ export function TimelineItem({
         </div>
       )}
       <div className="flex items-start gap-2">
-        <span aria-hidden className="inline-block w-[1em] flex-none text-ctp-blue">
+        <span
+          aria-hidden
+          className="inline-block w-[1em] flex-none text-ctp-blue"
+        >
           {playing ? "▶" : ""}
         </span>
         <span>{entry.text}</span>

--- a/frontend/src/components/VolumeControls.tsx
+++ b/frontend/src/components/VolumeControls.tsx
@@ -5,7 +5,12 @@ interface VolumeControlsProps {
   onMuteChange: (muted: boolean) => void;
 }
 
-export function VolumeControls({ volume, muted, onVolumeChange, onMuteChange }: VolumeControlsProps) {
+export function VolumeControls({
+  volume,
+  muted,
+  onVolumeChange,
+  onMuteChange,
+}: VolumeControlsProps) {
   const icon = muted || volume === 0 ? "🔇" : "🔊";
   return (
     <div className="mt-4 mb-1 flex flex-wrap items-center gap-4">

--- a/frontend/src/hooks/usePlaybackQueue.ts
+++ b/frontend/src/hooks/usePlaybackQueue.ts
@@ -1,4 +1,10 @@
-import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import type { ClipEvent } from "../types/api";
 
 interface PlaybackQueue {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -61,7 +61,9 @@ export function isClipEvent(value: unknown): value is ClipEvent {
   );
 }
 
-export function isErrorEventPayload(value: unknown): value is ErrorEventPayload {
+export function isErrorEventPayload(
+  value: unknown,
+): value is ErrorEventPayload {
   if (typeof value !== "object" || value === null) {
     return false;
   }
@@ -73,13 +75,19 @@ export function isErrorEventPayload(value: unknown): value is ErrorEventPayload 
   ) {
     return false;
   }
-  if (v.category !== "synthesis" && v.category !== "file" && v.category !== "connection") {
+  if (
+    v.category !== "synthesis" &&
+    v.category !== "file" &&
+    v.category !== "connection"
+  ) {
     return false;
   }
   if (v.path !== undefined && typeof v.path !== "string") return false;
   if (v.text !== undefined && typeof v.text !== "string") return false;
-  if (v.speakerName !== undefined && typeof v.speakerName !== "string") return false;
-  if (v.styleName !== undefined && typeof v.styleName !== "string") return false;
+  if (v.speakerName !== undefined && typeof v.speakerName !== "string")
+    return false;
+  if (v.styleName !== undefined && typeof v.styleName !== "string")
+    return false;
   return true;
 }
 

--- a/frontend/test/e2e/helpers.ts
+++ b/frontend/test/e2e/helpers.ts
@@ -1,10 +1,11 @@
-import { type APIRequestContext, type Page, expect } from "@playwright/test";
+import { type APIRequestContext, expect, type Page } from "@playwright/test";
 
 // stub-server.mjs の制御用エンドポイントは Vite dev server (`/`) からは proxy されない。
 // テストでは APIRequestContext を使って stub の素のポートに直接叩く。
 // VOX_STUB_PORT を変えた場合は同じ値を渡すこと（playwright.config.ts と揃える）。
 const STUB_PORT = process.env.VOX_STUB_PORT ?? "8080";
-const STUB_BASE_URL = process.env.VOX_STUB_BASE_URL ?? `http://127.0.0.1:${STUB_PORT}`;
+const STUB_BASE_URL =
+  process.env.VOX_STUB_BASE_URL ?? `http://127.0.0.1:${STUB_PORT}`;
 
 export interface ClipPayload {
   id?: number;
@@ -51,7 +52,9 @@ export async function pushClip(
   request: APIRequestContext,
   payload: ClipPayload,
 ): Promise<void> {
-  const resp = await request.post(`${STUB_BASE_URL}/__stub/clip`, { data: payload });
+  const resp = await request.post(`${STUB_BASE_URL}/__stub/clip`, {
+    data: payload,
+  });
   expect(resp.ok()).toBeTruthy();
 }
 
@@ -59,7 +62,9 @@ export async function pushError(
   request: APIRequestContext,
   payload: ErrorPayload,
 ): Promise<void> {
-  const resp = await request.post(`${STUB_BASE_URL}/__stub/error`, { data: payload });
+  const resp = await request.post(`${STUB_BASE_URL}/__stub/error`, {
+    data: payload,
+  });
   expect(resp.ok()).toBeTruthy();
 }
 
@@ -69,6 +74,9 @@ export async function disconnectAll(request: APIRequestContext): Promise<void> {
 }
 
 // localStorage を読み取るユーティリティ。永続化テストで利用する。
-export async function readLocalStorage(page: Page, key: string): Promise<string | null> {
+export async function readLocalStorage(
+  page: Page,
+  key: string,
+): Promise<string | null> {
   return page.evaluate((k) => window.localStorage.getItem(k), key);
 }

--- a/frontend/test/e2e/persistence.spec.ts
+++ b/frontend/test/e2e/persistence.spec.ts
@@ -31,8 +31,14 @@ test.describe("各種設定の localStorage 永続化", () => {
 
     await page.reload();
     await expect(page.getByLabel("履歴上限")).toHaveValue("50");
-    await expect(page.getByRole("checkbox", { name: "話者名" })).not.toBeChecked();
-    await expect(page.getByRole("checkbox", { name: "スタイル" })).not.toBeChecked();
-    await expect(page.getByRole("checkbox", { name: "時刻" })).not.toBeChecked();
+    await expect(
+      page.getByRole("checkbox", { name: "話者名" }),
+    ).not.toBeChecked();
+    await expect(
+      page.getByRole("checkbox", { name: "スタイル" }),
+    ).not.toBeChecked();
+    await expect(
+      page.getByRole("checkbox", { name: "時刻" }),
+    ).not.toBeChecked();
   });
 });

--- a/frontend/test/e2e/silent.spec.ts
+++ b/frontend/test/e2e/silent.spec.ts
@@ -11,14 +11,21 @@ test.describe("無音モード", () => {
     });
   });
 
-  test("SilentBadge が表示され、音声テストタブは描画されない", async ({ page }) => {
+  test("SilentBadge が表示され、音声テストタブは描画されない", async ({
+    page,
+  }) => {
     await page.goto("/");
-    await expect(page.getByRole("button", { name: /無音モード/ })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /無音モード/ }),
+    ).toBeVisible();
     await expect(page.getByRole("tab", { name: "配信" })).toBeVisible();
     await expect(page.getByRole("tab", { name: "音声テスト" })).toHaveCount(0);
   });
 
-  test("URL 空の clip イベントもタイムラインに表示される", async ({ page, request }) => {
+  test("URL 空の clip イベントもタイムラインに表示される", async ({
+    page,
+    request,
+  }) => {
     await page.goto("/");
     await expect(page.getByText("● 接続中")).toBeVisible();
 

--- a/frontend/test/e2e/stream.spec.ts
+++ b/frontend/test/e2e/stream.spec.ts
@@ -6,7 +6,10 @@ test.describe("配信タブ: SSE と Timeline", () => {
     await resetStub(request);
   });
 
-  test("SSE 接続後、clip イベントが Timeline に反映される", async ({ page, request }) => {
+  test("SSE 接続後、clip イベントが Timeline に反映される", async ({
+    page,
+    request,
+  }) => {
     await page.goto("/");
     await expect(page.getByText("● 接続中")).toBeVisible();
 
@@ -24,7 +27,10 @@ test.describe("配信タブ: SSE と Timeline", () => {
     await expect(item).toContainText("ずんだもん");
   });
 
-  test("error イベントが Timeline にエラーとして表示される", async ({ page, request }) => {
+  test("error イベントが Timeline にエラーとして表示される", async ({
+    page,
+    request,
+  }) => {
     await page.goto("/");
     await expect(page.getByText("● 接続中")).toBeVisible();
 

--- a/frontend/test/e2e/test-panel.spec.ts
+++ b/frontend/test/e2e/test-panel.spec.ts
@@ -6,7 +6,9 @@ test.describe("音声テストタブ", () => {
     await resetStub(request);
   });
 
-  test("話者選択は localStorage に保存され、リロード後も復元される", async ({ page }) => {
+  test("話者選択は localStorage に保存され、リロード後も復元される", async ({
+    page,
+  }) => {
     await page.goto("/");
     await page.getByRole("tab", { name: "音声テスト" }).click();
 

--- a/frontend/test/e2e/volume.spec.ts
+++ b/frontend/test/e2e/volume.spec.ts
@@ -21,7 +21,9 @@ test.describe("音量・消音コントロール", () => {
     await expect(page.getByRole("slider", { name: "音量" })).toHaveValue("23");
   });
 
-  test("消音チェックボックスの操作で audio.muted が連動する", async ({ page }) => {
+  test("消音チェックボックスの操作で audio.muted が連動する", async ({
+    page,
+  }) => {
     await page.goto("/");
 
     await expect(page.locator("audio")).toHaveJSProperty("muted", true);

--- a/frontend/test/stub-server.mjs
+++ b/frontend/test/stub-server.mjs
@@ -141,7 +141,8 @@ async function handleStubClip(req, res) {
     id: typeof body.id === "number" ? body.id : nextClipId,
     url: typeof body.url === "string" ? body.url : `/clips/${nextClipId}.wav`,
     text: typeof body.text === "string" ? body.text : "",
-    speakerName: typeof body.speakerName === "string" ? body.speakerName : "ずんだもん",
+    speakerName:
+      typeof body.speakerName === "string" ? body.speakerName : "ずんだもん",
     styleName: typeof body.styleName === "string" ? body.styleName : "ノーマル",
     timestamp: typeof body.timestamp === "number" ? body.timestamp : Date.now(),
   };
@@ -160,7 +161,8 @@ async function handleStubError(req, res) {
   };
   if (typeof body.path === "string") payload.path = body.path;
   if (typeof body.text === "string") payload.text = body.text;
-  if (typeof body.speakerName === "string") payload.speakerName = body.speakerName;
+  if (typeof body.speakerName === "string")
+    payload.speakerName = body.speakerName;
   if (typeof body.styleName === "string") payload.styleName = body.styleName;
   broadcast("error", payload);
   writeJSON(res, 200, { ok: true, payload });
@@ -177,10 +179,17 @@ function handleStubDisconnect(_req, res) {
 async function handleStubApiStatus(req, res) {
   const body = await readJSON(req);
   apiStatus = {
-    silent: typeof body.silent === "boolean" ? body.silent : DEFAULT_API_STATUS.silent,
+    silent:
+      typeof body.silent === "boolean"
+        ? body.silent
+        : DEFAULT_API_STATUS.silent,
     silentReason:
-      typeof body.silentReason === "string" ? body.silentReason : DEFAULT_API_STATUS.silentReason,
-    speakers: Array.isArray(body.speakers) ? body.speakers : DEFAULT_API_STATUS.speakers,
+      typeof body.silentReason === "string"
+        ? body.silentReason
+        : DEFAULT_API_STATUS.silentReason,
+    speakers: Array.isArray(body.speakers)
+      ? body.speakers
+      : DEFAULT_API_STATUS.speakers,
   };
   writeJSON(res, 200, { ok: true, apiStatus });
 }
@@ -201,20 +210,29 @@ const server = http.createServer((req, res) => {
   const path = url.pathname;
 
   if (req.method === "GET" && path === "/events") return handleEvents(req, res);
-  if (req.method === "GET" && path === "/api/status") return handleApiStatus(req, res);
-  if (req.method === "GET" && path === "/test-clip") return handleTestClip(req, res);
-  if (req.method === "GET" && path.startsWith("/clips/") && path.endsWith(".wav")) {
+  if (req.method === "GET" && path === "/api/status")
+    return handleApiStatus(req, res);
+  if (req.method === "GET" && path === "/test-clip")
+    return handleTestClip(req, res);
+  if (
+    req.method === "GET" &&
+    path.startsWith("/clips/") &&
+    path.endsWith(".wav")
+  ) {
     return handleClipFile(req, res);
   }
-  if (req.method === "POST" && path === "/__stub/clip") return handleStubClip(req, res);
-  if (req.method === "POST" && path === "/__stub/error") return handleStubError(req, res);
+  if (req.method === "POST" && path === "/__stub/clip")
+    return handleStubClip(req, res);
+  if (req.method === "POST" && path === "/__stub/error")
+    return handleStubError(req, res);
   if (req.method === "POST" && path === "/__stub/disconnect") {
     return handleStubDisconnect(req, res);
   }
   if (req.method === "POST" && path === "/__stub/api-status") {
     return handleStubApiStatus(req, res);
   }
-  if (req.method === "POST" && path === "/__stub/reset") return handleStubReset(req, res);
+  if (req.method === "POST" && path === "/__stub/reset")
+    return handleStubReset(req, res);
 
   res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
   res.end("not found");


### PR DESCRIPTION
## Summary

- フロントエンドのリンター/フォーマッターとして [Biome](https://biomejs.dev/) を `frontend/` に導入
- `linter.rules.recommended = true` のみを有効化し、独自カスタマイズは入れない
- `npm run lint` / `format` / `check` の3スクリプトを追加し、`make lint` から `lint-frontend` サブターゲット経由で frontend lint を実行できるようにした

## 主な変更

- `frontend/package.json` に `@biomejs/biome` を devDependency として追加し、`lint` / `format` / `check` の npm scripts を追加
- `frontend/biome.json` を作成
  - `linter.rules.recommended = true`
  - 既存コードに合わせて 2 スペースインデント・ダブルクォートを採用
  - `node_modules` / `dist` / `test-results` / `playwright-report` を除外
  - Tailwind v4 の `@import "tailwindcss";` / `@theme` / `@layer` を解釈するため `css.parser.tailwindDirectives = true` を有効化
  - `assist.actions.source.organizeImports` を有効化
- `frontend/` 配下の `.ts` / `.tsx` / `.js` / `.css` / `.mjs` を Biome のルールに合わせて一括整形（フォーマッタと organizeImports の自動修正のみ）
- `frontend/src/components/SilentBadge.tsx` で `lint/a11y/noStaticElementInteractions` 1件を `// biome-ignore` で抑止（ホバー検知用ラッパー span。実際のインタラクティブ要素はネスト先の button が担う）
- `Makefile` の `lint` ターゲットに `lint-frontend` を依存追加し、Go の golangci-lint と同時に Biome lint が走るようにした

## 受け入れ条件

- [x] `cd frontend && npm run lint` がエラーなく完了する
- [x] `cd frontend && npm run format` 実行後に `git diff --exit-code` で差分が出ない
- [x] `make lint` がローカルで成功する（`make build`・`typecheck`・Biome lint・golangci-lint がすべて通過）
- [x] `build` ワークフローで lint 違反を検知できる（`make lint` 経由で実行されるため）

## Test plan

- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run format && git diff --exit-code -- frontend/`
- [x] `cd frontend && npm run typecheck`
- [x] `make build`
- [x] `make lint`
- [x] `go test ./...`
- [ ] CI（`build` ワークフロー）が緑

Closes #300

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
