### PR TITLE
feat: カスタムフック (useEventSource/usePlaybackQueue) の単体テストを追加する #306

### DIFF
--- a/frontend/src/hooks/useEventSource.test.ts
+++ b/frontend/src/hooks/useEventSource.test.ts
@@ -1,0 +1,134 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useEventSource } from "./useEventSource";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  readonly url: string;
+  private listeners: Map<string, Array<(event: Event) => void>> = new Map();
+  close = vi.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, handler: (event: Event) => void): void {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(handler);
+    this.listeners.set(type, existing);
+  }
+
+  emit(type: string, event: Event): void {
+    for (const handler of this.listeners.get(type) ?? []) {
+      handler(event);
+    }
+  }
+}
+
+describe("useEventSource", () => {
+  const URL = "http://localhost/events";
+
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal("EventSource", MockEventSource);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function latestEs(): MockEventSource {
+    return MockEventSource.instances[MockEventSource.instances.length - 1];
+  }
+
+  it("open 受信で connected=true に遷移する", () => {
+    const { result } = renderHook(() => useEventSource(URL, vi.fn(), vi.fn()));
+    expect(result.current).toBe(false);
+    act(() => {
+      latestEs().emit("open", new Event("open"));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("clip イベント受信で onClip(event.data) が呼ばれる", () => {
+    const onClip = vi.fn();
+    renderHook(() => useEventSource(URL, onClip, vi.fn()));
+    act(() => {
+      latestEs().emit("clip", new MessageEvent("clip", { data: "clip-data" }));
+    });
+    expect(onClip).toHaveBeenCalledWith("clip-data");
+  });
+
+  it("サーバー送信 error は onError を呼び再接続しない", () => {
+    const onError = vi.fn();
+    renderHook(() => useEventSource(URL, vi.fn(), onError));
+    const countBefore = MockEventSource.instances.length;
+    act(() => {
+      latestEs().emit(
+        "error",
+        new MessageEvent("error", { data: "err-data" }),
+      );
+    });
+    expect(onError).toHaveBeenCalledWith("err-data");
+    expect(MockEventSource.instances.length).toBe(countBefore);
+  });
+
+  it("ネイティブ接続失敗で connected=false に遷移し 2秒後に再接続する", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useEventSource(URL, vi.fn(), vi.fn()));
+    act(() => {
+      latestEs().emit("open", new Event("open"));
+    });
+    expect(result.current).toBe(true);
+    const esBeforeReconnect = latestEs();
+    act(() => {
+      latestEs().emit("error", new Event("error"));
+    });
+    expect(result.current).toBe(false);
+    expect(esBeforeReconnect.close).toHaveBeenCalled();
+    const countBefore = MockEventSource.instances.length;
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(MockEventSource.instances.length).toBe(countBefore + 1);
+  });
+
+  it("アンマウントで close が呼ばれ再接続タイマーがキャンセルされる", () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() =>
+      useEventSource(URL, vi.fn(), vi.fn()),
+    );
+    const es = latestEs();
+    act(() => {
+      es.emit("error", new Event("error"));
+    });
+    unmount();
+    const countAfterUnmount = MockEventSource.instances.length;
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(MockEventSource.instances.length).toBe(countAfterUnmount);
+    expect(es.close).toHaveBeenCalled();
+  });
+
+  it("onClip と onError を差し替えても再接続しない", () => {
+    const onClip1 = vi.fn();
+    const onClip2 = vi.fn();
+    const { rerender } = renderHook(
+      ({ clip }: { clip: (data: string) => void }) =>
+        useEventSource(URL, clip, vi.fn()),
+      { initialProps: { clip: onClip1 } },
+    );
+    const countBefore = MockEventSource.instances.length;
+    rerender({ clip: onClip2 });
+    expect(MockEventSource.instances.length).toBe(countBefore);
+    act(() => {
+      latestEs().emit("clip", new MessageEvent("clip", { data: "data" }));
+    });
+    expect(onClip2).toHaveBeenCalledWith("data");
+    expect(onClip1).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/usePlaybackQueue.test.ts
+++ b/frontend/src/hooks/usePlaybackQueue.test.ts
@@ -1,0 +1,113 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClipEvent } from "../types/api";
+import { usePlaybackQueue } from "./usePlaybackQueue";
+
+function makeClip(id: number): ClipEvent {
+  return {
+    id,
+    url: `http://example.com/clip/${id}.wav`,
+    text: `clip ${id}`,
+    speakerName: "speaker",
+    styleName: "normal",
+    timestamp: id * 1000,
+  };
+}
+
+describe("usePlaybackQueue", () => {
+  let audio: HTMLAudioElement;
+  let audioRef: { current: HTMLAudioElement };
+  let mockPlay: ReturnType<typeof vi.spyOn>;
+  let mockPause: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    audio = document.createElement("audio");
+    audioRef = { current: audio };
+    mockPlay = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockResolvedValue(undefined);
+    mockPause = vi
+      .spyOn(HTMLMediaElement.prototype, "pause")
+      .mockImplementation(() => {});
+    vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("enqueue で audio.play が呼ばれ playingClipId が更新される", async () => {
+    const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
+    expect(result.current.playingClipId).toBeNull();
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+    });
+    expect(mockPlay).toHaveBeenCalled();
+    expect(result.current.playingClipId).toBe(1);
+  });
+
+  it("ended イベント発火で次クリップが再生されキューが空なら null", async () => {
+    const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+      result.current.enqueue(makeClip(2));
+    });
+    expect(result.current.playingClipId).toBe(1);
+    await act(async () => {
+      audio.dispatchEvent(new Event("ended"));
+    });
+    expect(result.current.playingClipId).toBe(2);
+    await act(async () => {
+      audio.dispatchEvent(new Event("ended"));
+    });
+    expect(result.current.playingClipId).toBeNull();
+  });
+
+  it("active=false への遷移で pause とキュー破棄と playingClipId=null になる", async () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) => usePlaybackQueue(audioRef, active),
+      { initialProps: { active: true } },
+    );
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+    });
+    expect(result.current.playingClipId).toBe(1);
+    await act(async () => {
+      rerender({ active: false });
+    });
+    expect(mockPause).toHaveBeenCalled();
+    expect(result.current.playingClipId).toBeNull();
+  });
+
+  it("active=false の間に enqueue してもキューに積まれない", async () => {
+    const { result } = renderHook(() => usePlaybackQueue(audioRef, false));
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+    });
+    expect(mockPlay).not.toHaveBeenCalled();
+    expect(result.current.playingClipId).toBeNull();
+  });
+
+  it("audio.play reject 時に playingClipId が null に戻り次の再生試行が走る", async () => {
+    mockPlay
+      .mockRejectedValueOnce(new Error("play failed"))
+      .mockResolvedValue(undefined);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+      result.current.enqueue(makeClip(2));
+    });
+    expect(result.current.playingClipId).toBe(2);
+  });
+
+  it("アンマウントで ended リスナーが解除される", () => {
+    const removeEventListenerSpy = vi.spyOn(audio, "removeEventListener");
+    const { unmount } = renderHook(() => usePlaybackQueue(audioRef, true));
+    unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "ended",
+      expect.any(Function),
+    );
+  });
+});


