### PR TITLE
feat: 配信タイムライン関連コンポーネント (StreamPanel/Timeline/TimelineItem/TimelineControls) の単体テストを追加する #303

### DIFF
--- a/frontend/src/components/StreamPanel.test.tsx
+++ b/frontend/src/components/StreamPanel.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TimelineEntry } from "../types/api";
+import { StreamPanel } from "./StreamPanel";
+
+const mockEntries: TimelineEntry[] = [
+  {
+    kind: "clip",
+    id: 1,
+    url: "http://example.com/audio.mp3",
+    text: "クリップテキスト",
+    speakerName: "話者A",
+    styleName: "ノーマル",
+    timestamp: 1700000000000,
+  },
+];
+
+const defaultProps = {
+  entries: [],
+  playingClipId: null,
+  historySize: 50,
+  historySizeOptions: [10, 50, 100] as const,
+  onHistorySizeChange: vi.fn(),
+  showSpeakerName: false,
+  showStyleName: false,
+  showTimestamp: false,
+  onShowSpeakerNameChange: vi.fn(),
+  onShowStyleNameChange: vi.fn(),
+  onShowTimestampChange: vi.fn(),
+};
+
+describe("StreamPanel", () => {
+  it("hidden=false のときにパネルが表示される", () => {
+    render(<StreamPanel {...defaultProps} hidden={false} />);
+    const panel = screen.getByRole("tabpanel", { hidden: false });
+    expect(panel).toBeInTheDocument();
+  });
+
+  it("hidden=true のときにパネルが非表示になる", () => {
+    render(<StreamPanel {...defaultProps} hidden={true} />);
+    const panel = screen.queryByRole("tabpanel", { hidden: false });
+    expect(panel).not.toBeInTheDocument();
+  });
+
+  it("TimelineControls に historySize が渡される", () => {
+    render(<StreamPanel {...defaultProps} hidden={false} historySize={50} />);
+    const select = screen.getByRole("combobox");
+    expect(select).toHaveValue("50");
+  });
+
+  it("TimelineControls に historySizeOptions が渡される", () => {
+    render(
+      <StreamPanel
+        {...defaultProps}
+        hidden={false}
+        historySizeOptions={[10, 50, 100]}
+      />,
+    );
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent("10");
+    expect(options[1]).toHaveTextContent("50");
+    expect(options[2]).toHaveTextContent("100");
+  });
+
+  it("Timeline に entries が渡される", () => {
+    render(
+      <StreamPanel {...defaultProps} hidden={false} entries={mockEntries} />,
+    );
+    expect(screen.getByText("クリップテキスト")).toBeInTheDocument();
+  });
+
+  it("Timeline に playingClipId が渡され再生中エントリが強調される", () => {
+    render(
+      <StreamPanel
+        {...defaultProps}
+        hidden={false}
+        entries={mockEntries}
+        playingClipId={1}
+      />,
+    );
+    expect(screen.getByText("▶")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Timeline.test.tsx
+++ b/frontend/src/components/Timeline.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { TimelineEntry } from "../types/api";
+import { Timeline } from "./Timeline";
+
+const defaultProps = {
+  playingClipId: null,
+  showSpeakerName: false,
+  showStyleName: false,
+  showTimestamp: false,
+};
+
+const clipEntry = (id: number, text: string): TimelineEntry => ({
+  kind: "clip",
+  id,
+  url: `http://example.com/${id}.mp3`,
+  text,
+  speakerName: "話者A",
+  styleName: "ノーマル",
+  timestamp: 1700000000000,
+});
+
+describe("Timeline", () => {
+  it("entries が空のとき何も描画されない", () => {
+    render(<Timeline {...defaultProps} entries={[]} />);
+    const list = screen.getByRole("list");
+    expect(list).toBeEmptyDOMElement();
+  });
+
+  it("entries の数だけリストアイテムが描画される", () => {
+    const entries: TimelineEntry[] = [
+      clipEntry(1, "テキスト1"),
+      clipEntry(2, "テキスト2"),
+      clipEntry(3, "テキスト3"),
+    ];
+    render(<Timeline {...defaultProps} entries={entries} />);
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(3);
+  });
+
+  it("entries のテキストが描画される", () => {
+    const entries: TimelineEntry[] = [
+      clipEntry(1, "最初のテキスト"),
+      clipEntry(2, "次のテキスト"),
+    ];
+    render(<Timeline {...defaultProps} entries={entries} />);
+    expect(screen.getByText("最初のテキスト")).toBeInTheDocument();
+    expect(screen.getByText("次のテキスト")).toBeInTheDocument();
+  });
+
+  it("playingClipId が一致するエントリにのみ再生中アイコンが表示される", () => {
+    const entries: TimelineEntry[] = [
+      clipEntry(1, "テキスト1"),
+      clipEntry(2, "テキスト2"),
+    ];
+    render(<Timeline {...defaultProps} entries={entries} playingClipId={1} />);
+    const playIcons = screen.getAllByText("▶");
+    expect(playIcons).toHaveLength(1);
+  });
+
+  it("playingClipId が null のとき再生中アイコンが表示されない", () => {
+    const entries: TimelineEntry[] = [
+      clipEntry(1, "テキスト1"),
+      clipEntry(2, "テキスト2"),
+    ];
+    render(<Timeline {...defaultProps} entries={entries} playingClipId={null} />);
+    expect(screen.queryByText("▶")).not.toBeInTheDocument();
+  });
+
+  it("error エントリも描画される", () => {
+    const entries: TimelineEntry[] = [
+      {
+        kind: "error",
+        id: 1,
+        category: "synthesis",
+        message: "合成に失敗しました",
+        timestamp: 1700000000000,
+      },
+    ];
+    render(<Timeline {...defaultProps} entries={entries} />);
+    expect(screen.getByText("合成に失敗しました")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TimelineControls.test.tsx
+++ b/frontend/src/components/TimelineControls.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TimelineControls } from "./TimelineControls";
+
+const defaultProps = {
+  historySize: 50,
+  historySizeOptions: [10, 50, 100] as const,
+  onHistorySizeChange: vi.fn(),
+  showSpeakerName: false,
+  showStyleName: false,
+  showTimestamp: false,
+  onShowSpeakerNameChange: vi.fn(),
+  onShowStyleNameChange: vi.fn(),
+  onShowTimestampChange: vi.fn(),
+};
+
+describe("TimelineControls - 履歴サイズ", () => {
+  it("historySize が select の選択値に反映される", () => {
+    render(<TimelineControls {...defaultProps} historySize={50} />);
+    expect(screen.getByRole("combobox")).toHaveValue("50");
+  });
+
+  it("historySizeOptions が option として描画される", () => {
+    render(
+      <TimelineControls {...defaultProps} historySizeOptions={[10, 50, 100]} />,
+    );
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent("10");
+    expect(options[1]).toHaveTextContent("50");
+    expect(options[2]).toHaveTextContent("100");
+  });
+
+  it("select の変更で onHistorySizeChange が数値で呼ばれる", () => {
+    const onHistorySizeChange = vi.fn();
+    render(
+      <TimelineControls
+        {...defaultProps}
+        onHistorySizeChange={onHistorySizeChange}
+      />,
+    );
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "100" } });
+    expect(onHistorySizeChange).toHaveBeenCalledWith(100);
+    expect(onHistorySizeChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("TimelineControls - チェックボックストグル", () => {
+  it("showSpeakerName=true のとき話者名チェックボックスが checked になる", () => {
+    render(<TimelineControls {...defaultProps} showSpeakerName={true} />);
+    expect(screen.getByLabelText("話者名")).toBeChecked();
+  });
+
+  it("showSpeakerName=false のとき話者名チェックボックスが unchecked になる", () => {
+    render(<TimelineControls {...defaultProps} showSpeakerName={false} />);
+    expect(screen.getByLabelText("話者名")).not.toBeChecked();
+  });
+
+  it("話者名チェックボックスをクリックすると onShowSpeakerNameChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onShowSpeakerNameChange = vi.fn();
+    render(
+      <TimelineControls
+        {...defaultProps}
+        onShowSpeakerNameChange={onShowSpeakerNameChange}
+      />,
+    );
+    await user.click(screen.getByLabelText("話者名"));
+    expect(onShowSpeakerNameChange).toHaveBeenCalledWith(true);
+    expect(onShowSpeakerNameChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("showStyleName=true のときスタイルチェックボックスが checked になる", () => {
+    render(<TimelineControls {...defaultProps} showStyleName={true} />);
+    expect(screen.getByLabelText("スタイル")).toBeChecked();
+  });
+
+  it("スタイルチェックボックスをクリックすると onShowStyleNameChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onShowStyleNameChange = vi.fn();
+    render(
+      <TimelineControls
+        {...defaultProps}
+        onShowStyleNameChange={onShowStyleNameChange}
+      />,
+    );
+    await user.click(screen.getByLabelText("スタイル"));
+    expect(onShowStyleNameChange).toHaveBeenCalledWith(true);
+    expect(onShowStyleNameChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("showTimestamp=true のとき時刻チェックボックスが checked になる", () => {
+    render(<TimelineControls {...defaultProps} showTimestamp={true} />);
+    expect(screen.getByLabelText("時刻")).toBeChecked();
+  });
+
+  it("時刻チェックボックスをクリックすると onShowTimestampChange が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onShowTimestampChange = vi.fn();
+    render(
+      <TimelineControls
+        {...defaultProps}
+        onShowTimestampChange={onShowTimestampChange}
+      />,
+    );
+    await user.click(screen.getByLabelText("時刻"));
+    expect(onShowTimestampChange).toHaveBeenCalledWith(true);
+    expect(onShowTimestampChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/TimelineItem.test.tsx
+++ b/frontend/src/components/TimelineItem.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TimelineEntry } from "../types/api";
+import { TimelineItem } from "./TimelineItem";
+
+const clipEntry: TimelineEntry = {
+  kind: "clip",
+  id: 1,
+  url: "http://example.com/audio.mp3",
+  text: "クリップテキスト",
+  speakerName: "話者A",
+  styleName: "スタイル1",
+  timestamp: 1700000000000,
+};
+
+const defaultProps = {
+  entry: clipEntry,
+  playing: false,
+  showSpeakerName: false,
+  showStyleName: false,
+  showTimestamp: false,
+};
+
+describe("TimelineItem - clip", () => {
+  it("テキストが描画される", () => {
+    render(<TimelineItem {...defaultProps} />);
+    expect(screen.getByText("クリップテキスト")).toBeInTheDocument();
+  });
+
+  it("playing=false のとき再生アイコンが表示されない", () => {
+    render(<TimelineItem {...defaultProps} playing={false} />);
+    expect(screen.queryByText("▶")).not.toBeInTheDocument();
+  });
+
+  it("playing=true のとき再生アイコンが表示される", () => {
+    render(<TimelineItem {...defaultProps} playing={true} />);
+    expect(screen.getByText("▶")).toBeInTheDocument();
+  });
+
+  it("playing=true のときハイライトクラスが付く", () => {
+    render(<TimelineItem {...defaultProps} playing={true} />);
+    const item = screen.getByRole("listitem");
+    expect(item).toHaveClass("bg-ctp-overlay");
+  });
+
+  it("playing=false のときハイライトクラスが付かない", () => {
+    render(<TimelineItem {...defaultProps} playing={false} />);
+    const item = screen.getByRole("listitem");
+    expect(item).not.toHaveClass("bg-ctp-overlay");
+  });
+});
+
+describe("TimelineItem - clip meta toggles", () => {
+  it("showSpeakerName=true のとき話者名が表示される", () => {
+    render(<TimelineItem {...defaultProps} showSpeakerName={true} />);
+    expect(screen.getByText("話者A")).toBeInTheDocument();
+  });
+
+  it("showSpeakerName=false のとき話者名が表示されない", () => {
+    render(<TimelineItem {...defaultProps} showSpeakerName={false} />);
+    expect(screen.queryByText("話者A")).not.toBeInTheDocument();
+  });
+
+  it("showStyleName=true のときスタイル名が表示される", () => {
+    render(<TimelineItem {...defaultProps} showStyleName={true} />);
+    expect(screen.getByText("[スタイル1]")).toBeInTheDocument();
+  });
+
+  it("showStyleName=false のときスタイル名が表示されない", () => {
+    render(<TimelineItem {...defaultProps} showStyleName={false} />);
+    expect(screen.queryByText("[スタイル1]")).not.toBeInTheDocument();
+  });
+
+  it("showTimestamp=true のとき時刻が表示される", () => {
+    render(<TimelineItem {...defaultProps} showTimestamp={true} />);
+    const item = screen.getByRole("listitem");
+    expect(item).toHaveTextContent(/\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("showTimestamp=false のとき時刻が表示されない", () => {
+    render(<TimelineItem {...defaultProps} showTimestamp={false} />);
+    const item = screen.getByRole("listitem");
+    expect(item).not.toHaveTextContent(/\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+describe("TimelineItem - error", () => {
+  it("category=synthesis のとき合成エラーラベルが表示される", () => {
+    const entry: TimelineEntry = {
+      kind: "error",
+      id: 2,
+      category: "synthesis",
+      message: "合成に失敗しました",
+      timestamp: 1700000000000,
+    };
+    render(<TimelineItem {...defaultProps} entry={entry} />);
+    expect(screen.getByText("合成エラー")).toBeInTheDocument();
+    expect(screen.getByText("合成に失敗しました")).toBeInTheDocument();
+  });
+
+  it("category=file のときファイルエラーラベルが表示される", () => {
+    const entry: TimelineEntry = {
+      kind: "error",
+      id: 3,
+      category: "file",
+      message: "ファイルが見つかりません",
+      timestamp: 1700000000000,
+    };
+    render(<TimelineItem {...defaultProps} entry={entry} />);
+    expect(screen.getByText("ファイルエラー")).toBeInTheDocument();
+  });
+
+  it("category=connection のとき接続エラーラベルが表示される", () => {
+    const entry: TimelineEntry = {
+      kind: "error",
+      id: 4,
+      category: "connection",
+      message: "接続に失敗しました",
+      timestamp: 1700000000000,
+    };
+    render(<TimelineItem {...defaultProps} entry={entry} />);
+    expect(screen.getByText("接続エラー")).toBeInTheDocument();
+  });
+
+  it("error エントリの showSpeakerName=true のとき話者名が表示される", () => {
+    const entry: TimelineEntry = {
+      kind: "error",
+      id: 5,
+      category: "synthesis",
+      message: "エラー",
+      timestamp: 1700000000000,
+      text: "エラー時のテキスト",
+      speakerName: "話者B",
+    };
+    render(<TimelineItem {...defaultProps} entry={entry} showSpeakerName={true} />);
+    expect(screen.getByText("話者B")).toBeInTheDocument();
+  });
+});
+
+describe("TimelineItem - scrollIntoView", () => {
+  let scrollIntoViewMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    scrollIntoViewMock = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("playing が false→true になると scrollIntoView が呼ばれる", () => {
+    const { rerender } = render(
+      <TimelineItem {...defaultProps} playing={false} />,
+    );
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+    rerender(<TimelineItem {...defaultProps} playing={true} />);
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
+  it("playing が true→true で再描画しても scrollIntoView は呼ばれない", () => {
+    const { rerender } = render(
+      <TimelineItem {...defaultProps} playing={true} />,
+    );
+    scrollIntoViewMock.mockClear();
+
+    rerender(<TimelineItem {...defaultProps} playing={true} />);
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it("マウント時点で playing=true のとき scrollIntoView が呼ばれる", () => {
+    render(<TimelineItem {...defaultProps} playing={true} />);
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
+  it("マウント時点で playing=false のとき scrollIntoView は呼ばれない", () => {
+    render(<TimelineItem {...defaultProps} playing={false} />);
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/test/setup.ts
+++ b/frontend/test/setup.ts
@@ -1,1 +1,4 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom では scrollIntoView が未実装のためグローバルにスタブを設定する
+window.HTMLElement.prototype.scrollIntoView = function () {};


### PR DESCRIPTION
## 概要

Issue #303 の配信タイムライン関連コンポーネント単体テストを追加しました。

## 変更内容

- **StreamPanel.test.tsx**: `hidden` prop による表示/非表示切替、子コンポーネント（Timeline / TimelineControls）への props 正確性を検証
- **Timeline.test.tsx**: エントリ配列の TimelineItem として描画、空配列時の動作、`playingClipId` の伝播確認
- **TimelineItem.test.tsx**: 
  - clip kind の通常表示と playing=true 時のハイライト
  - error kind の各カテゴリ (synthesis / file / connection) のラベル分岐
  - showSpeakerName / showStyleName / showTimestamp トグルでメタ表示が切り替わる
  - `scrollIntoView` が false→true の立ち上がりエッジで呼ばれる
  - マウント時点で playing=true のケースも scrollIntoView が発火する
- **TimelineControls.test.tsx**: 履歴サイズ select の change コールバック、各トグル checkbox の change コールバック
- **test/setup.ts**: jsdom では scrollIntoView が未実装のためグローバルスタブを追加

## テスト結果

```
Test Files  13 passed (13)
Tests       90 passed (90)
```

## チェックリスト

- [x] 4ファイルの `*.test.tsx` が追加されている
- [x] `make test-frontend-unit` がローカルで成功している
- [x] `TimelineItem` の `scrollIntoView` 立ち上がりエッジが検証されている

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
