### PR TITLE
fix(viewer): 音声テストの話者ドロップダウン表示順をVOICEVOX取得順・キャラ単位でグルーピングする

### DIFF
--- a/cmd/viewer.go
+++ b/cmd/viewer.go
@@ -34,10 +34,11 @@ func startStreamPlayer(
 	addr string,
 	logger *slog.Logger,
 	client app.VoicevoxClient,
-	factory func(string, *slog.Logger, map[int]entity.SpeakerStyleInfo, app.VoicevoxClient) (app.StreamPlayer, error),
+	factory func(string, *slog.Logger, map[int]entity.SpeakerStyleInfo, []int, app.VoicevoxClient) (app.StreamPlayer, error),
 ) (sp app.StreamPlayer, silent bool, err error) {
 	var (
 		lookup       map[int]entity.SpeakerStyleInfo
+		orderedIDs   []int
 		silentReason string
 	)
 	if hcErr := client.HealthCheck(ctx); hcErr != nil {
@@ -51,15 +52,16 @@ func startStreamPlayer(
 			silentReason = silentReasonGetSpeakersFailed
 			logger.Warn(silentLogMessage, "error", fmt.Errorf("get speakers failed: %w", gsErr))
 		} else {
-			lookup = entity.BuildSpeakerStyleLookup(speakers)
+			lookup, orderedIDs = entity.BuildSpeakerStyleLookupWithOrder(speakers)
 			logger.Info("speakers loaded", "speakerCount", len(speakers), "styleCount", len(lookup))
 		}
 	}
 	if silent {
 		lookup = map[int]entity.SpeakerStyleInfo{}
+		orderedIDs = nil
 	}
 
-	sp, err = factory(addr, logger, lookup, client)
+	sp, err = factory(addr, logger, lookup, orderedIDs, client)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to create stream player: %w", err)
 	}
@@ -81,7 +83,7 @@ type ViewerDeps struct {
 	ClientFactory       func(engineURL string) app.VoicevoxClient
 	Mover               app.FileMover
 	DirWatcherFactory   func(logger *slog.Logger) app.DirWatcher
-	StreamPlayerFactory func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, client app.VoicevoxClient) (app.StreamPlayer, error)
+	StreamPlayerFactory func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, orderedSpeakerIDs []int, client app.VoicevoxClient) (app.StreamPlayer, error)
 	QueuePathResolver   func() (string, error)
 }
 

--- a/cmd/viewer_test.go
+++ b/cmd/viewer_test.go
@@ -167,7 +167,7 @@ func TestViewerCmd_PortOutOfRange_ReturnsUsageError(t *testing.T) {
 			deps := &Deps{
 				Viewer: &ViewerDeps{
 					ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
-					StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+					StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 						return &stubStreamPlayer{}, nil
 					},
 				},
@@ -199,7 +199,7 @@ func TestViewerCmd_WatchWithFile_ReturnsUsageError(t *testing.T) {
 	deps := &Deps{
 		Viewer: &ViewerDeps{
 			ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return &stubStreamPlayer{}, nil
 			},
 		},
@@ -223,7 +223,7 @@ func TestViewerCmd_WatchWithNonExistentPath_ReturnsUsageError(t *testing.T) {
 	deps := &Deps{
 		Viewer: &ViewerDeps{
 			ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return &stubStreamPlayer{}, nil
 			},
 		},
@@ -264,7 +264,7 @@ func TestViewerCmd_HealthCheckFailure_FallsBackToSilent(t *testing.T) {
 			ClientFactory:     func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{healthCheckErr: errors.New("down")} },
 			Mover:             stubFileMover{},
 			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return sp, nil
 			},
 		},
@@ -292,7 +292,7 @@ func TestViewerCmd_GetSpeakersFailure_FallsBackToSilent(t *testing.T) {
 			},
 			Mover:             stubFileMover{},
 			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return sp, nil
 			},
 		},
@@ -324,7 +324,7 @@ func TestViewerCmd_EngineHealthy_DoesNotEnterSilent(t *testing.T) {
 			},
 			Mover:             stubFileMover{},
 			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return sp, nil
 			},
 		},
