### PR TITLE
feat: watch --stream を viewer サブコマンドとして独立させる

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -28,8 +28,8 @@ func buildLoggerFromFlags(cmd *cobra.Command) *slog.Logger {
 	}))
 }
 
-// registerCommonFlags は各サブコマンド共通のフラグを登録する。
-func registerCommonFlags(cmd *cobra.Command) {
+// registerBaseFlags は dry-run を除く共通フラグを登録する。viewer など dry-run を持たないコマンドで使う。
+func registerBaseFlags(cmd *cobra.Command) {
 	engineURLDefault := "http://localhost:50021"
 	if v := os.Getenv("VOX_ENGINE_URL"); v != "" {
 		engineURLDefault = v
@@ -48,5 +48,10 @@ func registerCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().Float64("pitch", 0.0, "音高")
 	cmd.Flags().Float64("intonation", 1.0, "抑揚")
 	cmd.Flags().Bool("verbose", false, "詳細ログを出力")
+}
+
+// registerCommonFlags は各サブコマンド共通のフラグを登録する。
+func registerCommonFlags(cmd *cobra.Command) {
+	registerBaseFlags(cmd)
 	cmd.Flags().Bool("dry-run", false, "VOICEVOX・音声再生を行わず、読み上げ対象をログ出力")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ type Deps struct {
 	Watch      *WatchDeps
 	Say        *SayDeps
 	AudioCheck *AudioCheckDeps
+	Viewer     *ViewerDeps
 }
 
 func makeRootCmd(deps ...*Deps) *cobra.Command {
@@ -46,11 +47,16 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 		sayDeps = d.Say
 		audioCheckDeps = d.AudioCheck
 	}
+	var viewerDeps *ViewerDeps
+	if d != nil {
+		viewerDeps = d.Viewer
+	}
 	cmd.AddCommand(makeActCmd(actDeps))
 	cmd.AddCommand(makeWatchCmd(watchDeps))
 	cmd.AddCommand(makeSayCmd(sayDeps))
 	cmd.AddCommand(makeConfigCmd())
 	cmd.AddCommand(makeAudioCheckCmd(audioCheckDeps))
+	cmd.AddCommand(makeViewerCmd(viewerDeps))
 
 	return cmd
 }

--- a/cmd/viewer.go
+++ b/cmd/viewer.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/spf13/cobra"
+)
+
+// ViewerDeps はviewerコマンドの依存を保持する。
+type ViewerDeps struct {
+	Reader              app.ScriptReader
+	ClientFactory       func(engineURL string) app.VoicevoxClient
+	Mover               app.FileMover
+	DirWatcherFactory   func(logger *slog.Logger) app.DirWatcher
+	StreamPlayerFactory func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, client app.VoicevoxClient) (app.StreamPlayer, error)
+	QueuePathResolver   func() (string, error)
+}
+
+func makeViewerCmd(deps *ViewerDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "viewer",
+		Short: "HTTPサーバーを起動してブラウザUIで音声配信を行う",
+		Long:  "HTTPサーバーとブラウザUIを起動して音声配信を行う。--watch や --watch-queue でディレクトリを監視できる。",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runViewer(cmd, deps)
+		},
+	}
+
+	registerBaseFlags(cmd)
+	cmd.Flags().StringArray("watch", nil, "監視対象ディレクトリ（複数回指定可）")
+	cmd.Flags().Bool("watch-queue", false, "vox-actor config path.queue で解決される queue ディレクトリを監視対象に追加")
+	cmd.Flags().Bool("delete", false, "処理済みファイルを削除する（未指定時は各ディレクトリの done/ に移動）")
+	cmd.Flags().String("host", "127.0.0.1", "HTTPサーバーのバインドホスト")
+	cmd.Flags().Int("port", 8080, "HTTPサーバーのバインドポート")
+
+	return cmd
+}
+
+func runViewer(cmd *cobra.Command, deps *ViewerDeps) error {
+	host, _ := cmd.Flags().GetString("host")
+	port, _ := cmd.Flags().GetInt("port")
+	watchDirs, _ := cmd.Flags().GetStringArray("watch")
+	watchQueue, _ := cmd.Flags().GetBool("watch-queue")
+	deleteMode, _ := cmd.Flags().GetBool("delete")
+	engineURL, _ := cmd.Flags().GetString("engine-url")
+	speakerID, _ := cmd.Flags().GetInt("speaker")
+	speed, _ := cmd.Flags().GetFloat64("speed")
+	pitch, _ := cmd.Flags().GetFloat64("pitch")
+	intonation, _ := cmd.Flags().GetFloat64("intonation")
+
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("%w: invalid port: %d", ErrUsage, port)
+	}
+
+	dirs, err := resolveViewerPaths(watchDirs, watchQueue, deps)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range dirs {
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			return fmt.Errorf("%w: %v", ErrUsage, statErr)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%w: %s is not a directory", ErrUsage, path)
+		}
+	}
+
+	if deps == nil || deps.ClientFactory == nil || deps.StreamPlayerFactory == nil {
+		return fmt.Errorf("viewer command dependencies are not initialized")
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	logger := buildLoggerFromFlags(cmd)
+	addr := fmt.Sprintf("%s:%d", host, port)
+
+	client := deps.ClientFactory(engineURL)
+	if client == nil {
+		return fmt.Errorf("failed to create VoicevoxClient for %s", engineURL)
+	}
+
+	sp, silent, err := startStreamPlayer(ctx, addr, logger, client, deps.StreamPlayerFactory)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if shutdownErr := sp.Shutdown(shutdownCtx); shutdownErr != nil {
+			logger.Error("stream server shutdown error", "error", shutdownErr)
+		}
+	}()
+	logger.Info("stream server listening", "addr", sp.Addr(), "silent", silent)
+
+	if len(dirs) == 0 {
+		<-ctx.Done()
+		return nil
+	}
+
+	if deps.Reader == nil || deps.Mover == nil || deps.DirWatcherFactory == nil {
+		return fmt.Errorf("viewer command dependencies for watching are not initialized")
+	}
+
+	watcher := deps.DirWatcherFactory(logger)
+	opts := []app.WatchOption{app.WithWatchLogger(logger)}
+	if deleteMode {
+		opts = append(opts, app.WithDeleteMode())
+	}
+	if silent {
+		opts = append(opts, app.WithSilent())
+	}
+
+	uc := app.NewWatchUsecase(deps.Reader, client, sp, deps.Mover, watcher, opts...)
+	return uc.Run(ctx, app.WatchParams{
+		Paths:      dirs,
+		SpeakerID:  speakerID,
+		Speed:      &speed,
+		Pitch:      &pitch,
+		Intonation: &intonation,
+	})
+}
+
+func resolveViewerPaths(watchDirs []string, watchQueue bool, deps *ViewerDeps) ([]string, error) {
+	dirs := append([]string(nil), watchDirs...)
+
+	if watchQueue {
+		var resolver func() (string, error)
+		if deps != nil {
+			resolver = deps.QueuePathResolver
+		}
+		queuePath, err := resolveQueueDir(resolver)
+		if err != nil {
+			return nil, err
+		}
+		dirs = append(dirs, queuePath)
+	}
+
+	return dirs, nil
+}

