### PR TITLE
feat: say --output にディレクトリパスと拡張子検証を追加する

### DIFF
--- a/internal/infra/file_writer.go
+++ b/internal/infra/file_writer.go
@@ -14,10 +14,17 @@ import (
 	"github.com/canpok1/vox-actor/internal/domain/entity"
 )
 
+const (
+	extJSON  = ".json"
+	extJSONL = ".jsonl"
+	extTxt   = ".txt"
+)
+
 // FileWriter は entity.Script をファイルへ書き出す。
 // app.ScriptWriter インターフェースを実装する。
 type FileWriter struct {
 	logger *slog.Logger
+	now    func() time.Time
 }
 
 var _ app.ScriptWriter = (*FileWriter)(nil)
@@ -34,10 +41,18 @@ func WithFileWriterLogger(logger *slog.Logger) FileWriterOption {
 	}
 }
 
+// WithFileWriterNow は FileWriter の時刻関数を設定するオプション（テスト用）。
+func WithFileWriterNow(now func() time.Time) FileWriterOption {
+	return func(w *FileWriter) {
+		w.now = now
+	}
+}
+
 // NewFileWriter は FileWriter を生成する。
 func NewFileWriter(opts ...FileWriterOption) *FileWriter {
 	w := &FileWriter{
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:    time.Now,
 	}
 	for _, opt := range opts {
 		opt(w)
@@ -46,11 +61,46 @@ func NewFileWriter(opts ...FileWriterOption) *FileWriter {
 }
 
 // Write は entity.Script を path に書き出す。
-// 拡張子で書き出し形式を判定する: .json / .jsonl / その他は本文のみ。
+// path がディレクトリ（末尾が "/" または os.Stat で IsDir）の場合、配下に <UnixMilli>_say.json を生成。
+// ディレクトリ指定時に末尾が "/" で未存在ならば os.MkdirAll で作成する。
+// path がファイル名の場合、拡張子で書き出し形式を判定：.json / .jsonl のみ JSON 出力、.txt は本文のみ。
+// ファイル指定時は拡張子必須で、.json / .jsonl / .txt 以外はエラーで返す。
 // 既存ファイルがある場合は <name>_<UnixNano><ext> で連番を付与する。
-// 親ディレクトリが存在しない場合はエラーを返す。
 // 戻り値は実際の書き出し先パス。
 func (w *FileWriter) Write(path string, script entity.Script) (string, error) {
+	// ディレクトリ判定：末尾が "/" または os.Stat で IsDir
+	isDir := strings.HasSuffix(path, string(os.PathSeparator))
+	if !isDir {
+		info, err := os.Stat(path)
+		if err == nil && info.IsDir() {
+			isDir = true
+		}
+	}
+
+	if isDir {
+		// ディレクトリ指定時の処理
+		dir := strings.TrimSuffix(path, string(os.PathSeparator))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return "", fmt.Errorf("failed to create directory: %s: %w", dir, err)
+		}
+		// 自動ファイル名生成：<UnixMilli>_say.json
+		filename := fmt.Sprintf("%d_say.json", w.now().UnixMilli())
+		path = filepath.Join(dir, filename)
+	} else {
+		// ファイル指定時の拡張子検証
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext == "" {
+			return "", fmt.Errorf("output path has no extension; specify .json, .jsonl, .txt, or a directory path ending with \"/\"")
+		}
+		switch ext {
+		case extJSON, extJSONL, extTxt:
+			// OK
+		default:
+			return "", fmt.Errorf("unsupported output extension: %q (allowed: .json, .jsonl, .txt)", ext)
+		}
+	}
+
+	// 親ディレクトリの存在確認
 	parent := filepath.Dir(path)
 	info, err := os.Stat(parent)
 	if err != nil {
@@ -64,7 +114,7 @@ func (w *FileWriter) Write(path string, script entity.Script) (string, error) {
 
 	ext := strings.ToLower(filepath.Ext(dest))
 	switch ext {
-	case ".json", ".jsonl":
+	case extJSON, extJSONL:
 		return dest, writeJSONLine(dest, script)
 	default:
 		w.warnUnsavedParams(dest, script)
@@ -81,7 +131,7 @@ func (w *FileWriter) resolveDest(path string) string {
 	base := filepath.Base(path)
 	ext := filepath.Ext(base)
 	name := strings.TrimSuffix(base, ext)
-	return filepath.Join(dir, fmt.Sprintf("%s_%d%s", name, time.Now().UnixNano(), ext))
+	return filepath.Join(dir, fmt.Sprintf("%s_%d%s", name, w.now().UnixNano(), ext))
 }
 
 // warnUnsavedParams は .txt / 未知拡張子の出力時に保存できないパラメータが指定されていれば WARN ログを出す。

--- a/internal/infra/file_writer_test.go
+++ b/internal/infra/file_writer_test.go
@@ -207,23 +207,19 @@ func TestFileWriter_Write_Txt_TextOnly(t *testing.T) {
 	}
 }
 
-func TestFileWriter_Write_UnknownExt_TextOnly(t *testing.T) {
+func TestFileWriter_Write_UnknownExt_ReturnsError(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	dest := filepath.Join(dir, "out.foo")
 
 	w := infra.NewFileWriter()
-	if _, err := w.Write(dest, entity.Script{Text: "未知拡張子"}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := w.Write(dest, entity.Script{Text: "未知拡張子"})
+	if err == nil {
+		t.Fatal("expected error for unknown extension, got nil")
 	}
-
-	data, err := os.ReadFile(dest)
-	if err != nil {
-		t.Fatalf("read failed: %v", err)
-	}
-	if string(data) != "未知拡張子" {
-		t.Errorf("expected exact text, got: %q", string(data))
+	if !strings.Contains(err.Error(), "unsupported output extension") {
+		t.Errorf("expected 'unsupported output extension' in error, got: %v", err)
 	}
 }
 
@@ -343,5 +339,133 @@ func TestFileWriter_Write_MissingParentDir_ReturnsError(t *testing.T) {
 	w := infra.NewFileWriter()
 	if _, err := w.Write(dest, entity.Script{Text: "本文"}); err == nil {
 		t.Fatal("expected error for missing parent directory, got nil")
+	}
+}
+
+// ディレクトリ指定時のテスト
+
+func TestFileWriter_Write_DirectoryTarget_CreatesAutoNamedFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "out")
+	if err := os.Mkdir(outDir, 0o755); err != nil {
+		t.Fatalf("failed to create output dir: %v", err)
+	}
+
+	w := infra.NewFileWriter()
+	written, err := w.Write(outDir, entity.Script{
+		Text:       "ディレクトリ指定",
+		SpeakerID:  ptrInt(2),
+		SpeedScale: ptrFloat64(1.1),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 出力先は outDir 配下、かつ _say.json で終わる
+	if !strings.HasPrefix(written, outDir) {
+		t.Errorf("expected written path under %s, got %s", outDir, written)
+	}
+	if !strings.HasSuffix(written, "_say.json") {
+		t.Errorf("expected filename ending with _say.json, got %s", filepath.Base(written))
+	}
+
+	// ファイルが実際に存在し、JSONで読める
+	data, err := os.ReadFile(written)
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("invalid JSON written: %v", err)
+	}
+	if got["text"] != "ディレクトリ指定" {
+		t.Errorf("text mismatch: %v", got["text"])
+	}
+	if got["speaker"].(float64) != 2 {
+		t.Errorf("speaker mismatch: %v", got["speaker"])
+	}
+}
+
+func TestFileWriter_Write_DirectoryTargetTrailingSlash_CreatesDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "newdir") + string(os.PathSeparator)
+
+	w := infra.NewFileWriter()
+	written, err := w.Write(outDir, entity.Script{Text: "末尾スラッシュ指定"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// ディレクトリが作成され、その下にファイルが生成される
+	if !strings.HasSuffix(written, "_say.json") {
+		t.Errorf("expected filename ending with _say.json, got %s", filepath.Base(written))
+	}
+
+	data, err := os.ReadFile(written)
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
+	}
+	if !strings.Contains(string(data), "末尾スラッシュ指定") {
+		t.Errorf("text not found in file: %s", string(data))
+	}
+}
+
+// ファイル拡張子検証のテスト
+
+func TestFileWriter_Write_NoExtension_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "noext")
+
+	w := infra.NewFileWriter()
+	_, err := w.Write(dest, entity.Script{Text: "本文"})
+	if err == nil {
+		t.Fatal("expected error for no extension, got nil")
+	}
+	if !strings.Contains(err.Error(), "no extension") {
+		t.Errorf("expected 'no extension' in error message, got: %v", err)
+	}
+}
+
+func TestFileWriter_Write_UnsupportedExtension_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.csv")
+
+	w := infra.NewFileWriter()
+	_, err := w.Write(dest, entity.Script{Text: "本文"})
+	if err == nil {
+		t.Fatal("expected error for unsupported extension, got nil")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "unsupported output extension") && !strings.Contains(errMsg, ".csv") {
+		t.Errorf("expected error message mentioning unsupported extension, got: %v", err)
+	}
+}
+
+func TestFileWriter_Write_SupportedExtensions_AllWork(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	exts := []string{".json", ".jsonl", ".txt"}
+
+	for _, ext := range exts {
+		t.Run(ext, func(t *testing.T) {
+			dest := filepath.Join(dir, "out"+ext)
+			w := infra.NewFileWriter()
+			_, err := w.Write(dest, entity.Script{Text: "テスト"})
+			if err != nil {
+				t.Fatalf("unexpected error for %s: %v", ext, err)
+			}
+			if _, err := os.Stat(dest); err != nil {
+				t.Fatalf("file not created: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## 概要

`say` コマンドの `--output` オプションでディレクトリパスを指定可能にし、指定したディレクトリ内に自動生成したファイル名で台本ファイルを出力する。あわせてファイル名指定時の拡張子検証を追加する。

## 実装内容

### ディレクトリ指定時の動作
- `--output <dir>` でディレクトリを指定（末尾が `/` または `os.Stat` で `IsDir() == true`）
- 指定ディレクトリ内に `<UnixMilli>_say.json` という名前で出力
- 末尾が `/` でディレクトリが未存在なら `os.MkdirAll(dir, 0o755)` で自動作成
- フォーマットは `.json` 固定（すべてのパラメータ保存）

### ファイル指定時の検証
- 拡張子は `.json` / `.jsonl` / `.txt` のみ許可
- 拡張子なし → エラー: "output path has no extension; ..."
- 許可外拡張子 → エラー: "unsupported output extension: ..."

### テスト容易性
- `FileWriter` に `now` フィールド（`func() time.Time`）を追加
- `WithFileWriterNow` オプションでテスト時に時刻関数を差し替え可能に

### コード品質改善
- 拡張子定数化（`extJSON`, `extJSONL`, `extTxt`）
- `WithFileWriterNow` で nil チェック削除（既存パターンとの一貫性）
- 不要な `os.Stat` チェック削除（`os.MkdirAll` は冪等的）
- 時刻関数の一貫性：`resolveDest()` で `w.now()` を使用

## テストケース

### ディレクトリ指定
- ✓ 既存ディレクトリへの出力
- ✓ 末尾 `/` で未存在ディレクトリの自動作成と出力

### ファイル指定
- ✓ 拡張子なしでエラー
- ✓ 許可外拡張子でエラー
- ✓ `.json` / `.jsonl` / `.txt` は成功

### 既存機能との互換性
- ✓ 既存テストすべて PASS
- ✓ gofmt OK / golangci-lint OK

## 関連Issue
Closes #314

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)