### PR TITLE
fix: キャラタブで再生中のクリップが表示されるよう usePlaybackQueue の active フラグを修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -125,7 +125,7 @@ export function App() {
 
   const { playingClipId, enqueue } = usePlaybackQueue(
     audioRef,
-    activeTab === "stream",
+    activeTab === "stream" || activeTab === "character",
   );
   const playingClipIdRef = useRef<number | null>(null);
   playingClipIdRef.current = playingClipId;


### PR DESCRIPTION
## 概要

キャラクタータブで再生中のクリップが表示されない問題を修正します。

## 修正内容

`frontend/src/App.tsx:128` の `usePlaybackQueue` の `active` フラグを修正しました。

修正前:
```typescript
const { playingClipId, enqueue } = usePlaybackQueue(
  audioRef,
  activeTab === "stream",
);
```

修正後:
```typescript
const { playingClipId, enqueue } = usePlaybackQueue(
  audioRef,
  activeTab === "stream" || activeTab === "character",
);
```

## 効果

キャラクタータブに切り替えた際にも再生キューが保持されるようになり、以下が実現されます:
- 配信タブで再生中のクリップをキャラクタータブから確認できる
- マッチするキャラクター画像が表示される
- 音声再生と連動して口パクが動作する
- タブ切り替え時に再生が中断しない

## 検証

- TypeScript 型チェック: ✅ パス
- ユニットテスト（13ファイル、90テスト）: ✅ 全てパス

## 関連 Issue

Closes #326

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)