### PR TITLE
refactor: watch コマンドから --stream / --stream-addr フラグを削除する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,9 @@ dev-frontend: frontend/node_modules
 
 # VOICEVOX エンジン URL は CLI 既定値（http://localhost:50021）または環境変数 VOX_ENGINE_URL に従う。
 # dev container 等で voicevox:50021 を使う場合は `VOX_ENGINE_URL=http://voicevox:50021 make dev-backend` のように指定する。
+# viewer サブコマンドで HTTP サーバーを起動し、0.0.0.0:8080 でリッスンする。
 dev-backend:
-	go run . watch --engine-url http://voicevox:50021 --stream --stream-addr 0.0.0.0:8080 --queue
+	go run . viewer --engine-url http://voicevox:50021 --host 0.0.0.0 --port 8080 --watch-queue
 
 dev:
 	$(MAKE) -j2 dev-backend dev-frontend
@@ -72,4 +73,4 @@ install: build-frontend
 
 all: build
 
-.PHONY: all setup build build-frontend clean test test-e2e test-frontend-unit test-frontend-e2e fmt lint lint-frontend typecheck depcheck run-stream dev dev-frontend dev-backend install
+.PHONY: all setup build build-frontend clean test test-e2e test-frontend-unit test-frontend-e2e fmt lint lint-frontend typecheck depcheck dev dev-frontend dev-backend install

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ export VOX_ACTOR_MONOLOGUE_MODE=file
 
 詳細なセットアップ手順は [プラグイン／スキルリファレンス](./docs/reference/plugins.md) を参照してください。
 
