### PR TITLE
feat: auto-monologue-plugin に Stop フックを復活させる

### DIFF
--- a/plugins/auto-monologue-plugin/.claude-plugin/plugin.json
+++ b/plugins/auto-monologue-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-monologue-plugin",
   "description": "独り言を自動的に生成するためのプラグイン",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": {
     "name": "canpok1"
   }

--- a/plugins/auto-monologue-plugin/hooks/hooks.json
+++ b/plugins/auto-monologue-plugin/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/monologue-stop.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/plugins/auto-monologue-plugin/scripts/monologue-stop.sh
+++ b/plugins/auto-monologue-plugin/scripts/monologue-stop.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+jq -n '{
+  decision: "block",
+  reason: "区切りがいいので/vox-actor-plugin:monologueスキルを活用して。"
+}'


### PR DESCRIPTION
## Summary

- `monologue-stop.sh` を復元し、応答終了時に monologue スキルを確実に呼び出すよう Stop フックを追加
- `hooks.json` に Stop エントリを追加（既存の SessionStart/PreToolUse/PostToolUse フックはそのまま維持）
- `plugin.json` の version を 0.0.6 → 0.0.7 に bump

## Test plan

- [ ] `monologue-stop.sh` が存在し、実行権限があることを確認
- [ ] `hooks.json` に Stop エントリが含まれていることを確認
- [ ] 既存の SessionStart/PreToolUse/PostToolUse フックが残っていることを確認
- [ ] `plugin.json` の version が 0.0.7 になっていることを確認
- [ ] `shellcheck plugins/auto-monologue-plugin/scripts/monologue-stop.sh` が無指摘であることを確認

Closes #328

---

🤖 Generated with [Claude Code](https://claude.ai/code)
