### PR TITLE
fix: 口パク機能で一度口が開くと閉じなくなる不具合

### DIFF
--- a/frontend/src/components/LipSyncImage.tsx
+++ b/frontend/src/components/LipSyncImage.tsx
@@ -44,6 +44,7 @@ export function LipSyncImage({
     return () => {
       if (closeTimerRef.current) {
         clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
       }
     };
   }, [volume, threshold, hysteresisMs]);


### PR DESCRIPTION
## 概要

LipSyncImage.tsx の useEffect cleanup 関数で、timer をクリアした後に closeTimerRef を null にリセットしていなかったため、一度口が開くと閉じなくなる不具合を修正しました。

## 原因

cleanup 関数で `clearTimeout()` のみを実行していたため、ref に古い timer ID が残ったままになり、次の effect 実行時に `if (!closeTimerRef.current)` のチェックが正しく機能していませんでした。

## 修正内容

cleanup 関数で `clearTimeout()` 後に `closeTimerRef.current = null` を追加し、ref を明示的にリセットするようにしました。

## テスト方法

1. viewer の「音声テスト」タブで音声を再生
2. キャラクタータブで口パク動作を確認
3. 音量レベルを変動させ、口が確実に開閉することを確認

## 対応 Issue

Closes #329

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)