-ホスト側にも音声デバイスがない場合は `vox-actor watch --stream` でブラウザに音声を配信する構成も利用できます。詳細は [CLIリファレンスのストリーム配信モード](./docs/reference/cli.md#ストリーム配信モード) を参照してください。
+ホスト側にも音声デバイスがない場合は `vox-actor viewer` でブラウザに音声を配信する構成も利用できます。詳細は [CLIリファレンスのストリーム配信モード](./docs/reference/cli.md#ストリーム配信モード) を参照してください。
 
 ## 📦 インストール方法
 

--- a/cmd/viewer.go
+++ b/cmd/viewer.go
@@ -14,6 +14,67 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// 無音モード通知用の固定文面（#284）。
+// silentLogMessage は WARN ログ、silentReason* はフロントに返す `silentReason` 本文。
+const (
+	silentLogMessage = "VOICEVOX engine unreachable, continuing in silent mode (no audio will be played)"
+
+	silentReasonHealthCheckFailed = `VOICEVOXに接続できないため無音モードで起動しました。
+音を再生したい場合はVOICEVOXに接続できる状態で起動し直してください。`
+
+	silentReasonGetSpeakersFailed = `VOICEVOXから話者一覧を取得できなかったため無音モードで起動しました。
+音を再生したい場合はVOICEVOXを正常に応答する状態にして起動し直してください。`
+)
+
+// startStreamPlayer は HealthCheck → /speakers 取得 → lookup 構築 → StreamPlayer 起動を行う。
+// VOICEVOX への接続失敗時は無音モードにフォールバックして起動を継続する（#284）。
+// 成功した場合、呼び出し元は defer sp.Shutdown を責務とする。
+func startStreamPlayer(
+	ctx context.Context,
+	addr string,
+	logger *slog.Logger,
+	client app.VoicevoxClient,
+	factory func(string, *slog.Logger, map[int]entity.SpeakerStyleInfo, app.VoicevoxClient) (app.StreamPlayer, error),
+) (sp app.StreamPlayer, silent bool, err error) {
+	var (
+		lookup       map[int]entity.SpeakerStyleInfo
+		silentReason string
+	)
+	if hcErr := client.HealthCheck(ctx); hcErr != nil {
+		silent = true
+		silentReason = silentReasonHealthCheckFailed
+		logger.Warn(silentLogMessage, "error", fmt.Errorf("health check failed: %w", hcErr))
+	} else {
+		speakers, gsErr := client.GetSpeakers(ctx)
+		if gsErr != nil {
+			silent = true
+			silentReason = silentReasonGetSpeakersFailed
+			logger.Warn(silentLogMessage, "error", fmt.Errorf("get speakers failed: %w", gsErr))
+		} else {
+			lookup = entity.BuildSpeakerStyleLookup(speakers)
+			logger.Info("speakers loaded", "speakerCount", len(speakers), "styleCount", len(lookup))
+		}
+	}
+	if silent {
+		lookup = map[int]entity.SpeakerStyleInfo{}
+	}
+
+	sp, err = factory(addr, logger, lookup, client)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create stream player: %w", err)
+	}
+	if silent {
+		sp.SetSilent(silentReason)
+	}
+	if err = sp.Start(ctx); err != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = sp.Shutdown(shutdownCtx)
+		return nil, false, fmt.Errorf("failed to start stream server: %w", err)
+	}
+	return sp, silent, nil
+}
+
 // ViewerDeps はviewerコマンドの依存を保持する。
 type ViewerDeps struct {
 	Reader              app.ScriptReader

--- a/cmd/viewer_test.go
+++ b/cmd/viewer_test.go
@@ -15,6 +15,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type stubStreamPlayer struct {
+	silentReason string
+}
+
+func (p *stubStreamPlayer) Start(_ context.Context) error                          { return nil }
+func (p *stubStreamPlayer) Shutdown(_ context.Context) error                       { return nil }
+func (p *stubStreamPlayer) Addr() string                                           { return "127.0.0.1:0" }
+func (p *stubStreamPlayer) Play(_ context.Context, _ []byte, _ app.PlayMeta) error { return nil }
+func (p *stubStreamPlayer) SetSilent(reason string)                                { p.silentReason = reason }
+func (p *stubStreamPlayer) PlayText(_ context.Context, _ app.PlayMeta) error       { return nil }
+
+// captureStderr は関数実行中の os.Stderr への出力を文字列として収集する。
+// buildLoggerFromFlags が os.Stderr に書くため、WARN ログの検証に使う。
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan string, 1)
+	go func() {
+		var out bytes.Buffer
+		_, _ = out.ReadFrom(r)
+		done <- out.String()
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stderr = orig
+	return <-done
+}
+
 func findViewerCmd(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
 	t.Helper()
 	for _, c := range rootCmd.Commands() {

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,30 +1,15 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/canpok1/vox-actor/internal/app"
-	"github.com/canpok1/vox-actor/internal/domain/entity"
 	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
-)
-
-// 無音モード通知用の固定文面（#284）。
-// silentLogMessage は WARN ログ、silentReason* はフロントに返す `silentReason` 本文。
-const (
-	silentLogMessage = "VOICEVOX engine unreachable, continuing in silent mode (no audio will be played)"
-
-	silentReasonHealthCheckFailed = `VOICEVOXに接続できないため無音モードで起動しました。
-音を再生したい場合はVOICEVOXに接続できる状態で起動し直してください。`
-
-	silentReasonGetSpeakersFailed = `VOICEVOXから話者一覧を取得できなかったため無音モードで起動しました。
-音を再生したい場合はVOICEVOXを正常に応答する状態にして起動し直してください。`
 )
 
 // WatchDeps はwatchコマンドの依存を保持する。
@@ -34,11 +19,6 @@ type WatchDeps struct {
 	Player            app.AudioPlayer
 	Mover             app.FileMover
 	DirWatcherFactory func(logger *slog.Logger) app.DirWatcher
-	// StreamPlayerFactory は --stream 指定時にストリーム配信用の AudioPlayer を生成する。
-	// speakerLookup は /speakers 取得結果から構築されたマップで、配信時に話者名/スタイル名を解決する。
-	// マップが空でも factory はエラーにせず player を返してよい（フォールバック表示が使われる）。
-	// client はブラウザ側の /test-clip エンドポイントから音声合成を呼ぶために渡す。
-	StreamPlayerFactory func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, client app.VoicevoxClient) (app.StreamPlayer, error)
 	// QueuePathResolver は --queue 指定時に監視対象パスを解決する関数。
 	// nil の場合は infra.ResolveQueuePath がデフォルトで使われる。
 	QueuePathResolver func() (string, error)
@@ -51,6 +31,15 @@ func makeWatchCmd(deps *WatchDeps) *cobra.Command {
 		Long:  "1つ以上のディレクトリを並列監視し、検知したファイルを順次読み上げる。",
 		// 位置引数と --queue の排他・片方必須は RunE 側で検証する。
 		Args: cobra.ArbitraryArgs,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if cmd.Flags().Changed("stream") {
+				return fmt.Errorf("%w: --stream is removed; use 'vox-actor viewer' instead", ErrUsage)
+			}
+			if cmd.Flags().Changed("stream-addr") {
+				return fmt.Errorf("%w: --stream-addr is removed; use 'vox-actor viewer --host <host> --port <port>' instead", ErrUsage)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runWatch(cmd, args, deps)
 		},
@@ -58,9 +47,13 @@ func makeWatchCmd(deps *WatchDeps) *cobra.Command {
 
 	registerCommonFlags(cmd)
 	cmd.Flags().Bool("delete", false, "処理済みファイルを削除する（未指定時は各ディレクトリの done/ に移動）")
-	cmd.Flags().Bool("stream", false, "HTTPサーバーを起動し、SSE経由でブラウザに音声配信する")
-	cmd.Flags().String("stream-addr", "127.0.0.1:8080", "ストリーム配信用のバインドアドレス")
 	cmd.Flags().Bool("queue", false, "vox-actor config path.queue で解決される queue ディレクトリを監視対象に自動選択する（位置引数と併用不可、起動時に自動作成）")
+
+	// --stream / --stream-addr は廃止済み。廃止フラグが渡された場合は PreRunE でエラーを返す。
+	cmd.Flags().Bool("stream", false, "")
+	cmd.Flags().String("stream-addr", "", "")
+	_ = cmd.Flags().MarkHidden("stream")
+	_ = cmd.Flags().MarkHidden("stream-addr")
 
 	return cmd
 }
@@ -89,55 +82,6 @@ func resolveWatchPaths(args []string, useQueue bool, deps *WatchDeps) ([]string,
 		return nil, err
 	}
 	return []string{queuePath}, nil
-}
-
-// startStreamPlayer は HealthCheck → /speakers 取得 → lookup 構築 → StreamPlayer 起動を行う。
-// VOICEVOX への接続失敗時は無音モードにフォールバックして起動を継続する（#284）。
-// 成功した場合、呼び出し元は defer sp.Shutdown を責務とする。
-func startStreamPlayer(
-	ctx context.Context,
-	addr string,
-	logger *slog.Logger,
-	client app.VoicevoxClient,
-	factory func(string, *slog.Logger, map[int]entity.SpeakerStyleInfo, app.VoicevoxClient) (app.StreamPlayer, error),
-) (sp app.StreamPlayer, silent bool, err error) {
-	var (
-		lookup       map[int]entity.SpeakerStyleInfo
-		silentReason string
-	)
-	if hcErr := client.HealthCheck(ctx); hcErr != nil {
-		silent = true
-		silentReason = silentReasonHealthCheckFailed
-		logger.Warn(silentLogMessage, "error", fmt.Errorf("health check failed: %w", hcErr))
-	} else {
-		speakers, gsErr := client.GetSpeakers(ctx)
-		if gsErr != nil {
-			silent = true
-			silentReason = silentReasonGetSpeakersFailed
-			logger.Warn(silentLogMessage, "error", fmt.Errorf("get speakers failed: %w", gsErr))
-		} else {
-			lookup = entity.BuildSpeakerStyleLookup(speakers)
-			logger.Info("speakers loaded", "speakerCount", len(speakers), "styleCount", len(lookup))
-		}
-	}
-	if silent {
-		lookup = map[int]entity.SpeakerStyleInfo{}
-	}
-
-	sp, err = factory(addr, logger, lookup, client)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to create stream player: %w", err)
-	}
-	if silent {
-		sp.SetSilent(silentReason)
-	}
-	if err = sp.Start(ctx); err != nil {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = sp.Shutdown(shutdownCtx)
-		return nil, false, fmt.Errorf("failed to start stream server: %w", err)
-	}
-	return sp, silent, nil
 }
 
 // resolveQueueDir はキュー解決関数を使ってキューディレクトリパスを解決・自動作成する。
