### PR TITLE
feat: 共通UIコンポーネント (StatusBadge/Tabs/VolumeControls) の単体テストを追加する #305

### DIFF
--- a/frontend/src/components/StatusBadge.test.tsx
+++ b/frontend/src/components/StatusBadge.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StatusBadge } from "./StatusBadge";
+
+describe("StatusBadge", () => {
+  it("connected=true のときに接続中ラベルが表示される", () => {
+    render(<StatusBadge connected={true} />);
+    expect(screen.getByText("● 接続中")).toBeInTheDocument();
+  });
+
+  it("connected=false のときに切断ラベルが表示される", () => {
+    render(<StatusBadge connected={false} />);
+    expect(screen.getByText("● 切断")).toBeInTheDocument();
+  });
+
+  it("connected=true のときに緑色の背景クラスが適用される", () => {
+    render(<StatusBadge connected={true} />);
+    const badge = screen.getByText("● 接続中");
+    expect(badge).toHaveClass("bg-ctp-green");
+  });
+
+  it("connected=false のときに赤色の背景クラスが適用される", () => {
+    render(<StatusBadge connected={false} />);
+    const badge = screen.getByText("● 切断");
+    expect(badge).toHaveClass("bg-ctp-red");
+  });
+});

--- a/frontend/src/components/Tabs.test.tsx
+++ b/frontend/src/components/Tabs.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Tabs } from "./Tabs";
+
+describe("Tabs", () => {
+  it("active='stream' のときに配信タブにアクティブ表示が付く", () => {
+    render(<Tabs active="stream" onChange={() => {}} />);
+    const streamTab = screen.getByRole("tab", { name: "配信" });
+    expect(streamTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("active='test' のときに音声テストタブにアクティブ表示が付く", () => {
+    render(<Tabs active="test" onChange={() => {}} />);
+    const testTab = screen.getByRole("tab", { name: "音声テスト" });
+    expect(testTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("非アクティブタブをクリックすると onChange が対応する TabName で呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Tabs active="stream" onChange={onChange} />);
+
+    const testTab = screen.getByRole("tab", { name: "音声テスト" });
+    await user.click(testTab);
+
+    expect(onChange).toHaveBeenCalledWith("test");
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("アクティブタブをクリックしても onChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Tabs active="stream" onChange={onChange} />);
+
+    const streamTab = screen.getByRole("tab", { name: "配信" });
+    await user.click(streamTab);
+
+    expect(onChange).toHaveBeenCalledWith("stream");
+  });
+
+  it("hideTest=true のときに音声テストタブが描画されない", () => {
+    render(<Tabs active="stream" onChange={() => {}} hideTest={true} />);
+    expect(
+      screen.queryByRole("tab", { name: "音声テスト" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hideTest=false のときに音声テストタブが描画される", () => {
+    render(<Tabs active="stream" onChange={() => {}} hideTest={false} />);
+    expect(
+      screen.getByRole("tab", { name: "音声テスト" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hideTest を指定しない場合（デフォルト）に音声テストタブが描画される", () => {
+    render(<Tabs active="stream" onChange={() => {}} />);
+    expect(
+      screen.getByRole("tab", { name: "音声テスト" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/VolumeControls.test.tsx
+++ b/frontend/src/components/VolumeControls.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { VolumeControls } from "./VolumeControls";
+
+describe("VolumeControls", () => {
+  it("volume 値がスライダーに反映される", () => {
+    render(
+      <VolumeControls
+        volume={50}
+        muted={false}
+        onVolumeChange={() => {}}
+        onMuteChange={() => {}}
+      />,
+    );
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveValue("50");
+  });
+
+  it("スライダー変更で onVolumeChange が数値で呼ばれる", () => {
+    const onVolumeChange = vi.fn();
+    render(
+      <VolumeControls
+        volume={50}
+        muted={false}
+        onVolumeChange={onVolumeChange}
+        onMuteChange={() => {}}
+      />,
+    );
+
+    const slider = screen.getByRole("slider") as HTMLInputElement;
+    fireEvent.change(slider, { target: { value: "75" } });
+
+    expect(onVolumeChange).toHaveBeenCalledWith(75);
+  });
+
+  it("muted=true のときにチェックボックスが checked 状態になる", () => {
+    render(
+      <VolumeControls
+        volume={50}
+        muted={true}
+        onVolumeChange={() => {}}
+        onMuteChange={() => {}}
+      />,
+    );
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeChecked();
+  });
+
+  it("muted=false のときにチェックボックスが checked 状態でない", () => {
+    render(
+      <VolumeControls
+        volume={50}
+        muted={false}
+        onVolumeChange={() => {}}
+        onMuteChange={() => {}}
+      />,
+    );
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("ミュートチェックボックス操作で onMuteChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onMuteChange = vi.fn();
+    render(
+      <VolumeControls
+        volume={50}
+        muted={false}
+        onVolumeChange={() => {}}
+        onMuteChange={onMuteChange}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    await user.click(checkbox);
+
+    expect(onMuteChange).toHaveBeenCalledWith(true);
+  });
+
+  it("muted=true または volume=0 のときにアイコンが🔇になる", () => {
+    const { rerender } = render(
+      <VolumeControls
+        volume={50}
+        muted={true}
+        onVolumeChange={() => {}}
+        onMuteChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("🔇")).toBeInTheDocument();
+
+    rerender(
+      <VolumeControls
+        volume={0}
+        muted={false}
+        onVolumeChange={() => {}}
+        onMuteChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("🔇")).toBeInTheDocument();
+  });
+
+  it("muted=false かつ volume > 0 のときにアイコンが🔊になる", () => {
+    render(
+      <VolumeControls
+        volume={50}
+        muted={false}
+        onVolumeChange={() => {}}
+        onMuteChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("🔊")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

StatusBadge、Tabs、VolumeControls の3つの共通UIコンポーネントに対して、主要な状態分岐と状態遷移をカバーする単体テストを追加しました。

### テストカバレッジ

**StatusBadge (4 tests)**
- `connected=true` 時の表示（接続中ラベル・緑色）
- `connected=false` 時の表示（切断ラベル・赤色）

**Tabs (7 tests)**
- `active` prop に応じたアクティブ表示の切り替え
- `onChange` コールバックの正しい呼び出し
- `hideTest` prop によるタブの表示・非表示制御
- デフォルト props の動作確認

**VolumeControls (7 tests)**
- `volume` 値がスライダーに反映されること
- スライダー変更時の `onVolumeChange` コールバック
- `muted` 値がチェックボックス状態に反映されること
- チェックボックス操作時の `onMuteChange` コールバック
- `muted` と `volume` に応じたアイコン表示（🔇 / 🔊）

### テスト実行結果

```
Test Files  7 passed (7)
Tests  37 passed (37)
```

全テストが成功し、`make test-frontend-unit` でローカル実行も確認済みです。

Closes #305

---
🤖 Generated with [Claude Code](https://claude.ai/code)
