### PR TITLE
feat: 音声テスト画面コンポーネントの単体テストを追加する #304

### DIFF
--- a/frontend/src/components/TestControls.test.tsx
+++ b/frontend/src/components/TestControls.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Speaker } from "../types/api";
+import { TestControls } from "./TestControls";
+
+describe("TestControls", () => {
+  const mockSpeakers: Speaker[] = [
+    { id: 1, speakerName: "Taro", styleName: "happy" },
+    { id: 2, speakerName: "Hanako", styleName: "sad" },
+    { id: 3, speakerName: "Jiro", styleName: "" },
+  ];
+
+  const mockCallbacks = {
+    onSpeakerChange: vi.fn(),
+    onPlay: vi.fn(),
+  };
+
+  it("speakers が空のときはオプションが表示されない", () => {
+    render(
+      <TestControls
+        speakers={[]}
+        selectedSpeakerId=""
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error=""
+      />,
+    );
+    const options = screen.queryAllByRole("option");
+    expect(options).toHaveLength(0);
+  });
+
+  it("speakers の各要素が option として描画される", () => {
+    render(
+      <TestControls
+        speakers={mockSpeakers}
+        selectedSpeakerId="1"
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error=""
+      />,
+    );
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent("Taro(happy)");
+    expect(options[1]).toHaveTextContent("Hanako(sad)");
+    expect(options[2]).toHaveTextContent("Jiro");
+  });
+
+  it("styleName が空のときはスタイル部分を表示しない", () => {
+    render(
+      <TestControls
+        speakers={mockSpeakers}
+        selectedSpeakerId="1"
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error=""
+      />,
+    );
+    const jiroOption = screen.getByRole("option", { name: /^Jiro$/ });
+    expect(jiroOption.textContent).not.toContain("(");
+  });
+
+  it("選択変更で onSpeakerChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TestControls
+        speakers={mockSpeakers}
+        selectedSpeakerId="1"
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error=""
+      />,
+    );
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    await user.selectOptions(select, "2");
+
+    expect(mockCallbacks.onSpeakerChange).toHaveBeenCalledWith("2");
+  });
+
+  it("テスト再生ボタンクリックで onPlay が呼ばれる", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TestControls
+        speakers={mockSpeakers}
+        selectedSpeakerId="1"
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error=""
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /テスト再生/ });
+    await user.click(button);
+
+    expect(mockCallbacks.onPlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("エラーメッセージが渡されたときに表示される", () => {
+    const errorMessage = "再生に失敗しました";
+    render(
+      <TestControls
+        speakers={mockSpeakers}
+        selectedSpeakerId="1"
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error={errorMessage}
+      />,
+    );
+
+    const statusElement = screen.getByRole("status");
+    expect(statusElement).toHaveTextContent(errorMessage);
+  });
+
+  it("エラーメッセージが空のときは何も表示されない", () => {
+    render(
+      <TestControls
+        speakers={mockSpeakers}
+        selectedSpeakerId="1"
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error=""
+      />,
+    );
+
+    const statusElement = screen.getByRole("status");
+    expect(statusElement).toHaveTextContent("");
+  });
+});

--- a/frontend/src/components/TestPanel.test.tsx
+++ b/frontend/src/components/TestPanel.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Speaker } from "../types/api";
+import { TestPanel } from "./TestPanel";
+
+describe("TestPanel", () => {
+  const mockSpeakers: Speaker[] = [
+    { id: 1, speakerName: "Speaker A", styleName: "style1" },
+    { id: 2, speakerName: "Speaker B", styleName: "" },
+  ];
+
+  const mockCallbacks = {
+    onSpeakerChange: vi.fn(),
+    onPlay: vi.fn(),
+  };
+
+  it("hidden=false で表示される", () => {
+    render(
+      <TestPanel
+        hidden={false}
+        speakers={mockSpeakers}
+        selectedSpeakerId="1"
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error=""
+      />,
+    );
+    const panel = screen.getByRole("tabpanel", { hidden: false });
+    expect(panel).toBeInTheDocument();
+  });
+
+  it("hidden=true で非表示になる", () => {
+    render(
+      <TestPanel
+        hidden={true}
+        speakers={mockSpeakers}
+        selectedSpeakerId="1"
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error=""
+      />,
+    );
+    const panel = screen.queryByRole("tabpanel", { hidden: false });
+    expect(panel).not.toBeInTheDocument();
+  });
+
+  it("TestControls に正しい props が渡される", () => {
+    render(
+      <TestPanel
+        hidden={false}
+        speakers={mockSpeakers}
+        selectedSpeakerId="2"
+        onSpeakerChange={mockCallbacks.onSpeakerChange}
+        onPlay={mockCallbacks.onPlay}
+        error="エラーメッセージ"
+      />,
+    );
+    const select = screen.getByRole("combobox");
+    expect(select).toHaveValue("2");
+
+    const speakerOptions = screen.getAllByRole("option");
+    expect(speakerOptions).toHaveLength(2);
+    expect(speakerOptions[0]).toHaveTextContent("Speaker A(style1)");
+    expect(speakerOptions[1]).toHaveTextContent("Speaker B");
+
+    const errorElement = screen.getByRole("status");
+    expect(errorElement).toHaveTextContent("エラーメッセージ");
+  });
+});


### PR DESCRIPTION
## 概要

TestPanel と TestControls コンポーネントに対して、主要な分岐と状態遷移をカバーする単体テストを追加しました。

## テスト内容

### TestPanel (3テスト)
- `hidden=false` で表示される
- `hidden=true` で非表示になる
- TestControls に正しい props が渡される

### TestControls (7テスト)
- speakers が空のときはオプションが表示されない
- speakers の各要素が option として描画される
- styleName が空のときはスタイル部分を表示しない
- 選択変更で onSpeakerChange が呼ばれる
- テスト再生ボタンクリックで onPlay が呼ばれる
- エラーメッセージが渡されたときに表示される
- エラーメッセージが空のときは何も表示されない

## テスト実行結果

すべてのテストが成功しています:
```
Test Files  4 passed (4)
Tests  19 passed (19)
```

## 関連Issue

Closes #304

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)