@@ -181,12 +125,6 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	stream, _ := cmd.Flags().GetBool("stream")
-	streamAddr, _ := cmd.Flags().GetString("stream-addr")
-
-	if stream && dryRun {
-		return fmt.Errorf("%w: --stream and --dry-run cannot be used together", ErrUsage)
-	}
 
 	if deps == nil || deps.ClientFactory == nil || deps.Reader == nil || deps.Player == nil || deps.Mover == nil || deps.DirWatcherFactory == nil {
 		return fmt.Errorf("watch command dependencies are not initialized")
@@ -202,39 +140,13 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 		return fmt.Errorf("failed to create VoicevoxClient for %s", engineURL)
 	}
 
-	player := deps.Player
-	silent := false
-	if stream {
-		if deps.StreamPlayerFactory == nil {
-			return fmt.Errorf("stream player factory is not initialized")
-		}
-
-		sp, isSilent, err := startStreamPlayer(ctx, streamAddr, logger, client, deps.StreamPlayerFactory)
-		if err != nil {
-			return err
-		}
-		silent = isSilent
-		defer func() {
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err := sp.Shutdown(shutdownCtx); err != nil {
-				logger.Error("stream server shutdown error", "error", err)
-			}
-		}()
-		logger.Info("stream server listening", "addr", sp.Addr(), "silent", silent)
-		player = sp
-	}
-
 	watcher := deps.DirWatcherFactory(logger)
 	opts := []app.WatchOption{app.WithWatchLogger(logger)}
 	if deleteMode {
 		opts = append(opts, app.WithDeleteMode())
 	}