--- a/cmd/viewer_test.go
+++ b/cmd/viewer_test.go
@@ -1,0 +1,391 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/canpok1/vox-actor/internal/infra"
+	"github.com/spf13/cobra"
+)
+
+func findViewerCmd(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
+	t.Helper()
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "viewer" {
+			return c
+		}
+	}
+	t.Fatal("viewer subcommand not found")
+	return nil
+}
+
+func TestViewerCmd_RegisteredAsSubcommand(t *testing.T) {
+	rootCmd := makeRootCmd()
+
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "viewer" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'viewer' subcommand to be registered")
+	}
+}
+
+func TestViewerCmd_DefaultOptionValues(t *testing.T) {
+	rootCmd := makeRootCmd()
+	viewerCmd := findViewerCmd(t, rootCmd)
+
+	engineURL, _ := viewerCmd.Flags().GetString("engine-url")
+	if engineURL != "http://localhost:50021" {
+		t.Errorf("expected default engine-url 'http://localhost:50021', got: %s", engineURL)
+	}
+	host, _ := viewerCmd.Flags().GetString("host")
+	if host != "127.0.0.1" {
+		t.Errorf("expected default host '127.0.0.1', got: %s", host)
+	}
+	port, _ := viewerCmd.Flags().GetInt("port")
+	if port != 8080 {
+		t.Errorf("expected default port 8080, got: %d", port)
+	}
+	speaker, _ := viewerCmd.Flags().GetInt("speaker")
+	if speaker != 3 {
+		t.Errorf("expected default speaker 3, got: %d", speaker)
+	}
+	speed, _ := viewerCmd.Flags().GetFloat64("speed")
+	if speed != 1.0 {
+		t.Errorf("expected default speed 1.0, got: %f", speed)
+	}
+	pitch, _ := viewerCmd.Flags().GetFloat64("pitch")
+	if pitch != 0.0 {
+		t.Errorf("expected default pitch 0.0, got: %f", pitch)
+	}
+	intonation, _ := viewerCmd.Flags().GetFloat64("intonation")
+	if intonation != 1.0 {
+		t.Errorf("expected default intonation 1.0, got: %f", intonation)
+	}
+	deleteMode, _ := viewerCmd.Flags().GetBool("delete")
+	if deleteMode {
+		t.Error("expected --delete default to be false")
+	}
+	watchQueue, _ := viewerCmd.Flags().GetBool("watch-queue")
+	if watchQueue {
+		t.Error("expected --watch-queue default to be false")
+	}
+	verbose, _ := viewerCmd.Flags().GetBool("verbose")
+	if verbose {
+		t.Error("expected --verbose default to be false")
+	}
+}
+
+func TestViewerCmd_NoDryRunFlag(t *testing.T) {
+	rootCmd := makeRootCmd()
+	viewerCmd := findViewerCmd(t, rootCmd)
+	if viewerCmd.Flags().Lookup("dry-run") != nil {
+		t.Error("viewer should not have --dry-run flag")
+	}
+}
+
+func TestViewerCmd_HelpContainsFlags(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"viewer", "--help"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error for --help, got: %v", err)
+	}
+
+	output := buf.String()
+	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--host", "--port", "--watch", "--watch-queue", "--delete", "--verbose"}
+	for _, flag := range flags {
+		if !strings.Contains(output, flag) {
+			t.Errorf("expected help output to contain '%s'\noutput:\n%s", flag, output)
+		}
+	}
+	if strings.Contains(output, "--dry-run") {
+		t.Error("viewer help should NOT contain '--dry-run'")
+	}
+}
+
+func TestViewerCmd_PortOutOfRange_ReturnsUsageError(t *testing.T) {
+	cases := []struct {
+		name string
+		port string
+	}{
+		{"port 0", "0"},
+		{"port 65536", "65536"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := &Deps{
+				Viewer: &ViewerDeps{
+					ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+					StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+						return &stubStreamPlayer{}, nil
+					},
+				},
+			}
+			rootCmd := makeRootCmd(deps)
+			buf := new(bytes.Buffer)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			rootCmd.SetArgs([]string{"viewer", "--port", tc.port})
+
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error for port %s", tc.port)
+			}
+			if !errors.Is(err, ErrUsage) {
+				t.Errorf("expected ErrUsage for port %s, got: %v", tc.port, err)
+			}
+		})
+	}
+}
+
+func TestViewerCmd_WatchWithFile_ReturnsUsageError(t *testing.T) {
+	dir := t.TempDir()
+	file := dir + "/test.txt"
+	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := &Deps{
+		Viewer: &ViewerDeps{
+			ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+				return &stubStreamPlayer{}, nil
+			},
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"viewer", "--watch", file})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when file path is given to --watch")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func TestViewerCmd_WatchWithNonExistentPath_ReturnsUsageError(t *testing.T) {
+	deps := &Deps{
+		Viewer: &ViewerDeps{
+			ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+				return &stubStreamPlayer{}, nil
+			},
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"viewer", "--watch", "/path/that/does/not/exist"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when non-existent path given to --watch")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func runViewerWithDeps(t *testing.T, deps *Deps, args ...string) error {
+	t.Helper()
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rootCmd.SetContext(ctx)
+	rootCmd.SetArgs(args)
+	return rootCmd.Execute()
+}
+
+func TestViewerCmd_HealthCheckFailure_FallsBackToSilent(t *testing.T) {
+	sp := &stubStreamPlayer{}
+	deps := &Deps{
+		Viewer: &ViewerDeps{
+			Reader:            stubScriptReader{},
+			ClientFactory:     func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{healthCheckErr: errors.New("down")} },
+			Mover:             stubFileMover{},
+			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+				return sp, nil
+			},
+		},
+	}
+
+	logs := captureStderr(t, func() {
+		_ = runViewerWithDeps(t, deps, "viewer")
+	})
+
+	if sp.silentReason == "" {
+		t.Errorf("expected SetSilent called with non-empty reason")
+	}
+	if !strings.Contains(logs, "VOICEVOX engine unreachable") {
+		t.Errorf("expected WARN log 'VOICEVOX engine unreachable', got: %s", logs)
+	}
+}
+
+func TestViewerCmd_GetSpeakersFailure_FallsBackToSilent(t *testing.T) {
+	sp := &stubStreamPlayer{}
+	deps := &Deps{
+		Viewer: &ViewerDeps{
+			Reader: stubScriptReader{},
+			ClientFactory: func(_ string) app.VoicevoxClient {
+				return &stubVoicevoxClient{getSpeakersErr: errors.New("speakers down")}
+			},
+			Mover:             stubFileMover{},
+			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+				return sp, nil
+			},
+		},
+	}
+
+	logs := captureStderr(t, func() {
+		_ = runViewerWithDeps(t, deps, "viewer")
+	})
+
+	if sp.silentReason == "" {
+		t.Errorf("expected SetSilent called with non-empty reason")
+	}
+	if !strings.Contains(logs, "VOICEVOX engine unreachable") {
+		t.Errorf("expected WARN log 'VOICEVOX engine unreachable', got: %s", logs)
+	}
+}
+
+func TestViewerCmd_EngineHealthy_DoesNotEnterSilent(t *testing.T) {
+	sp := &stubStreamPlayer{}
+	deps := &Deps{
+		Viewer: &ViewerDeps{
+			Reader: stubScriptReader{},
+			ClientFactory: func(_ string) app.VoicevoxClient {
+				return &stubVoicevoxClient{
+					speakers: []entity.Speaker{
+						{Name: "ずんだもん", Styles: []entity.SpeakerStyle{{ID: 3, Name: "ノーマル"}}},
+					},
+				}
+			},
+			Mover:             stubFileMover{},
+			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+				return sp, nil
+			},
+		},
+	}
+
+	logs := captureStderr(t, func() {
+		_ = runViewerWithDeps(t, deps, "viewer")
+	})
+
+	if sp.silentReason != "" {
+		t.Errorf("expected SetSilent not called in normal mode, got %q", sp.silentReason)
+	}
+	if strings.Contains(logs, "VOICEVOX engine unreachable") {
+		t.Errorf("expected no WARN log in normal mode, got: %s", logs)
+	}
+}
+
+func TestViewerCmd_WatchQueue_ResolvesAndCreatesQueueDir(t *testing.T) {
+	baseDir := t.TempDir()
+	queueDir := baseDir + "/.vox-actor/queue"
+
+	resolverCalled := 0
+	sp := &stubStreamPlayer{}
+	deps := &Deps{
+		Viewer: &ViewerDeps{
+			Reader:            stubScriptReader{},
+			ClientFactory:     func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+			Mover:             stubFileMover{},
+			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+				return sp, nil
+			},
+			QueuePathResolver: func() (string, error) {
+				resolverCalled++
+				return queueDir, nil
+			},
+		},
+	}
+
+	_ = runViewerWithDeps(t, deps, "viewer", "--watch-queue")
+
+	if resolverCalled != 1 {
+		t.Errorf("expected QueuePathResolver to be called once, got %d", resolverCalled)
+	}
+	info, err := os.Stat(queueDir)
+	if err != nil {
+		t.Fatalf("expected queue directory to be auto-created at %s: %v", queueDir, err)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected %s to be a directory", queueDir)
+	}
+}
+
+func TestViewerCmd_WatchQueue_ResolverReturnsNotInRepo_ReturnsError(t *testing.T) {
+	deps := &Deps{
+		Viewer: &ViewerDeps{
+			ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+				return &stubStreamPlayer{}, nil
+			},
+			QueuePathResolver: func() (string, error) {
+				return "", infra.ErrNotInGitRepo
+			},
+		},
+	}
+
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"viewer", "--watch-queue"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when resolver fails with not-in-git-repo")
+	}
+	if !strings.Contains(err.Error(), "gitリポジトリではありません") {
+		t.Errorf("expected error to contain 'gitリポジトリではありません', got: %v", err)
+	}
+}
+
+func TestViewerCmd_EnvVarVOXEngineURL(t *testing.T) {
+	t.Setenv("VOX_ENGINE_URL", "http://custom:9999")
+	rootCmd := makeRootCmd()
+	viewerCmd := findViewerCmd(t, rootCmd)
+	engineURL, _ := viewerCmd.Flags().GetString("engine-url")
+	if engineURL != "http://custom:9999" {
+		t.Errorf("expected engine-url to be 'http://custom:9999', got: %s", engineURL)
+	}
+}
+
+func TestViewerCmd_EnvVarVOXSpeaker(t *testing.T) {
+	t.Setenv("VOX_SPEAKER", "42")
+	rootCmd := makeRootCmd()
+	viewerCmd := findViewerCmd(t, rootCmd)
+	speaker, _ := viewerCmd.Flags().GetInt("speaker")
+	if speaker != 42 {
+		t.Errorf("expected speaker to be 42, got: %d", speaker)
+	}
+}

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -80,18 +80,80 @@ func resolveWatchPaths(args []string, useQueue bool, deps *WatchDeps) ([]string,
 		return args, nil
 	}
 
