### PR TITLE
feat: actスキルから VOX_ACTOR_WORKSPACE 環境変数を隠蔽する (#317)

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/canpok1/vox-actor/internal/infra"
@@ -11,6 +14,7 @@ import (
 // supportedConfigKeys は `vox-actor config <key>` で解決可能なキーをアルファベット順で保持する。
 var supportedConfigKeys = []string{
 	"path.queue",
+	"path.tmp",
 	"path.workspace",
 }
 
@@ -39,9 +43,19 @@ func runConfig(cmd *cobra.Command, key string) error {
 	)
 	switch key {
 	case "path.queue":
-		path, err = infra.ResolveQueuePath()
+		var ws string
+		ws, err = resolveWorkspaceWithFallback()
+		if err == nil {
+			path = filepath.Join(ws, "queue")
+		}
+	case "path.tmp":
+		var ws string
+		ws, err = resolveWorkspaceWithFallback()
+		if err == nil {
+			path = filepath.Join(ws, "tmp")
+		}
 	case "path.workspace":
-		path, err = infra.ResolveWorkspacePath()
+		path, err = resolveWorkspaceWithFallback()
 	default:
 		return fmt.Errorf("%w: unknown key: %s\nsupported keys:\n%s", ErrUsage, key, formatSupportedKeys())
 	}
@@ -52,6 +66,19 @@ func runConfig(cmd *cobra.Command, key string) error {
 		return err
 	}
 	return nil
+}
+
+// resolveWorkspaceWithFallback はワークスペースルートを解決し、git管理外の場合はカレントディレクトリにフォールバックする。
+func resolveWorkspaceWithFallback() (string, error) {
+	path, err := infra.ResolveWorkspacePath()
+	if errors.Is(err, infra.ErrNotInGitRepo) {
+		cwd, cwdErr := os.Getwd()
+		if cwdErr != nil {
+			return "", cwdErr
+		}
+		return cwd, nil
+	}
+	return path, err
 }
 
 func formatSupportedKeys() string {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -36,6 +36,23 @@ func withTempGitRepo(t *testing.T) string {
 	return dir
 }
 
+// withTempNonGitDir はテスト実行中だけカレントディレクトリを一時的な非gitディレクトリに切り替える。
+func withTempNonGitDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(orig)
+	})
+	return dir
+}
+
 func TestConfigCmd_RegisteredAsSubcommand(t *testing.T) {
 	rootCmd := makeRootCmd()
 
@@ -121,17 +138,9 @@ func TestConfigCmd_PathWorkspace_WithEnv_PrintsEnvValue(t *testing.T) {
 	}
 }
 