-	if silent {
-		opts = append(opts, app.WithSilent())
-	}
 
-	uc := app.NewWatchUsecase(deps.Reader, client, player, deps.Mover, watcher, opts...)
+	uc := app.NewWatchUsecase(deps.Reader, client, deps.Player, deps.Mover, watcher, opts...)
 	return uc.Run(ctx, app.WatchParams{
 		Paths:      args,
 		SpeakerID:  speakerID,

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -75,16 +74,6 @@ func TestWatchCmd_DefaultOptionValues(t *testing.T) {
 	deleteMode, _ := watchCmd.Flags().GetBool("delete")
 	if deleteMode {
 		t.Error("expected --delete default to be false")
-	}
-
-	stream, _ := watchCmd.Flags().GetBool("stream")
-	if stream {
-		t.Error("expected --stream default to be false")
-	}
-
-	streamAddr, _ := watchCmd.Flags().GetString("stream-addr")
-	if streamAddr != "127.0.0.1:8080" {
-		t.Errorf("expected default stream-addr '127.0.0.1:8080', got: %s", streamAddr)
 	}
 
 	verbose, _ := watchCmd.Flags().GetBool("verbose")
@@ -177,11 +166,16 @@ func TestWatchCmd_HelpContainsFlags(t *testing.T) {
 	}
 
 	output := buf.String()
-	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--delete", "--stream", "--stream-addr", "--verbose", "--dry-run"}
+	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--delete", "--verbose", "--dry-run"}
 	for _, flag := range flags {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected help output to contain '%s'", flag)
 		}
+	}
+
+	// --stream / --stream-addr は廃止済みのため help に表示されない
+	if strings.Contains(output, "--stream") {
+		t.Error("expected help output NOT to contain '--stream'")
 	}
 
 	// --stream-history-size は #226 で廃止された
@@ -190,25 +184,47 @@ func TestWatchCmd_HelpContainsFlags(t *testing.T) {
 	}
 }
 
-func TestWatchCmd_StreamAndDryRun_ReturnsUsageError(t *testing.T) {
+func TestWatchCmd_StreamFlagRemoved_ReturnsUsageError(t *testing.T) {
 	dir := t.TempDir()
 
 	rootCmd := makeRootCmd()
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"watch", "--stream", "--dry-run", dir})
+	rootCmd.SetArgs([]string{"watch", "--stream", dir})
 
 	err := rootCmd.Execute()
 	if err == nil {
-		t.Fatal("expected error when --stream and --dry-run are combined")
+		t.Fatal("expected error when --stream is used")
 	}
 	if !errors.Is(err, ErrUsage) {
 		t.Errorf("expected ErrUsage, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "viewer") {
+		t.Errorf("expected error to mention 'viewer', got: %v", err)
+	}
 }
 
-// --- #228 /speakers 取得 ---
+func TestWatchCmd_StreamAddrFlagRemoved_ReturnsUsageError(t *testing.T) {
+	dir := t.TempDir()
+
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"watch", "--stream-addr", "0.0.0.0:9090", dir})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --stream-addr is used")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "viewer") {
+		t.Errorf("expected error to mention 'viewer', got: %v", err)
+	}
+}
 
 // stubVoicevoxClient は GetSpeakers/HealthCheck の振る舞いをカスタマイズできるテスト用クライアント。
 type stubVoicevoxClient struct {
@@ -255,249 +271,6 @@ func (stubDirWatcher) Watch(ctx context.Context, _ string) (<-chan string, <-cha
 type stubAudioPlayer struct{}
 
 func (stubAudioPlayer) Play(_ context.Context, _ []byte, _ app.PlayMeta) error { return nil }
-
-type stubStreamPlayer struct {
-	silentReason string
-	playTextCall int
-}
-
-func (p *stubStreamPlayer) Start(_ context.Context) error                          { return nil }
-func (p *stubStreamPlayer) Shutdown(_ context.Context) error                       { return nil }
-func (p *stubStreamPlayer) Addr() string                                           { return "127.0.0.1:0" }
-func (p *stubStreamPlayer) Play(_ context.Context, _ []byte, _ app.PlayMeta) error { return nil }
-func (p *stubStreamPlayer) SetSilent(reason string)                                { p.silentReason = reason }
-func (p *stubStreamPlayer) PlayText(_ context.Context, _ app.PlayMeta) error {
-	p.playTextCall++
-	return nil
-}
-
-// captureStderr は関数実行中の os.Stderr への出力を文字列として収集する。
-// buildLoggerFromFlags が os.Stderr に書くため、WARN ログの検証に使う。
-func captureStderr(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stderr = w
-
-	done := make(chan string, 1)
-	go func() {
-		var out bytes.Buffer
-		_, _ = io.Copy(&out, r)
-		done <- out.String()
-	}()
-
-	fn()
-
-	_ = w.Close()
-	os.Stderr = orig
-	return <-done
-}
-
-// runStreamWatchWithDeps は --stream 実行用の共通ヘルパー。cancelled な ctx を渡して usecase.Run を即座に抜けさせる。
-// captureStderr と組み合わせて WARN ログを検証する。
-func runStreamWatchWithDeps(t *testing.T, deps *Deps, args ...string) error {
-	t.Helper()
-	rootCmd := makeRootCmd(deps)
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	rootCmd.SetContext(ctx)
-	rootCmd.SetArgs(args)
-	return rootCmd.Execute()
-}
-
-func TestWatchCmd_Stream_GetSpeakersFailure_FallsBackToSilent(t *testing.T) {
-	dir := t.TempDir()
-
-	stubClient := &stubVoicevoxClient{
-		getSpeakersErr: errors.New("speakers endpoint down"),
-	}
-	var capturedLookup map[int]entity.SpeakerStyleInfo
-	sp := &stubStreamPlayer{}
-	deps := &Deps{
-		Watch: &WatchDeps{
-			Reader:            stubScriptReader{},
-			ClientFactory:     func(_ string) app.VoicevoxClient { return stubClient },
-			Player:            stubAudioPlayer{},
-			Mover:             stubFileMover{},
-			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, lookup map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
-				capturedLookup = lookup
-				return sp, nil
-			},
-		},
-	}
-
-	var err error
-	logs := captureStderr(t, func() {
-		err = runStreamWatchWithDeps(t, deps, "watch", "--stream", dir)
-	})
-	if err != nil {
-		t.Fatalf("expected no error (fallback to silent), got: %v", err)
-	}
-
-	if stubClient.getSpeakersCall != 1 {
-		t.Errorf("expected GetSpeakers to be called once, got %d", stubClient.getSpeakersCall)
-	}
-	if len(capturedLookup) != 0 {
-		t.Errorf("expected empty lookup in silent fallback, got %+v", capturedLookup)
-	}
-	if sp.silentReason == "" {
-		t.Errorf("expected SetSilent called with non-empty reason")
-	}
-	if !strings.Contains(sp.silentReason, "話者一覧") {
-		t.Errorf("expected silentReason to mention 話者一覧 (GetSpeakers case), got %q", sp.silentReason)
-	}
-
-	if !strings.Contains(logs, "VOICEVOX engine unreachable") {
-		t.Errorf("expected WARN log 'VOICEVOX engine unreachable', got: %s", logs)
-	}
-	if strings.Count(logs, "VOICEVOX engine unreachable") != 1 {
-		t.Errorf("expected WARN log to fire exactly once, got: %s", logs)
-	}
-}
-
-func TestWatchCmd_Stream_HealthCheckFailure_FallsBackToSilent(t *testing.T) {
-	dir := t.TempDir()
-
-	stubClient := &stubVoicevoxClient{
-		healthCheckErr: errors.New("engine down"),
-	}
-	var capturedLookup map[int]entity.SpeakerStyleInfo
-	sp := &stubStreamPlayer{}
-	deps := &Deps{
-		Watch: &WatchDeps{
-			Reader:            stubScriptReader{},
-			ClientFactory:     func(_ string) app.VoicevoxClient { return stubClient },
-			Player:            stubAudioPlayer{},
-			Mover:             stubFileMover{},
-			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, lookup map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
-				capturedLookup = lookup
-				return sp, nil
-			},
-		},
-	}
-
-	var err error
-	logs := captureStderr(t, func() {
-		err = runStreamWatchWithDeps(t, deps, "watch", "--stream", dir)
-	})
-	if err != nil {
-		t.Fatalf("expected no error (fallback to silent), got: %v", err)
-	}
-
-	// HealthCheck 失敗時は GetSpeakers は呼ばれない
-	if stubClient.getSpeakersCall != 0 {
-		t.Errorf("expected GetSpeakers not to be called when HealthCheck fails, got %d", stubClient.getSpeakersCall)
-	}
-	if len(capturedLookup) != 0 {
-		t.Errorf("expected empty lookup in silent fallback, got %+v", capturedLookup)
-	}
-	if sp.silentReason == "" {
-		t.Errorf("expected SetSilent called with non-empty reason")
-	}
-	if !strings.Contains(sp.silentReason, "接続できない") {
-		t.Errorf("expected silentReason to mention 接続できない (HealthCheck case), got %q", sp.silentReason)
-	}
-
-	if !strings.Contains(logs, "VOICEVOX engine unreachable") {
-		t.Errorf("expected WARN log 'VOICEVOX engine unreachable', got: %s", logs)
-	}
-}
-
-func TestWatchCmd_Stream_EngineHealthy_DoesNotEnterSilent(t *testing.T) {
-	dir := t.TempDir()
-
-	stubClient := &stubVoicevoxClient{
-		speakers: []entity.Speaker{
-			{Name: "ずんだもん", Styles: []entity.SpeakerStyle{{ID: 3, Name: "ノーマル"}}},
-		},
-	}
-	sp := &stubStreamPlayer{}
-	deps := &Deps{
-		Watch: &WatchDeps{
-			Reader:            stubScriptReader{},
-			ClientFactory:     func(_ string) app.VoicevoxClient { return stubClient },
-			Player:            stubAudioPlayer{},
-			Mover:             stubFileMover{},
-			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
-				return sp, nil
-			},
-		},
-	}
-
-	var err error
-	logs := captureStderr(t, func() {
-		err = runStreamWatchWithDeps(t, deps, "watch", "--stream", dir)
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if sp.silentReason != "" {
-		t.Errorf("expected SetSilent not called in normal mode, got %q", sp.silentReason)
-	}
-	if strings.Contains(logs, "VOICEVOX engine unreachable") {
-		t.Errorf("expected no WARN log in normal mode")
-	}
-}
-
-func TestWatchCmd_Stream_PassesSpeakerLookupToFactory(t *testing.T) {
-	dir := t.TempDir()
-
-	stubClient := &stubVoicevoxClient{
-		speakers: []entity.Speaker{
-			{Name: "ずんだもん", Styles: []entity.SpeakerStyle{{ID: 3, Name: "ノーマル"}}},
-		},
-	}
-
-	var captured map[int]entity.SpeakerStyleInfo
-	deps := &Deps{
-		Watch: &WatchDeps{
-			Reader:            stubScriptReader{},
-			ClientFactory:     func(_ string) app.VoicevoxClient { return stubClient },
-			Player:            stubAudioPlayer{},
-			Mover:             stubFileMover{},
-			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, lookup map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
-				captured = lookup
-				// usecase.Run まで進ませず、watch loop から確実に抜けるためにキャンセルを返す。
-				return &stubStreamPlayer{}, nil
-			},
-		},
-	}
-	rootCmd := makeRootCmd(deps)
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	// usecase.Run 内のディレクトリ監視は stubDirWatcher が ctx.Done() を待つだけなので、
-	// 短い timeout を持つ context を作って即座に抜ける。
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	rootCmd.SetContext(ctx)
-	rootCmd.SetArgs([]string{"watch", "--stream", dir})
-
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if captured == nil {
-		t.Fatal("StreamPlayerFactory was not called with a lookup")
-	}
-	info, ok := captured[3]
-	if !ok {
-		t.Fatalf("lookup missing key 3, got: %+v", captured)
-	}
-	if info.SpeakerName != "ずんだもん" || info.StyleName != "ノーマル" {
-		t.Errorf("unexpected lookup[3]=%+v", info)
-	}
-}
 
 func TestWatchCmd_EnvVarVOXEngineURL(t *testing.T) {
 	t.Setenv("VOX_ENGINE_URL", "http://custom:9999")

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -130,7 +130,7 @@ cd frontend && npm run test:unit:watch
 
 ## 配信画面の E2E テスト（Playwright）
 
-`frontend/test/e2e/` 以下に Playwright + Chromium による配信画面の E2E テストがあります。実バックエンド（`vox-actor watch --stream`）の代わりに `frontend/test/stub-server.mjs` のスタブを使い、SSE / `/api/status` / `/test-clip` / `/clips/*.wav` を決定的にエミュレートします。
+`frontend/test/e2e/` 以下に Playwright + Chromium による配信画面の E2E テストがあります。実バックエンド（`vox-actor viewer`）の代わりに `frontend/test/stub-server.mjs` のスタブを使い、SSE / `/api/status` / `/test-clip` / `/clips/*.wav` を決定的にエミュレートします。
 
 ### 実行
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -148,8 +148,6 @@ vox-actor watch --queue
 | `--pitch` | — | `0.0` | 音高 |
 | `--intonation` | — | `1.0` | 抑揚 |
 | `--delete` | — | `false` | 処理済みファイルを削除（未指定時は各ディレクトリの `done/` に移動） |
-| `--stream` | — | `false` | HTTPサーバーを起動し、SSE経由でブラウザに音声を配信（[詳細](#ストリーム配信モード)） |
-| `--stream-addr` | — | `127.0.0.1:8080` | ストリーム配信用のバインドアドレス |
 | `--queue` | — | `false` | `vox-actor config path.queue` で解決される queue ディレクトリを監視対象に自動選択（[詳細](#queueオプション)） |
 | `--verbose` | — | `false` | 詳細ログを出力 |
 | `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#dry-runモード)） |
@@ -162,7 +160,7 @@ vox-actor watch --queue
 - `VOX_ACTOR_WORKSPACE` 未設定かつカレントディレクトリがgitリポジトリ外、または `git` コマンドがPATH上に無い場合は起動時にエラー終了します。
 - queue ディレクトリが存在しない場合は起動時に自動作成されます（`os.MkdirAll(..., 0o755)`）。
 - worktree 上で実行した場合でも、`git rev-parse --git-common-dir` で本体リポジトリの `.git` を参照するため、**本体リポジトリ直下**の `.vox-actor/queue` が選ばれます。
-- `--delete` / `--stream` / `--stream-addr` / `--dry-run` などの既存オプションとは自由に併用できます。
+- `--delete` / `--dry-run` などの既存オプションとは自由に併用できます。
 
 ```bash
 # config path.queue で解決される queue ディレクトリを監視（done/ 移動モード）
@@ -170,9 +168,6 @@ vox-actor watch --queue
 
 # 削除モードで監視
 vox-actor watch --queue --delete
-
-# ストリーム配信モード
-vox-actor watch --queue --stream
 ```
 
 ## `viewer` サブコマンド
@@ -382,21 +377,18 @@ fi
 
 HTTPサーバーを起動し、SSE経由でブラウザに音声を配信します。音声デバイスが利用できない環境でホスト側のブラウザに再生させるケースで利用できます。
 
-推奨は [`viewer` サブコマンド](#viewer-サブコマンド)を使う方法です。`watch --stream`（後方互換）も引き続き動作します。
+[`viewer` サブコマンド](#viewer-サブコマンド)を使ってください。
 
 ```bash
-# viewer（推奨）
+# viewer
 vox-actor viewer --watch /path/to/watch-dir
 
 # viewer でバインドアドレスを変更
 vox-actor viewer --host 0.0.0.0 --port 8080 --watch /path/to/watch-dir
-
-# watch --stream（後方互換）
-vox-actor watch --stream /path/to/watch-dir
-
-# watch --stream でバインドアドレスを変更（後方互換）
-vox-actor watch --stream --stream-addr 0.0.0.0:8080 /path/to/watch-dir
 ```
+
+> **注意**: `watch --stream` および `watch --stream-addr` は削除されました。
+> `vox-actor viewer` を使ってください。
 
 - `http://<host>:<port>/` をブラウザで開き、音量スライダーを操作すると再生が解禁されます（ブラウザの自動再生ポリシー対策）。
 - 画面上部のタブで「配信」「音声テスト」を切り替えます。タブ切替時は再生中の音声が即停止し、再生キューも破棄されます。選択中のタブは localStorage に保存されてリロード後も復元されます（初期タブは「配信」）。
@@ -410,12 +402,11 @@ vox-actor watch --stream --stream-addr 0.0.0.0:8080 /path/to/watch-dir
 - サーバー側のWAVリングバッファは固定容量（20件）で、上限を超えた古いものから破棄されます。
 - テスト再生用の WAV は話者ごとに初回合成時のみ VOICEVOX へ問い合わせ、以降は watch プロセス終了までキャッシュから返されます。
 - 複数ブラウザで同時に開いた場合、全クライアントに同じクリップが配信されます。
-- `--stream` と `--dry-run` の併用はエラーになります。
-- デフォルトでは `127.0.0.1` にバインドするため外部からはアクセスできません。LAN公開したい場合は `--stream-addr 0.0.0.0:8080` のように明示的に指定してください。
+- デフォルトでは `127.0.0.1` にバインドするため外部からはアクセスできません。LAN公開したい場合は `--host 0.0.0.0` を指定してください。
 
 ### 無音モード（VOICEVOX 未起動時の自動フォールバック）
 
-`viewer` または `watch --stream` 起動時に VOICEVOX エンジンへの `HealthCheck` または `/speakers` 取得が失敗した場合、エラー終了せず**無音モード**で起動を継続します。VOICEVOX を立ち上げずにテキストだけをブラウザで読みたいときに有効です。
+`viewer` 起動時に VOICEVOX エンジンへの `HealthCheck` または `/speakers` 取得が失敗した場合、エラー終了せず**無音モード**で起動を継続します。VOICEVOX を立ち上げずにテキストだけをブラウザで読みたいときに有効です。
 
 - 判定は **起動時のみ** 行われます。起動後にエンジンが切断されても無音モードへは切り替わりません（リカバリ対象外）。
 - フォールバック発動時、標準エラー出力に WARN ログ `VOICEVOX engine unreachable, continuing in silent mode (no audio will be played)` が1回出力されます。`error` 属性で `HealthCheck` 失敗か `GetSpeakers` 失敗かを識別できます。
@@ -424,10 +415,10 @@ vox-actor watch --stream --stream-addr 0.0.0.0:8080 /path/to/watch-dir
   - セリフの配信間隔は WAV 長ではなく固定 0.5 秒になります（タイムラインが一瞬で流れ去らないための暫定値）。
   - 話者名は全 SpeakerID について `話者#<ID>` にフォールバックします（スタイル名は空文字）。
   - 「音声テスト」タブは画面上に表示されません。
-  - ヘッダーの SSE 接続バッジの右隣に `🔇 無音モード` バッジが表示され、ホバーまたはタップで無音モードに入った理由と対処法（VOICEVOX を起動した状態で `watch --stream` を起動し直すなど）をツールチップで確認できます。
+  - ヘッダーの SSE 接続バッジの右隣に `🔇 無音モード` バッジが表示され、ホバーまたはタップで無音モードに入った理由と対処法（VOICEVOX を起動した状態で `viewer` を起動し直すなど）をツールチップで確認できます。
 - サーバーの現在の状態は `GET /api/status` で取得できます。無音フラグ・理由文面・話者一覧をまとめて返す単一エンドポイントで、既存の `/speakers.json` は廃止されています。
 - ディレクトリ監視・`done/` への移動／削除は無音モードでも通常通り実施されます。
-- 非ストリームの `watch` / `say` / `act` では従来通り `HealthCheck` 失敗時に即エラー終了します（本フォールバックは `viewer` / `watch --stream` のみ）。
+- `watch` / `say` / `act` では従来通り `HealthCheck` 失敗時に即エラー終了します（本フォールバックは `viewer` のみ）。
 
 ## dry-runモード
 

--- a/main.go
+++ b/main.go
@@ -54,12 +54,11 @@ func main() {
 			DirWatcherFactory: dirWatcherFactory,
 		},
 		Watch: &cmd.WatchDeps{
-			Reader:              reader,
-			ClientFactory:       clientFactory,
-			Player:              player,
-			Mover:               mover,
-			DirWatcherFactory:   dirWatcherFactory,
-			StreamPlayerFactory: streamPlayerFactory,
+			Reader:            reader,
+			ClientFactory:     clientFactory,
+			Player:            player,
+			Mover:             mover,
+			DirWatcherFactory: dirWatcherFactory,
 		},
 		Viewer: &cmd.ViewerDeps{
 			Reader:              reader,

--- a/test/e2e/watch_test.go
+++ b/test/e2e/watch_test.go
@@ -276,7 +276,8 @@ func TestWatchE2E_UsageError_ExitCode2(t *testing.T) {
 		args []string
 	}{
 		{name: "queue with positional arg", args: []string{"watch", "--queue", "--dry-run", dir}},
-		{name: "stream with dry-run", args: []string{"watch", "--stream", "--dry-run", dir}},
+		{name: "stream flag removed", args: []string{"watch", "--stream", dir}},
+		{name: "stream-addr flag removed", args: []string{"watch", "--stream-addr", "0.0.0.0:9090", dir}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

watch コマンドの `--stream` / `--stream-addr` フラグを廃止し、ストリーム配信機能を viewer サブコマンドに完全に集約します。#320 の viewer サブコマンド追加に続く整理作業です。

- `--stream` / `--stream-addr` フラグを hidden に変更し、使用時に viewer への移行を案内するエラーを表示
- startStreamPlayer 関数と無音モード定数を watch.go から viewer.go に移動
- WatchDeps から StreamPlayerFactory フィールドを削除
- watch 専用のストリーム分岐ロジックと silent フラグ処理を削除
- ストリーム関連テストを削除し、廃止フラグ検知テストを追加
- ドキュメント更新（README, CLI reference, contributing guide）
- Makefile の dev-backend を viewer 呼び出しに変更

## テスト・品質確認

- `go build ./...` OK
- `go test ./...` 全てパス
- `golangci-lint run` 指摘なし
- simplify レビュー 指摘なし
- self-review 指摘なし

## 受け入れ条件確認

- [x] `vox-actor watch /path` はローカルスピーカー再生で動作
- [x] `vox-actor watch --stream /path` は ErrUsage で viewer 案内表示
- [x] `vox-actor watch --stream-addr ...` も同様に廃止エラー表示
- [x] WatchDeps.StreamPlayerFactory が削除
- [x] ストリーム関連テストが削除・更新
- [x] ドキュメント更新完了

Closes #321

🤖 Generated with [Claude Code](https://claude.ai/code)