### PR DESCRIPTION
## 概要

Issue #306 の単体テスト追加を完了しました。useEventSource と usePlaybackQueue の2つのカスタムフックに対して主要な状態遷移とエッジケースをカバーする単体テストを追加しています。

## テスト内容

### useEventSource.test.ts（6テスト）

- **open 受信**: EventSource の open イベント受信で connected=true に遷移
- **clip イベント**: clip イベント受信で onClip(event.data) が呼ばれる
- **サーバー error**: MessageEvent 型の error で onError が呼ばれ、再接続が走らない
- **ネイティブ接続失敗**: Event 型の error で connected=false に遷移し、2秒後に再接続
- **アンマウント**: unmount で close() が呼ばれ、再接続タイマーがキャンセルされる
- **コールバック差し替え**: onClip/onError を差し替えても再接続は走らない（url 変更時のみ再接続）

### usePlaybackQueue.test.ts（6テスト）

- **enqueue**: enqueue で audio.play() が呼ばれ playingClipId が更新される
- **ended イベント**: ended イベント発火で次クリップが再生され、キューが空なら playingClipId が null に
- **active=false**: active=false への遷移で pause() が呼ばれ、キュー破棄、playingClipId=null
- **active=false 中は enqueue 不可**: active=false の間に enqueue してもキューに積まれない
- **play() reject**: audio.play() が reject されたとき、playingClipId が null に戻り次の再生試行が走る
- **アンマウント**: アンマウントで ended リスナーが解除される

## テスト実行結果

```
✓ src/hooks/useEventSource.test.ts (6 tests) 
✓ src/hooks/usePlaybackQueue.test.ts (6 tests)
✓ その他テストも全て成功

Test Files: 9 passed (9)
Tests: 49 passed (49)
Duration: 3.60s
```

## 実装の特徴

- **MockEventSource**: vi.stubGlobal で EventSource を差し替え、addEventListener で登録されたハンドラを直接呼び出して動作検証
- **HTMLMediaElement モック**: vi.spyOn で play/pause/load を差し替え、Promise の resolve/reject 動作を検証
- **タイマーテスト**: vi.useFakeTimers/advanceTimersByTime で再接続タイマーをテスト
- **状態遷移**: useCallback と useRef を活用した複雑な状態遷移を act() で検証

Closes #306

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)