-	resolver := infra.ResolveQueuePath
-	if deps != nil && deps.QueuePathResolver != nil {
+	var resolver func() (string, error)
+	if deps != nil {
 		resolver = deps.QueuePathResolver
 	}
-	queuePath, err := resolver()
+	queuePath, err := resolveQueueDir(resolver)
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(queuePath, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create queue directory %s: %w", queuePath, err)
-	}
 	return []string{queuePath}, nil
+}
+
+// startStreamPlayer は HealthCheck → /speakers 取得 → lookup 構築 → StreamPlayer 起動を行う。
+// VOICEVOX への接続失敗時は無音モードにフォールバックして起動を継続する（#284）。
+// 成功した場合、呼び出し元は defer sp.Shutdown を責務とする。
+func startStreamPlayer(
+	ctx context.Context,
+	addr string,
+	logger *slog.Logger,
+	client app.VoicevoxClient,
+	factory func(string, *slog.Logger, map[int]entity.SpeakerStyleInfo, app.VoicevoxClient) (app.StreamPlayer, error),
+) (sp app.StreamPlayer, silent bool, err error) {
+	var (
+		lookup       map[int]entity.SpeakerStyleInfo
+		silentReason string
+	)
+	if hcErr := client.HealthCheck(ctx); hcErr != nil {
+		silent = true
+		silentReason = silentReasonHealthCheckFailed
+		logger.Warn(silentLogMessage, "error", fmt.Errorf("health check failed: %w", hcErr))
+	} else {
+		speakers, gsErr := client.GetSpeakers(ctx)
+		if gsErr != nil {
+			silent = true
+			silentReason = silentReasonGetSpeakersFailed
+			logger.Warn(silentLogMessage, "error", fmt.Errorf("get speakers failed: %w", gsErr))
+		} else {
+			lookup = entity.BuildSpeakerStyleLookup(speakers)
+			logger.Info("speakers loaded", "speakerCount", len(speakers), "styleCount", len(lookup))
+		}
+	}
+	if silent {
+		lookup = map[int]entity.SpeakerStyleInfo{}
+	}
+
+	sp, err = factory(addr, logger, lookup, client)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create stream player: %w", err)
+	}
+	if silent {
+		sp.SetSilent(silentReason)
+	}
+	if err = sp.Start(ctx); err != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = sp.Shutdown(shutdownCtx)
+		return nil, false, fmt.Errorf("failed to start stream server: %w", err)
+	}
+	return sp, silent, nil
+}
+
+// resolveQueueDir はキュー解決関数を使ってキューディレクトリパスを解決・自動作成する。
+// resolver が nil の場合は infra.ResolveQueuePath を使う。
+func resolveQueueDir(resolver func() (string, error)) (string, error) {
+	if resolver == nil {
+		resolver = infra.ResolveQueuePath
+	}
+	queuePath, err := resolver()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(queuePath, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create queue directory %s: %w", queuePath, err)
+	}
+	return queuePath, nil
 }
 
 func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
