### PR TITLE
fix: auto-assignとauto-solveスクリプトのエラーハンドリングを修正

### DIFF
--- a/workflow-scripts/auto-assign.sh
+++ b/workflow-scripts/auto-assign.sh
@@ -93,7 +93,7 @@ while $RUNNING; do
       echo ""
       echo "Queue: ${QUEUE_COUNT} (< ${MIN_QUEUE}), assigning..."
 
-      "${SCRIPT_DIR}/claude-stream.sh" -p "/base-tools:assign-issues --count ${ASSIGN_COUNT}" || true
+      "${SCRIPT_DIR}/claude-stream.sh" -p "/base-tools:assign-issues --count ${ASSIGN_COUNT}"
     fi
   fi
 

--- a/workflow-scripts/auto-solve.sh
+++ b/workflow-scripts/auto-solve.sh
@@ -28,7 +28,7 @@ while $RUNNING; do
     ISSUE_TITLE=$(echo "$ISSUE" | jq -r '.title')
     echo ""
     echo "#${ISSUE_NUMBER} ${ISSUE_TITLE}"
-    "${SCRIPT_DIR}/solve-issue.sh" -p "$ISSUE_NUMBER" || true
+    "${SCRIPT_DIR}/solve-issue.sh" -p "$ISSUE_NUMBER"
   else
     printf "."
   fi


### PR DESCRIPTION
このプルリクエストでは、ワークフロースクリプトに小規模な変更を加え、2箇所のコマンド呼び出しから || true の使用を削除しました。この変更により、これらのコマンドで発生したエラーが暗黙のうちに無視されることはなくなり、スクリプトが確実に終了または失敗するようになります。

主な変更点は以下の通りです：

エラーハンドリングの改善：
- auto-assign.sh 内の claude-stream.sh の呼び出しから || true を削除し、スクリプトのエラーが無視されないようにしました。
- auto-solve.sh 内の solve-issue.sh の呼び出しから || true を削除し、スクリプトのエラーが無視されないようにしました。