### PR TITLE
feat: dev スクリプトにホストオプションを追加し、Makefile の dev-backend ターゲットを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,6 @@ test-frontend-unit: frontend/node_modules
 test-frontend-e2e: frontend/node_modules
 	cd frontend && npm run test:e2e
 
-run-stream: build-frontend
-	go run . watch --engine-url http://voicevox:50021 --stream --stream-addr 0.0.0.0:8080 --queue
-
 # 配信画面のローカル開発用ターゲット。
 # dev-backend は frontend/dist を参照せず起動できる前提（assets.go の //go:embed all: と frontend/dist/.gitkeep でビルド可）。
 # dev-frontend の Vite dev server (既定 :5173) は vite.config.ts の proxy で /events, /speakers.json, /test-clip, /clips/ を :8080 に中継する。
@@ -65,7 +62,7 @@ dev-frontend: frontend/node_modules
 # VOICEVOX エンジン URL は CLI 既定値（http://localhost:50021）または環境変数 VOX_ENGINE_URL に従う。
 # dev container 等で voicevox:50021 を使う場合は `VOX_ENGINE_URL=http://voicevox:50021 make dev-backend` のように指定する。
 dev-backend:
-	go run . watch --stream --stream-addr 127.0.0.1:8080 --queue
+	go run . watch --engine-url http://voicevox:50021 --stream --stream-addr 0.0.0.0:8080 --queue
 
 dev:
 	$(MAKE) -j2 dev-backend dev-frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build": "vite build",
     "postbuild": "touch dist/.gitkeep",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary

dev container環境でのホスト疎通性を改善するため、dev スクリプトにホストオプションを追加し、Makefile の dev-backend ターゲットを修正しました。

- `frontend/package.json` の `dev` スクリプトに `--host 0.0.0.0` フラグを追加
- `Makefile` の `dev-backend` ターゲットで VOICEVOX エンジン URL をデフォルト値から `http://voicevox:50021` に変更
- `Makefile` の不要な `run-stream` ターゲットを削除

## Changes

- **frontend/package.json**: `vite --host 0.0.0.0` で Vite dev server をすべてのインターフェースで起動
- **Makefile**: 
  - `dev-backend` の `--stream-addr` を `127.0.0.1:8080` → `0.0.0.0:8080` に変更
  - `dev-backend` の `--engine-url` に `http://voicevox:50021` を指定
  - 不要な `run-stream` ターゲットを削除

## Closes
#XX

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)