@@ -147,41 +209,11 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 			return fmt.Errorf("stream player factory is not initialized")
 		}
 
-		// HealthCheck → /speakers 取得 → lookup を組み立ててから stream player を起動する。
-		// どちらかが失敗した場合は無音モードにフォールバックして起動を継続する（#284）。
-		var (
-			lookup       map[int]entity.SpeakerStyleInfo
-			silentReason string
-		)
-		if err := client.HealthCheck(ctx); err != nil {
-			silent = true
-			silentReason = silentReasonHealthCheckFailed
-			logger.Warn(silentLogMessage, "error", fmt.Errorf("health check failed: %w", err))
-		} else {
-			speakers, err := client.GetSpeakers(ctx)
-			if err != nil {
-				silent = true
-				silentReason = silentReasonGetSpeakersFailed
-				logger.Warn(silentLogMessage, "error", fmt.Errorf("get speakers failed: %w", err))
-			} else {
-				lookup = entity.BuildSpeakerStyleLookup(speakers)
-				logger.Info("speakers loaded", "speakerCount", len(speakers), "styleCount", len(lookup))
-			}
-		}
-		if silent {
-			lookup = map[int]entity.SpeakerStyleInfo{}
-		}
-
-		sp, err := deps.StreamPlayerFactory(streamAddr, logger, lookup, client)
+		sp, isSilent, err := startStreamPlayer(ctx, streamAddr, logger, client, deps.StreamPlayerFactory)
 		if err != nil {
-			return fmt.Errorf("failed to create stream player: %w", err)
+			return err
 		}