-func TestConfigCmd_PathWorkspace_OutsideGitRepo_ReturnsErrorWithJapaneseMessage(t *testing.T) {
+func TestConfigCmd_PathWorkspace_OutsideGitRepo_PrintsCwd(t *testing.T) {
 	t.Setenv("VOX_ACTOR_WORKSPACE", "")
-	dir := t.TempDir()
-	orig, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("failed to chdir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(orig) })
+	cwd := withTempNonGitDir(t)
 
 	rootCmd := makeRootCmd()
 	outBuf := new(bytes.Buffer)
@@ -140,12 +149,16 @@ func TestConfigCmd_PathWorkspace_OutsideGitRepo_ReturnsErrorWithJapaneseMessage(
 	rootCmd.SetErr(errBuf)
 	rootCmd.SetArgs([]string{"config", "path.workspace"})
 
-	err = rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when outside git repo, got nil")
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v, stderr: %s", err, errBuf.String())
 	}
-	if !strings.Contains(err.Error(), "gitリポジトリではありません") {
-		t.Errorf("expected error to contain 'gitリポジトリではありません', got: %v", err)
+
+	got := strings.TrimRight(outBuf.String(), "\n")
+	// macOS の /var → /private/var シンボリックリンクを考慮して比較する。
+	gotEval, _ := filepath.EvalSymlinks(got)
+	cwdEval, _ := filepath.EvalSymlinks(cwd)
+	if gotEval != cwdEval {
+		t.Errorf("got %q, want %q", got, cwd)
 	}
 }
 
@@ -171,18 +184,9 @@ func TestConfigCmd_PathQueue_WithEnv_PrintsEnvValueJoinedWithQueue(t *testing.T)
 	}
 }
 
-func TestConfigCmd_PathQueue_OutsideGitRepo_ReturnsErrorWithJapaneseMessage(t *testing.T) {
+func TestConfigCmd_PathQueue_OutsideGitRepo_PrintsCwdQueue(t *testing.T) {
 	t.Setenv("VOX_ACTOR_WORKSPACE", "")
-	// TempDir はgitリポジトリではない
-	dir := t.TempDir()
-	orig, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("failed to chdir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(orig) })
+	cwd := withTempNonGitDir(t)
 
 	rootCmd := makeRootCmd()
 	outBuf := new(bytes.Buffer)
@@ -191,12 +195,86 @@ func TestConfigCmd_PathQueue_OutsideGitRepo_ReturnsErrorWithJapaneseMessage(t *t
 	rootCmd.SetErr(errBuf)
 	rootCmd.SetArgs([]string{"config", "path.queue"})
 
-	err = rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when outside git repo, got nil")
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v, stderr: %s", err, errBuf.String())
 	}
-	if !strings.Contains(err.Error(), "gitリポジトリではありません") {
-		t.Errorf("expected error to contain 'gitリポジトリではありません', got: %v", err)
+
+	got := strings.TrimRight(outBuf.String(), "\n")
+	want := filepath.Join(cwd, "queue")
+	wantEval, _ := filepath.EvalSymlinks(filepath.Dir(want))
+	gotEval, _ := filepath.EvalSymlinks(filepath.Dir(got))
+	if gotEval != wantEval || filepath.Base(got) != filepath.Base(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestConfigCmd_PathTmp_InsideGitRepo_PrintsAbsolutePath(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	repoRoot := withTempGitRepo(t)
+
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.tmp"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v, stderr: %s", err, errBuf.String())
+	}
+
+	got := strings.TrimRight(outBuf.String(), "\n")
+	want := filepath.Join(repoRoot, ".vox-actor", "tmp")
+	wantEval, _ := filepath.EvalSymlinks(filepath.Dir(want))
+	gotEval, _ := filepath.EvalSymlinks(filepath.Dir(got))
+	if gotEval != wantEval || filepath.Base(got) != filepath.Base(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestConfigCmd_PathTmp_OutsideGitRepo_PrintsCwdTmp(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	cwd := withTempNonGitDir(t)
+
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.tmp"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v, stderr: %s", err, errBuf.String())
+	}
+
+	got := strings.TrimRight(outBuf.String(), "\n")
+	want := filepath.Join(cwd, "tmp")
+	wantEval, _ := filepath.EvalSymlinks(filepath.Dir(want))
+	gotEval, _ := filepath.EvalSymlinks(filepath.Dir(got))
+	if gotEval != wantEval || filepath.Base(got) != filepath.Base(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestConfigCmd_PathTmp_WithEnv_PrintsEnvValueJoinedWithTmp(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", workspace)
+
+	rootCmd := makeRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"config", "path.tmp"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v, stderr: %s", err, errBuf.String())
+	}
+
+	got := strings.TrimRight(outBuf.String(), "\n")
+	want := filepath.Join(workspace, "tmp")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -189,14 +189,17 @@ vox-actor config <key>
 |---|---|
 | `path.workspace` | vox-actor のワークスペースルート絶対パス |
 | `path.queue` | ワークスペースルート配下の `queue` ディレクトリ絶対パス |
+| `path.tmp` | ワークスペースルート配下の `tmp` ディレクトリ絶対パス |
 
-**解決順（両キー共通）:**
+**解決順（全キー共通）:**
 
 1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその値をワークスペースルートとして扱う
 2. gitリポジトリ内であれば `git rev-parse --path-format=absolute --git-common-dir` の結果の親ディレクトリ配下の `.vox-actor` をワークスペースルートとする
-3. それ以外は非0終了
+3. git管理外の場合はカレントディレクトリをワークスペースルートとして扱う
 
-`path.queue` はワークスペースルートに `queue` を結合した値を返すため、`path.workspace`/queue = `path.queue` の関係が常に成立します。
+`path.queue` と `path.tmp` はワークスペースルートに各サブディレクトリを結合した値を返すため、常に以下の関係が成立します:
+- `path.workspace`/queue = `path.queue`
+- `path.workspace`/tmp = `path.tmp`
 
 **出力:**
 
@@ -210,7 +213,7 @@ vox-actor config <key>
 | 成功 | 0 | — |
 | 未知のキー | 2 (`ErrUsage`) | `unknown key: <key>` とサポートキー一覧 |
 | `git` コマンドがPATH上に無い | 1 | `Error: gitコマンドが見つかりません` |
-| カレントディレクトリがgitリポジトリ外かつ `VOX_ACTOR_WORKSPACE` 未設定 | 1 | `Error: カレントディレクトリはgitリポジトリではありません` |
+| カレント ディレクトリ取得失敗（通常発生しない） | 1 | `Error: カレントディレクトリが取得できません` |
 
 **使用例:**
 
@@ -220,18 +223,31 @@ $ cd /path/to/repo && vox-actor config path.workspace
 /path/to/repo/.vox-actor
 $ cd /path/to/repo && vox-actor config path.queue
 /path/to/repo/.vox-actor/queue
+$ cd /path/to/repo && vox-actor config path.tmp
+/path/to/repo/.vox-actor/tmp
+
+# git管理外で実行（カレントディレクトリにフォールバック）
+$ cd /tmp/non-git && vox-actor config path.workspace
+/tmp/non-git
+$ cd /tmp/non-git && vox-actor config path.queue
+/tmp/non-git/queue
+$ cd /tmp/non-git && vox-actor config path.tmp
+/tmp/non-git/tmp
 
 # VOX_ACTOR_WORKSPACE 明示
 $ VOX_ACTOR_WORKSPACE=/custom vox-actor config path.workspace
 /custom
 $ VOX_ACTOR_WORKSPACE=/custom vox-actor config path.queue
 /custom/queue
+$ VOX_ACTOR_WORKSPACE=/custom vox-actor config path.tmp
+/custom/tmp
 
 # 未知のキー
 $ vox-actor config path.unknown
 Error: unknown key: path.unknown
 supported keys:
   path.queue
+  path.tmp
   path.workspace
 ```
 

--- a/plugins/vox-actor-plugin/skills/act/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/act/SKILL.md
@@ -9,11 +9,9 @@ description: |
   直接ユーザーが呼ぶより、monologue/speak/talk経由の呼び出しを想定。
 argument-hint: "<種別:monologue|speak|talk> <本文> [追加の演出指示]"
 allowed-tools:
+  - "Bash(${CLAUDE_PLUGIN_ROOT}/skills/act/scripts/save-script.sh *)"
   - "Bash(${CLAUDE_PLUGIN_ROOT}/skills/act/scripts/play-script.sh *)"
-  - "Bash(mkdir -p *)"
-  - "Bash(date +%s%3N)"
   - "Read(${CLAUDE_PLUGIN_ROOT}/skills/act/characters/*.md)"
-  - "Write(${VOX_ACTOR_WORKSPACE}/tmp/*)"
 ---
 
 vox-actor を使った音声再生の技術的実行を担うスキルです。`monologue` / `speak` / `talk` の入口スキルから呼び出される前提で、台本生成と再生実行を一手に引き受けます。vox-actor CLI に関する利用知識（話速の目安・通知モード切替・ワークスペース解決・エラーログ仕様・JSON/JSONL の形式制約・キャラクター設定の扱いなど）はこのスキルに集約されています。
@@ -39,18 +37,22 @@ vox-actor を使った音声再生の技術的実行を担うスキルです。`
    - `speak`: 冒頭→本題→まとめの流れの JSONL（複数行）
    - `talk`: 複数キャラの掛け合い JSONL（複数行）。冒頭で全キャラが1回以上登場するよう構成する
 4. セリフ毎に内容の感情に合う `speaker` と `speedScale` を選定する
-5. `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で一時ディレクトリを作成する
-6. `date +%s%3N` でユニックス時刻（ms）を取得し、一時ファイル `${VOX_ACTOR_WORKSPACE}/tmp/<unix_ms>_<kind>.<ext>` に台本を Write する
-   - `monologue` → `<unix_ms>_monologue.json`
-   - `speak` → `<unix_ms>_speak.jsonl`
-   - `talk` → `<unix_ms>_talk.jsonl`
-7. `play-script.sh <path>` を呼び出して再生する
+5. 台本をstdinから `save-script.sh` に渡して、一時ファイルの絶対パスを取得する
+
+```bash
+SCRIPT_PATH=$(echo "$script_content" | ${CLAUDE_PLUGIN_ROOT}/skills/act/scripts/save-script.sh <kind>) || exit 1
+```
+
+- `<kind>`: 種別（`monologue` / `speak` / `talk`）
+- 返り値: `<workspace>/tmp/<unix_ms>_<kind>.<ext>` の絶対パス
+
+6. `play-script.sh <path>` を呼び出して再生する
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/skills/act/scripts/play-script.sh <path>
 ```
 
-- `<path>`（第1引数・必須）: 生成した台本ファイルの絶対パス
+- `<path>`（第1引数・必須）: `save-script.sh` が返した台本ファイルの絶対パス
 
 ## 台本の形式
 
@@ -117,16 +119,13 @@ ${CLAUDE_PLUGIN_ROOT}/skills/act/scripts/play-script.sh <path>
 
 ## 前提条件
 
-### play-script.sh の依存関係
+### CLI コマンドの依存関係
 
-再生の実行に使用する `${CLAUDE_PLUGIN_ROOT}/skills/act/scripts/play-script.sh` は以下の前提条件を必要とします。
+このスキルが使用する CLI コマンドについて、ワークスペース解決および一時ファイル管理は CLI 側に統一されています。詳細は `docs/reference/cli.md` を参照してください。
 
 - **`vox-actor` コマンドのインストール必須**: スクリプト冒頭で `command -v vox-actor` を検査し、未インストール時は `[ERROR] vox-actor コマンドが必要です` を stderr に出して非0終了する
-- **ワークスペースの解決**: スクリプトは `vox-actor config path.queue` / `vox-actor config path.workspace` を呼ぶだけで、環境変数の分岐は CLI 側が担う。CLI の解決順は以下のとおり
-  1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその値をワークスペースルートとして使う（queue は `${VOX_ACTOR_WORKSPACE}/queue`）
-  2. 未設定なら gitリポジトリ直下の `.vox-actor` をワークスペースルートとする（queue は `<repo>/.vox-actor/queue`）
-- **git 管理外で利用する場合**: `VOX_ACTOR_WORKSPACE` の明示が必要。未指定のままだと CLI が非0終了し、そのエラーメッセージが表示されてスクリプトも終了する
-- **出力先ディレクトリ**: ワークスペースルートおよび配下の `queue/` は `play-script.sh` が必要に応じて自動作成する。`tmp/` ディレクトリは Claude が Write する前に `mkdir -p "${VOX_ACTOR_WORKSPACE}/tmp"` で作成する（`tmp/` 利用時は `VOX_ACTOR_WORKSPACE` の明示が前提）
+- **ワークスペースの自動解決**: `vox-actor config path.*` は環境変数・git リポジトリ・カレントディレクトリの順で自動判定する
+  - 詳細は `docs/reference/cli.md` の `config` サブコマンドセクションを参照
 - `play-script-errors.log`（directモードのエラーログ）はワークスペースルート直下に配置される
 
 ### 通知モード

--- a/plugins/vox-actor-plugin/skills/act/scripts/save-script.sh
+++ b/plugins/vox-actor-plugin/skills/act/scripts/save-script.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# 種別引数の検証
+kind="${1:?種別は必須です (monologue|speak|talk)}"
+
+case "$kind" in
+  monologue) ext="json" ;;
+  speak|talk) ext="jsonl" ;;
+  *)
+    echo "[ERROR] 不明な種別: $kind" >&2
+    exit 1
+    ;;
+esac
+
+# tmpディレクトリを取得
+tmp_dir=$(vox-actor config path.tmp) || exit 1
+
+# tmpディレクトリを作成
+mkdir -p "$tmp_dir"
+
+# ユニックス時刻(ms)を取得
+unix_ms=$(date +%s%3N)
+
+# 出力ファイルのパス
+outfile="${tmp_dir}/${unix_ms}_${kind}.${ext}"
+
+# stdinから台本を読み込んでファイルに書き込む
+cat > "$outfile"
+
+# ファイルパスを標準出力に出力
+echo "$outfile"

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -105,6 +105,97 @@ func TestConfigE2E_PathQueue_InsideGitRepo(t *testing.T) {
 	}
 }
 
+func TestConfigE2E_PathTmp_WithEnv(t *testing.T) {
+	workspace := t.TempDir()
+	env := map[string]string{"VOX_ACTOR_WORKSPACE": workspace}
+
+	stdout, stderr, exitCode := runCLI(t, env, "config", "path.tmp")
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	got := assertSinglePathLine(t, stdout)
+	want := filepath.Join(workspace, "tmp")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestConfigE2E_PathTmp_InsideGitRepo(t *testing.T) {
+	repoRoot := initTempGitRepo(t)
+	env := map[string]string{"VOX_ACTOR_WORKSPACE": ""}
+
+	stdout, stderr, exitCode := runCLIInDir(t, repoRoot, env, "config", "path.tmp")
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	got := assertSinglePathLine(t, stdout)
+	want := filepath.Join(repoRoot, ".vox-actor", "tmp")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestConfigE2E_PathWorkspace_OutsideGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	env := map[string]string{"VOX_ACTOR_WORKSPACE": ""}
+
+	stdout, stderr, exitCode := runCLIInDir(t, dir, env, "config", "path.workspace")
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	got := assertSinglePathLine(t, stdout)
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("failed to eval symlinks for %q: %v", dir, err)
+	}
+	if got != resolved {
+		t.Errorf("got %q, want %q", got, resolved)
+	}
+}
+
+func TestConfigE2E_PathQueue_OutsideGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	env := map[string]string{"VOX_ACTOR_WORKSPACE": ""}
+
+	stdout, stderr, exitCode := runCLIInDir(t, dir, env, "config", "path.queue")
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	got := assertSinglePathLine(t, stdout)
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("failed to eval symlinks for %q: %v", dir, err)
+	}
+	want := filepath.Join(resolved, "queue")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestConfigE2E_PathTmp_OutsideGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	env := map[string]string{"VOX_ACTOR_WORKSPACE": ""}
+
+	stdout, stderr, exitCode := runCLIInDir(t, dir, env, "config", "path.tmp")
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	got := assertSinglePathLine(t, stdout)
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("failed to eval symlinks for %q: %v", dir, err)
+	}
+	want := filepath.Join(resolved, "tmp")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestConfigE2E_UnknownKey_ExitCode2(t *testing.T) {
 	stdout, stderr, exitCode := runCLI(t, nil, "config", "path.unknown")
 	if exitCode != 2 {
@@ -113,7 +204,7 @@ func TestConfigE2E_UnknownKey_ExitCode2(t *testing.T) {
 	if strings.TrimSpace(stdout) != "" {
 		t.Errorf("expected empty stdout, got %q", stdout)
 	}
-	wants := []string{"unknown key: path.unknown", "path.queue", "path.workspace"}
+	wants := []string{"unknown key: path.unknown", "path.queue", "path.tmp", "path.workspace"}
 	for _, w := range wants {
 		if !strings.Contains(stderr, w) {
 			t.Errorf("expected stderr to contain %q\nstderr:\n%s", w, stderr)
@@ -138,21 +229,5 @@ func TestConfigE2E_GitNotFound_ExitCode1(t *testing.T) {
 	}
 	if strings.TrimSpace(stderr) == "" {
 		t.Error("expected non-empty stderr for git-not-found")
-	}
-}
-
-func TestConfigE2E_OutsideGitRepo_ExitCode1(t *testing.T) {
-	dir := t.TempDir()
-	env := map[string]string{"VOX_ACTOR_WORKSPACE": ""}
-
-	stdout, stderr, exitCode := runCLIInDir(t, dir, env, "config", "path.workspace")
-	if exitCode != 1 {
-		t.Fatalf("expected exit code 1, got %d\nstderr:\n%s", exitCode, stderr)
-	}
-	if strings.TrimSpace(stdout) != "" {
-		t.Errorf("expected empty stdout, got %q", stdout)
-	}
-	if strings.TrimSpace(stderr) == "" {
-		t.Error("expected non-empty stderr for outside-git-repo")
 	}
 }


### PR DESCRIPTION
## 概要

Issue #317: actスキルから VOX_ACTOR_WORKSPACE 環境変数を隠蔽し、ワークスペース構造の詳細を CLI/スクリプト側に統一

## 変更内容

### 1. CLI に `path.tmp` 追加・git管理外フォールバック (cmd/)
- `vox-actor config path.tmp` で ワークスペースルート配下の `tmp` ディレクトリを返す
- git管理外の場合、カレントディレクトリにフォールバック（従来はエラー終了）
- 実装: `resolveWorkspaceWithFallback()` ヘルパー追加

### 2. 新規スクリプト save-script.sh (plugins/vox-actor-plugin/skills/act/scripts/)
- 種別とstdin台本を受け取り、`vox-actor config path.tmp` で tmp ディレクトリを取得
- `<tmp>/<unix_ms>_<kind>.<ext>` に保存し、絶対パスをstdoutに出力
- monologue/speak/talk 各種別に対応

### 3. SKILL.md から VOX_ACTOR_WORKSPACE 隠蔽
- allowed-tools: `Write(${VOX_ACTOR_WORKSPACE}/tmp/*)` 削除、`Bash(save-script.sh)` 追加
- 実行フロー: mkdir/date/Write → save-script.sh stdin に変更
- 前提条件: VOX_ACTOR_WORKSPACE 記述削除、docs 参照に簡潔化

### 4. docs/reference/cli.md 更新
- `path.tmp` サポートキー追加
- 解決順: git管理外フォールバック説明追加
- 使用例: path.tmp と git管理外の例を追加

## テスト

- ✅ Go unit tests: 全合格 (13個)
- ✅ go fmt / golangci-lint: 指摘ゼロ
- ✅ Manual verification: 
  - git内で `path.tmp` → /workspaces/vox-actor/.vox-actor/tmp
  - git外で `path.tmp` → /tmp/cwd/tmp
  - save-script.sh でmonologue/speak/talk対応確認
- ✅ SKILL.md から VOX_ACTOR_WORKSPACE 完全削除確認

## 受け入れ条件達成

- [x] vox-actor config path.tmp が <workspace>/tmp を返す
- [x] git管理外で path.workspace が <cwd> を返す
- [x] git管理外で path.queue が <cwd>/queue を返す
- [x] git管理外で path.tmp が <cwd>/tmp を返す
- [x] save-script.sh が stdin 台本を保存し絶対パス出力
- [x] save-script.sh が shellcheck 指摘ゼロ
- [x] SKILL.md 内に VOX_ACTOR_WORKSPACE 文字列なし
- [x] monologue/speak/talk 各種別で動作確認
- [x] docs/reference/cli.md 更新完了

## コミット

- 8a5a55a: vox-actor config に path.tmp 追加、git管理外フォールバック
- c3bd6be: save-script.sh 新規追加
- ed67b35: SKILL.md から VOX_ACTOR_WORKSPACE 隠蔽
- c432738: docs/reference/cli.md 更新

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)