@@ -354,7 +354,7 @@ func TestViewerCmd_WatchQueue_ResolvesAndCreatesQueueDir(t *testing.T) {
 			ClientFactory:     func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
 			Mover:             stubFileMover{},
 			DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return sp, nil
 			},
 			QueuePathResolver: func() (string, error) {
@@ -382,7 +382,7 @@ func TestViewerCmd_WatchQueue_ResolverReturnsNotInRepo_ReturnsError(t *testing.T
 	deps := &Deps{
 		Viewer: &ViewerDeps{
 			ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
-			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ app.VoicevoxClient) (app.StreamPlayer, error) {
+			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return &stubStreamPlayer{}, nil
 			},
 			QueuePathResolver: func() (string, error) {

--- a/internal/domain/entity/speaker.go
+++ b/internal/domain/entity/speaker.go
@@ -39,3 +39,24 @@ func BuildSpeakerStyleLookup(speakers []Speaker) map[int]SpeakerStyleInfo {
 	}
 	return lookup
 }
+
+// BuildSpeakerStyleLookupWithOrder は []Speaker から SpeakerID マップと
+// VOICEVOX 取得順を保持した ID リストを同時に構築する。
+// 複数 Speaker に同じスタイルIDが存在する場合は最初に現れた値が優先される。
+func BuildSpeakerStyleLookupWithOrder(speakers []Speaker) (map[int]SpeakerStyleInfo, []int) {
+	lookup := make(map[int]SpeakerStyleInfo)
+	var orderedIDs []int
+	for _, sp := range speakers {
+		for _, st := range sp.Styles {
+			if _, exists := lookup[st.ID]; exists {
+				continue
+			}
+			lookup[st.ID] = SpeakerStyleInfo{
+				SpeakerName: sp.Name,
+				StyleName:   st.Name,
+			}
+			orderedIDs = append(orderedIDs, st.ID)
+		}
+	}
+	return lookup, orderedIDs
+}

--- a/internal/domain/entity/speaker_test.go
+++ b/internal/domain/entity/speaker_test.go
@@ -76,3 +76,95 @@ func TestBuildSpeakerStyleLookup_EmptyInput(t *testing.T) {
 		t.Errorf("lookup should be empty for nil input, got %d entries", len(lookup))
 	}
 }
+
+func TestBuildSpeakerStyleLookupWithOrder_PresservesOrder(t *testing.T) {
+	speakers := []entity.Speaker{
+		{
+			Name: "ずんだもん",
+			Styles: []entity.SpeakerStyle{
+				{ID: 3, Name: "ノーマル"},
+				{ID: 1, Name: "あまあま"},
+			},
+		},
+		{
+			Name: "四国めたん",
+			Styles: []entity.SpeakerStyle{
+				{ID: 2, Name: "ノーマル"},
+			},
+		},
+	}
+
+	lookup, orderedIDs := entity.BuildSpeakerStyleLookupWithOrder(speakers)
+
+	if got, want := len(lookup), 3; got != want {
+		t.Fatalf("len(lookup) = %d, want %d", got, want)
+	}
+
+	wantIDs := []int{3, 1, 2}
+	if len(orderedIDs) != len(wantIDs) {
+		t.Fatalf("len(orderedIDs) = %d, want %d", len(orderedIDs), len(wantIDs))
+	}
+	for i, want := range wantIDs {
+		if got := orderedIDs[i]; got != want {
+			t.Errorf("orderedIDs[%d] = %d, want %d", i, got, want)
+		}
+	}
+
+	cases := []struct {
+		id      int
+		speaker string
+		style   string
+	}{
+		{3, "ずんだもん", "ノーマル"},
+		{1, "ずんだもん", "あまあま"},
+		{2, "四国めたん", "ノーマル"},
+	}
+	for _, c := range cases {
+		got, ok := lookup[c.id]
+		if !ok {
+			t.Errorf("lookup[%d] missing", c.id)
+			continue
+		}
+		if got.SpeakerName != c.speaker || got.StyleName != c.style {
+			t.Errorf("lookup[%d] = %+v, want speaker=%s style=%s", c.id, got, c.speaker, c.style)
+		}
+	}
+}
+
+func TestBuildSpeakerStyleLookupWithOrder_DuplicateIDKeepsFirst(t *testing.T) {
+	speakers := []entity.Speaker{
+		{
+			Name:   "話者A",
+			Styles: []entity.SpeakerStyle{{ID: 5, Name: "スタイルA"}},
+		},
+		{
+			Name:   "話者B",
+			Styles: []entity.SpeakerStyle{{ID: 5, Name: "スタイルB"}},
+		},
+	}
+
+	lookup, orderedIDs := entity.BuildSpeakerStyleLookupWithOrder(speakers)
+
+	got := lookup[5]
+	if got.SpeakerName != "話者A" || got.StyleName != "スタイルA" {
+		t.Errorf("lookup[5] = %+v, want speaker=話者A style=スタイルA (first wins)", got)
+	}
+
+	wantIDs := []int{5}
+	if len(orderedIDs) != len(wantIDs) {
+		t.Fatalf("len(orderedIDs) = %d, want %d (duplicate not included twice)", len(orderedIDs), len(wantIDs))
+	}
+	if orderedIDs[0] != 5 {
+		t.Errorf("orderedIDs[0] = %d, want 5", orderedIDs[0])
+	}
+}
+
+func TestBuildSpeakerStyleLookupWithOrder_EmptyInput(t *testing.T) {
+	lookup, orderedIDs := entity.BuildSpeakerStyleLookupWithOrder(nil)
+	if len(lookup) != 0 {
+		t.Errorf("lookup should be empty for nil input, got %d entries", len(lookup))
+	}
+	if len(orderedIDs) != 0 {
+		t.Errorf("orderedIDs should be empty for nil input, got %d entries", len(orderedIDs))
+	}
+}

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -46,6 +46,10 @@ type HTTPStreamPlayer struct {
 	// nil または未ヒットの場合は `話者#<ID>` / 空文字 にフォールバックする。
 	speakerLookup map[int]entity.SpeakerStyleInfo
 
+	// orderedSpeakerIDs は /api/status で返す speakers 配列の順序。
+	// 設定されていない場合は speakerLookup のキーを ID 昇順でソートして使用する（後方互換）。
+	orderedSpeakerIDs []int
+
 	// silent が true の場合、Play() / PlayText() は WAV を配信せずテキストのみを配信する。
 	// silentReason は /api/status でフロントに伝える文面（改行を含んでよい）。
 	silent       bool
@@ -143,6 +147,16 @@ func WithSpeakerLookup(lookup map[int]entity.SpeakerStyleInfo) HTTPStreamOption 
 	return func(p *HTTPStreamPlayer) {
 		if lookup != nil {
 			p.speakerLookup = lookup
+		}
+	}
+}
+
+// WithOrderedSpeakerIDs は /api/status で返す speakers 配列の順序を設定するオプション。
+// 設定されない場合は speakerLookup のキーを ID 昇順でソートして使用する。
+func WithOrderedSpeakerIDs(ids []int) HTTPStreamOption {
+	return func(p *HTTPStreamPlayer) {
+		if ids != nil {
+			p.orderedSpeakerIDs = ids
 		}
 	}
 }
@@ -537,16 +551,23 @@ type apiCharactersJSON struct {
 // buildAPIStatusJSON は speakerLookup と silent 状態から /api/status のレスポンスを
 // Start 時に一度だけマーシャルしてキャッシュする。
 // 無音モードでは speakers は空配列として固定する。
+// orderedSpeakerIDs が設定されている場合はその順序を使用し、
+// そうでない場合は speakerLookup のキーを ID 昇順でソートする（後方互換）。
 func (p *HTTPStreamPlayer) buildAPIStatusJSON() error {
 	var items []speakerJSON
 	if p.silent {
 		items = []speakerJSON{}
 	} else {
-		ids := make([]int, 0, len(p.speakerLookup))
-		for id := range p.speakerLookup {
-			ids = append(ids, id)
+		var ids []int
+		if len(p.orderedSpeakerIDs) > 0 {
+			ids = p.orderedSpeakerIDs
+		} else {
+			ids = make([]int, 0, len(p.speakerLookup))
+			for id := range p.speakerLookup {
+				ids = append(ids, id)
+			}
+			sort.Ints(ids)
 		}
-		sort.Ints(ids)
 		items = make([]speakerJSON, 0, len(ids))
 		for _, id := range ids {
 			info := p.speakerLookup[id]

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -1010,6 +1010,45 @@ func TestHTTPStreamPlayer_APIStatus_ReturnsSortedSpeakers(t *testing.T) {
 	}
 }
 
+func TestHTTPStreamPlayer_APIStatus_ReturnsOrderedSpeakers(t *testing.T) {
+	t.Parallel()
+	lookup := map[int]entity.SpeakerStyleInfo{
+		1: {SpeakerName: "四国めたん", StyleName: "あまあま"},
+		7: {SpeakerName: "四国めたん", StyleName: "ノーマル"},
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	orderedIDs := []int{7, 3, 1}
+	p := newStartedPlayerWithOpts(t,
+		WithSpeakerLookup(lookup),
+		WithOrderedSpeakerIDs(orderedIDs),
+	)
+	got := fetchAPIStatus(t, p)
+	if got.Silent {
+		t.Errorf("expected silent=false, got true")
+	}
+	if got.SilentReason != "" {
+		t.Errorf("expected silentReason empty, got %q", got.SilentReason)
+	}
+	if len(got.Speakers) != 3 {
+		t.Fatalf("expected 3 speakers, got %d: %+v", len(got.Speakers), got)
+	}
+	wantIDs := []int{7, 3, 1}
+	for i, w := range wantIDs {
+		if got.Speakers[i].ID != w {
+			t.Errorf("entry %d: expected id=%d, got %d", i, w, got.Speakers[i].ID)
+		}
+	}
+	if got.Speakers[0].SpeakerName != "四国めたん" || got.Speakers[0].StyleName != "ノーマル" {
+		t.Errorf("entry 0: expected 四国めたん/ノーマル, got %+v", got.Speakers[0])
+	}
+	if got.Speakers[1].SpeakerName != "ずんだもん" || got.Speakers[1].StyleName != "ノーマル" {
+		t.Errorf("entry 1: expected ずんだもん/ノーマル, got %+v", got.Speakers[1])
+	}
+	if got.Speakers[2].SpeakerName != "四国めたん" || got.Speakers[2].StyleName != "あまあま" {
+		t.Errorf("entry 2: expected 四国めたん/あまあま, got %+v", got.Speakers[2])
+	}
+}
+
 func TestHTTPStreamPlayer_APIStatus_NoLookupReturnsEmptySpeakers(t *testing.T) {
 	t.Parallel()
 	p := newStartedPlayer(t)

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	reader := infra.NewFileReader()
 	mover := infra.NewFileMover()
 
-	streamPlayerFactory := func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, client app.VoicevoxClient) (app.StreamPlayer, error) {
+	streamPlayerFactory := func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, orderedSpeakerIDs []int, client app.VoicevoxClient) (app.StreamPlayer, error) {
 		staticFS, err := streamAssetsFS()
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve stream assets: %w", err)
@@ -41,6 +41,7 @@ func main() {
 		opts := []infra.HTTPStreamOption{
 			infra.WithHTTPStreamLogger(logger),
 			infra.WithSpeakerLookup(speakerLookup),
+			infra.WithOrderedSpeakerIDs(orderedSpeakerIDs),
 			infra.WithVoicevoxClient(client),
 		}
 		workspacePath, wsErr := infra.ResolveWorkspacePath()


### PR DESCRIPTION
## Summary

Fix the viewer's audio test panel speaker dropdown to display speakers in VOICEVOX API order, grouped by character, rather than sorted by style ID.

### Changes

- **entity.BuildSpeakerStyleLookupWithOrder**: New function that preserves VOICEVOX speaker order while building the lookup map
- **HTTPStreamPlayer.WithOrderedSpeakerIDs**: New option to pass ordered speaker IDs to the stream player
- **buildAPIStatusJSON**: Modified to use provided ordered IDs instead of always sorting by ID (with backward compatibility fallback)
- **viewer.go**: Updated to use `BuildSpeakerStyleLookupWithOrder` and pass ordered IDs to the stream player factory
- **Tests**: Added comprehensive test cases for ordered speaker behavior

### Acceptance Criteria

✓ `/api/status` returns speakers in VOICEVOX acquisition order, grouped by character
✓ All existing tests pass (118+ infra tests)
✓ Backward compatibility maintained (ID sorting used when no ordered IDs provided)
✓ Integration with viewer command verified

Closes #332

---
🤖 Generated with [Claude Code](https://claude.ai/code)