-		if silent {
-			sp.SetSilent(silentReason)
-		}
-		if err := sp.Start(ctx); err != nil {
-			return fmt.Errorf("failed to start stream server: %w", err)
-		}
+		silent = isSilent
 		defer func() {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -175,6 +175,64 @@ vox-actor watch --queue --delete
 vox-actor watch --queue --stream
 ```
 
+## `viewer` サブコマンド
+
+```
+vox-actor viewer [--watch <dir>]... [--watch-queue] [--delete] \
+                 [--host <host>] [--port <port>] \
+                 [--engine-url <url>] [--speaker <id>] \
+                 [--speed N] [--pitch N] [--intonation N] [--verbose]
+```
+
+HTTPサーバーとブラウザUIを起動し、SSE経由でブラウザに音声を配信する。ブラウザ配信専用のサブコマンドで、`--watch` や `--watch-queue` でディレクトリを監視しながら配信できる。
+
+| オプション | 環境変数 | デフォルト値 | 説明 |
+|---|---|---|---|
+| `--watch <dir>` | — | （未指定可・複数可） | 監視対象ディレクトリ（`--watch dir1 --watch dir2` のように複数回指定） |
+| `--watch-queue` | — | `false` | `vox-actor config path.queue` で解決される queue ディレクトリを監視対象に追加 |
+| `--delete` | — | `false` | 処理済みファイルを削除（未指定時は各ディレクトリの `done/` に移動） |
+| `--host` | — | `127.0.0.1` | HTTPサーバーのバインドホスト |
+| `--port` | — | `8080` | HTTPサーバーのバインドポート（1〜65535） |
+| `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
+| `--speaker` | `VOX_SPEAKER` | `3` | 既定話者ID |
+| `--speed` | — | `1.0` | 話速 |
+| `--pitch` | — | `0.0` | 音高 |
+| `--intonation` | — | `1.0` | 抑揚 |
+| `--verbose` | — | `false` | 詳細ログを出力 |
+
+### 起動パターン
+
+```bash
+# 監視なし（HTTP+UIのみ）。「音声テスト」タブだけが機能する
+vox-actor viewer
+
+# ディレクトリを監視しながら配信
+vox-actor viewer --watch /path/to/dir
+
+# 複数ディレクトリを並列監視
+vox-actor viewer --watch /path/to/dir1 --watch /path/to/dir2
+
+# queue ディレクトリを監視
+vox-actor viewer --watch-queue
+
+# --watch と --watch-queue の併用
+vox-actor viewer --watch /extra/dir --watch-queue
+
+# バインドアドレスを変更（LAN公開）
+vox-actor viewer --host 0.0.0.0 --port 8080
+```
+
+### エラー条件
+
+| 状況 | 終了コード | エラー出力 |
+|---|---|---|
+| `--watch` のパスがディレクトリ以外 | 2 (`ErrUsage`) | `Error: <path> is not a directory` |
+| `--watch-queue` 指定時に git管理外かつ `VOX_ACTOR_WORKSPACE` 未設定 | 2 (`ErrUsage`) | `Error: gitコマンドが見つかりません` 等 |
+| `--port` が 1〜65535 範囲外 | 2 (`ErrUsage`) | `Error: invalid port: <n>` |
+| HTTPサーバー起動失敗（ポート占有等） | 1 | `Error: failed to start stream server: ...` |
+
+ブラウザUI・SSE・`/api/status`・無音モードの挙動は[ストリーム配信モード](#ストリーム配信モード)と同一です。
+
 ## `config` サブコマンド
 
 ```
@@ -322,17 +380,25 @@ fi
 
 ## ストリーム配信モード
 
-`watch --stream` を付けると、ローカルスピーカー再生の代わりにHTTPサーバーを起動し、SSE経由でブラウザに音声を配信します。音声デバイスが利用できない環境でホスト側のブラウザに再生させるケースで利用できます。
+HTTPサーバーを起動し、SSE経由でブラウザに音声を配信します。音声デバイスが利用できない環境でホスト側のブラウザに再生させるケースで利用できます。
+
+推奨は [`viewer` サブコマンド](#viewer-サブコマンド)を使う方法です。`watch --stream`（後方互換）も引き続き動作します。
 
 ```bash
-# デフォルト（127.0.0.1:8080 にバインド）
+# viewer（推奨）
+vox-actor viewer --watch /path/to/watch-dir
+
+# viewer でバインドアドレスを変更
+vox-actor viewer --host 0.0.0.0 --port 8080 --watch /path/to/watch-dir
+
+# watch --stream（後方互換）
 vox-actor watch --stream /path/to/watch-dir
 
-# バインドアドレスを変更
+# watch --stream でバインドアドレスを変更（後方互換）
 vox-actor watch --stream --stream-addr 0.0.0.0:8080 /path/to/watch-dir
 ```
 
-- `http://<stream-addr>/` をブラウザで開き、音量スライダーを操作すると再生が解禁されます（ブラウザの自動再生ポリシー対策）。
+- `http://<host>:<port>/` をブラウザで開き、音量スライダーを操作すると再生が解禁されます（ブラウザの自動再生ポリシー対策）。
 - 画面上部のタブで「配信」「音声テスト」を切り替えます。タブ切替時は再生中の音声が即停止し、再生キューも破棄されます。選択中のタブは localStorage に保存されてリロード後も復元されます（初期タブは「配信」）。
 - 「配信」タブはチャット風のタイムラインで、古いセリフが上、新しいセリフが下に並びます。再生中のセリフは背景色と `▶` アイコンで強調され、再生開始時に自動でスクロールして画面内に表示されます。
 - 各タイムライン項目はメタ行（時刻 / 話者名 / `[スタイル名]`）と本文の 2 段構成です。`☑話者名` `☑スタイル` `☑時刻` のチェックボックスで個別に表示/非表示を切り替えでき、状態は localStorage に保存されてリロード後も復元されます。
@@ -349,9 +415,9 @@ vox-actor watch --stream --stream-addr 0.0.0.0:8080 /path/to/watch-dir
 
 ### 無音モード（VOICEVOX 未起動時の自動フォールバック）
 
-`watch --stream` 起動時に VOICEVOX エンジンへの `HealthCheck` または `/speakers` 取得が失敗した場合、エラー終了せず**無音モード**で起動を継続します。VOICEVOX を立ち上げずに `watch --stream` でテキストだけをブラウザで読みたいときに有効です。
+`viewer` または `watch --stream` 起動時に VOICEVOX エンジンへの `HealthCheck` または `/speakers` 取得が失敗した場合、エラー終了せず**無音モード**で起動を継続します。VOICEVOX を立ち上げずにテキストだけをブラウザで読みたいときに有効です。
 
-- 判定は **watch 起動時のみ** 行われます。起動後にエンジンが切断されても無音モードへは切り替わりません（リカバリ対象外）。
+- 判定は **起動時のみ** 行われます。起動後にエンジンが切断されても無音モードへは切り替わりません（リカバリ対象外）。
 - フォールバック発動時、標準エラー出力に WARN ログ `VOICEVOX engine unreachable, continuing in silent mode (no audio will be played)` が1回出力されます。`error` 属性で `HealthCheck` 失敗か `GetSpeakers` 失敗かを識別できます。
 - 無音モード時は通常モードと比べて次のような挙動になります:
   - WAV の合成・配信は行われず、`clipEvent.url` は空文字で配信されます。`/clips/{id}.wav` へのリクエストは 404 を返します。
@@ -361,7 +427,7 @@ vox-actor watch --stream --stream-addr 0.0.0.0:8080 /path/to/watch-dir
   - ヘッダーの SSE 接続バッジの右隣に `🔇 無音モード` バッジが表示され、ホバーまたはタップで無音モードに入った理由と対処法（VOICEVOX を起動した状態で `watch --stream` を起動し直すなど）をツールチップで確認できます。
 - サーバーの現在の状態は `GET /api/status` で取得できます。無音フラグ・理由文面・話者一覧をまとめて返す単一エンドポイントで、既存の `/speakers.json` は廃止されています。
 - ディレクトリ監視・`done/` への移動／削除は無音モードでも通常通り実施されます。
-- 非ストリームの `watch` / `say` / `act` では従来通り `HealthCheck` 失敗時に即エラー終了します（本フォールバックは `watch --stream` のみ）。
+- 非ストリームの `watch` / `say` / `act` では従来通り `HealthCheck` 失敗時に即エラー終了します（本フォールバックは `viewer` / `watch --stream` のみ）。
 
 ## dry-runモード
 

--- a/main.go
+++ b/main.go
@@ -33,6 +33,18 @@ func main() {
 	reader := infra.NewFileReader()
 	mover := infra.NewFileMover()
 
+	streamPlayerFactory := func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, client app.VoicevoxClient) (app.StreamPlayer, error) {
+		staticFS, err := streamAssetsFS()
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve stream assets: %w", err)
+		}
+		return infra.NewHTTPStreamPlayer(addr, staticFS,
+			infra.WithHTTPStreamLogger(logger),
+			infra.WithSpeakerLookup(speakerLookup),
+			infra.WithVoicevoxClient(client),
+		)
+	}
+
 	deps := &cmd.Deps{
 		Act: &cmd.ActDeps{
 			Reader:            reader,
@@ -42,22 +54,19 @@ func main() {
 			DirWatcherFactory: dirWatcherFactory,
 		},
 		Watch: &cmd.WatchDeps{
-			Reader:            reader,
-			ClientFactory:     clientFactory,
-			Player:            player,
-			Mover:             mover,
-			DirWatcherFactory: dirWatcherFactory,
-			StreamPlayerFactory: func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, client app.VoicevoxClient) (app.StreamPlayer, error) {
-				staticFS, err := streamAssetsFS()
-				if err != nil {
-					return nil, fmt.Errorf("failed to resolve stream assets: %w", err)
-				}
-				return infra.NewHTTPStreamPlayer(addr, staticFS,
-					infra.WithHTTPStreamLogger(logger),
-					infra.WithSpeakerLookup(speakerLookup),
-					infra.WithVoicevoxClient(client),
-				)
-			},
+			Reader:              reader,
+			ClientFactory:       clientFactory,
+			Player:              player,
+			Mover:               mover,
+			DirWatcherFactory:   dirWatcherFactory,
+			StreamPlayerFactory: streamPlayerFactory,
+		},
+		Viewer: &cmd.ViewerDeps{
+			Reader:              reader,
+			ClientFactory:       clientFactory,
+			Mover:               mover,
+			DirWatcherFactory:   dirWatcherFactory,
+			StreamPlayerFactory: streamPlayerFactory,
 		},
 		Say: &cmd.SayDeps{
 			ClientFactory: clientFactory,

--- a/test/e2e/viewer_test.go
+++ b/test/e2e/viewer_test.go
@@ -135,11 +135,14 @@ func freePort(t *testing.T) int {
 }
 
 // extractAddrFromLog は "stream server listening" ログ行からアドレスを抽出する。
-// ログ形式: INFO stream server listening addr=127.0.0.1:8080 silent=...
+// HumanHandler の形式: "... stream server listening (addr=127.0.0.1:8080, silent=...)"
 func extractAddrFromLog(line string) string {
 	for _, field := range strings.Fields(line) {
-		if strings.HasPrefix(field, "addr=") {
-			return strings.TrimPrefix(field, "addr=")
+		f := strings.TrimPrefix(field, "(")
+		f = strings.TrimSuffix(f, ")")
+		f = strings.TrimSuffix(f, ",")
+		if strings.HasPrefix(f, "addr=") {
+			return strings.TrimPrefix(f, "addr=")
 		}
 	}
 	return ""

--- a/test/e2e/viewer_test.go
+++ b/test/e2e/viewer_test.go
@@ -1,0 +1,271 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type viewerProcess struct {
+	t        *testing.T
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+	stderr   *lineAccumulator
+	done     chan struct{}
+	waitErr  error
+	stopOnce sync.Once
+}
+
+// startViewer はビルド済み vox-actor を別プロセスで起動し、viewer サブコマンドを実行する。
+func startViewer(t *testing.T, env map[string]string, args ...string) *viewerProcess {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	fullArgs := append([]string{"viewer"}, args...)
+	cmd := exec.CommandContext(ctx, binaryPath, fullArgs...)
+	if len(env) > 0 {
+		base := os.Environ()
+		for k, v := range env {
+			base = append(base, k+"="+v)
+		}
+		cmd.Env = base
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("failed to start viewer: %v", err)
+	}
+
+	acc := &lineAccumulator{}
+	go readLinesInto(stderrPipe, acc)
+
+	vp := &viewerProcess{
+		t:      t,
+		cmd:    cmd,
+		cancel: cancel,
+		stderr: acc,
+		done:   make(chan struct{}),
+	}
+	go func() {
+		vp.waitErr = cmd.Wait()
+		close(vp.done)
+	}()
+
+	t.Cleanup(func() {
+		vp.stop(3 * time.Second)
+	})
+
+	return vp
+}
+
+func (v *viewerProcess) waitForStderr(needle string, timeout time.Duration) string {
+	v.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		for _, line := range v.stderr.snapshot() {
+			if strings.Contains(line, needle) {
+				return line
+			}
+		}
+		select {
+		case <-v.done:
+			v.t.Fatalf("viewer exited before %q appeared: err=%v\nstderr:\n%s",
+				needle, v.waitErr, v.stderr.String())
+		default:
+		}
+		if time.Now().After(deadline) {
+			v.t.Fatalf("timed out after %s waiting for stderr to contain %q\nstderr:\n%s",
+				timeout, needle, v.stderr.String())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func (v *viewerProcess) stop(timeout time.Duration) (exitCode int, err error) {
+	v.stopOnce.Do(func() {
+		_ = v.cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case <-v.done:
+		case <-time.After(timeout):
+			_ = v.cmd.Process.Kill()
+			<-v.done
+		}
+		v.cancel()
+	})
+	return exitCodeFromErr(v.waitErr), v.waitErr
+}
+
+func (v *viewerProcess) assertCleanExit(timeout time.Duration) {
+	v.t.Helper()
+	exitCode, _ := v.stop(timeout)
+	if exitCode != 0 {
+		v.t.Fatalf("expected clean exit (0), got %d\nstderr:\n%s",
+			exitCode, v.stderr.String())
+	}
+}
+
+// freePort は使用可能なTCPポート番号を返す。
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+// extractAddrFromLog は "stream server listening" ログ行からアドレスを抽出する。
+// ログ形式: INFO stream server listening addr=127.0.0.1:8080 silent=...
+func extractAddrFromLog(line string) string {
+	for _, field := range strings.Fields(line) {
+		if strings.HasPrefix(field, "addr=") {
+			return strings.TrimPrefix(field, "addr=")
+		}
+	}
+	return ""
+}
+
+func TestViewerE2E_StatusEndpoint(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	vp := startViewer(t, nil, "--port", fmt.Sprintf("%d", port))
+
+	line := vp.waitForStderr("stream server listening", 10*time.Second)
+	addr := extractAddrFromLog(line)
+	if addr == "" {
+		t.Fatalf("failed to extract addr from log line: %q", line)
+	}
+
+	url := fmt.Sprintf("http://%s/api/status", addr)
+	var resp *http.Response
+	var err error
+	for i := 0; i < 20; i++ {
+		resp, err = http.Get(url) //nolint:noctx
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("failed to GET /api/status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("expected valid JSON response, got: %s", body)
+	}
+	if _, ok := result["silent"]; !ok {
+		t.Errorf("expected 'silent' field in /api/status response, got: %s", body)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_WithWatchDir_WatchesDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	port := freePort(t)
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{"VOX_ACTOR_WORKSPACE": workspace},
+		"--port", fmt.Sprintf("%d", port),
+		"--watch", dir,
+	)
+
+	vp.waitForStderr("watching directory", 10*time.Second)
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_WatchQueue_StartsWatching(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	port := freePort(t)
+
+	vp := startViewer(t,
+		map[string]string{"VOX_ACTOR_WORKSPACE": workspace},
+		"--port", fmt.Sprintf("%d", port),
+		"--watch-queue",
+	)
+
+	vp.waitForStderr("watching directory", 10*time.Second)
+
+	// ResolveQueuePath: VOX_ACTOR_WORKSPACE/queue
+	queueDir := workspace + "/queue"
+	info, err := os.Stat(queueDir)
+	if err != nil {
+		t.Fatalf("expected queue dir to be auto-created at %s: %v", queueDir, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %s to be a directory", queueDir)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_InvalidPort_ReturnsUsageError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		port string
+	}{
+		{"port 0", "0"},
+		{"port 99999", "99999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, stderr, exitCode := runCLI(t, nil, "viewer", "--port", tc.port)
+			if exitCode != 2 {
+				t.Fatalf("expected exit code 2 (usage error) for port %s, got %d\nstderr:\n%s",
+					tc.port, exitCode, stderr)
+			}
+			if strings.TrimSpace(stderr) == "" {
+				t.Error("expected non-empty stderr for usage error")
+			}
+		})
+	}
+}
+
+func TestViewerE2E_WatchNonDirectory_ReturnsUsageError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	file := writeTempFile(t, dir, "notadir.txt", "hello")
+
+	_, stderr, exitCode := runCLI(t, nil, "viewer", "--watch", file)
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2 for non-directory --watch, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}


### PR DESCRIPTION
## Summary

- `viewer` サブコマンドを新規追加（HTTPサーバー+ブラウザUI、`--watch`/`--watch-queue`/`--host`/`--port` 等のフラグ対応）
- `watch --stream` の内部ロジック（HealthCheck → speakers 取得 → StreamPlayer 起動）を `startStreamPlayer` として抽出し `viewer` と共有
- キュー解決ロジックを `resolveQueueDir` として抽出（watch/viewer 両方で使用）
- `registerBaseFlags`（dry-run なし）を追加し viewer が使用
- `watch --stream` は後方互換として動作継続（Deprecated なし）

## Test plan

- [x] `go test ./cmd/...` — ユニットテスト全通過（11件の新規テスト含む）
- [x] `go build -tags e2e ./test/e2e/...` — e2e テストビルド成功
- [x] `gofmt -l .` — 差分なし
- [x] `golangci-lint run ./...` — 0 issues
- [ ] e2e テスト: `go test -tags e2e -v ./test/e2e/ -run TestViewer` で手動検証（CI で確認）
- [ ] 後方互換確認: `vox-actor watch --stream` が動作すること（CI で確認）

Closes #320

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
