### PR TITLE
feat(viewer): 音声テストタブにキャラクター画像と口パク表示を追加する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -362,6 +362,9 @@ export function App() {
             onSpeakerChange={setTestSpeakerId}
             onPlay={handleTestPlay}
             error={testError}
+            charactersEnabled={charactersEnabled}
+            characters={characters}
+            audioRef={audioRef}
           />
         )}
       </div>

--- a/frontend/src/components/TestPanel.test.tsx
+++ b/frontend/src/components/TestPanel.test.tsx
@@ -1,7 +1,12 @@
+import { createRef } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { Speaker } from "../types/api";
+import type { Speaker, CharacterEntry } from "../types/api";
 import { TestPanel } from "./TestPanel";
+
+vi.mock("../hooks/useAudioVolume", () => ({
+  useAudioVolume: vi.fn(() => 0),
+}));
 
 describe("TestPanel", () => {
   const mockSpeakers: Speaker[] = [
@@ -14,32 +19,27 @@ describe("TestPanel", () => {
     onPlay: vi.fn(),
   };
 
+  const mockAudioRef = createRef<HTMLAudioElement>();
+
+  const baseProps = {
+    speakers: mockSpeakers,
+    selectedSpeakerId: "1",
+    onSpeakerChange: mockCallbacks.onSpeakerChange,
+    onPlay: mockCallbacks.onPlay,
+    error: "",
+    charactersEnabled: false,
+    characters: [] as CharacterEntry[],
+    audioRef: mockAudioRef,
+  };
+
   it("hidden=false で表示される", () => {
-    render(
-      <TestPanel
-        hidden={false}
-        speakers={mockSpeakers}
-        selectedSpeakerId="1"
-        onSpeakerChange={mockCallbacks.onSpeakerChange}
-        onPlay={mockCallbacks.onPlay}
-        error=""
-      />,
-    );
+    render(<TestPanel hidden={false} {...baseProps} />);
     const panel = screen.getByRole("tabpanel", { hidden: false });
     expect(panel).toBeInTheDocument();
   });
 
   it("hidden=true で非表示になる", () => {
-    render(
-      <TestPanel
-        hidden={true}
-        speakers={mockSpeakers}
-        selectedSpeakerId="1"
-        onSpeakerChange={mockCallbacks.onSpeakerChange}
-        onPlay={mockCallbacks.onPlay}
-        error=""
-      />,
-    );
+    render(<TestPanel hidden={true} {...baseProps} />);
     const panel = screen.queryByRole("tabpanel", { hidden: false });
     expect(panel).not.toBeInTheDocument();
   });
@@ -48,10 +48,8 @@ describe("TestPanel", () => {
     render(
       <TestPanel
         hidden={false}
-        speakers={mockSpeakers}
+        {...baseProps}
         selectedSpeakerId="2"
-        onSpeakerChange={mockCallbacks.onSpeakerChange}
-        onPlay={mockCallbacks.onPlay}
         error="エラーメッセージ"
       />,
     );
@@ -65,5 +63,52 @@ describe("TestPanel", () => {
 
     const errorElement = screen.getByRole("status");
     expect(errorElement).toHaveTextContent("エラーメッセージ");
+  });
+
+  describe("キャラクター機能", () => {
+    const mockCharacters: CharacterEntry[] = [
+      {
+        speakerName: "Speaker A",
+        styleName: "style1",
+        mouthClosed: "closed.png",
+        mouthOpen: "open.png",
+      },
+    ];
+
+    it("charactersEnabled=false のときキャラクター表示エリアが表示されない", () => {
+      render(<TestPanel hidden={false} {...baseProps} />);
+      expect(
+        screen.queryByAltText("character mouth closed"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("charactersEnabled=true かつ一致するキャラがある場合に口パク画像が表示される", () => {
+      render(
+        <TestPanel
+          hidden={false}
+          {...baseProps}
+          charactersEnabled={true}
+          characters={mockCharacters}
+          selectedSpeakerId="1"
+        />,
+      );
+      expect(screen.getByAltText("character mouth closed")).toBeInTheDocument();
+      expect(screen.getByAltText("character mouth open")).toBeInTheDocument();
+    });
+
+    it("charactersEnabled=true かつ一致するキャラがない場合にプレースホルダーが表示される", () => {
+      render(
+        <TestPanel
+          hidden={false}
+          {...baseProps}
+          charactersEnabled={true}
+          characters={mockCharacters}
+          selectedSpeakerId="2"
+        />,
+      );
+      expect(
+        screen.queryByAltText("character mouth closed"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/TestPanel.tsx
+++ b/frontend/src/components/TestPanel.tsx
@@ -1,5 +1,8 @@
-import type { Speaker } from "../types/api";
+import { useMemo } from "react";
+import type { Speaker, CharacterEntry } from "../types/api";
 import { TestControls } from "./TestControls";
+import { LipSyncImage } from "./LipSyncImage";
+import { useAudioVolume } from "../hooks/useAudioVolume";
 
 interface TestPanelProps {
   hidden: boolean;
@@ -8,6 +11,9 @@ interface TestPanelProps {
   onSpeakerChange: (id: string) => void;
   onPlay: () => void;
   error: string;
+  charactersEnabled: boolean;
+  characters: CharacterEntry[];
+  audioRef: React.RefObject<HTMLAudioElement>;
 }
 
 export function TestPanel({
@@ -17,15 +23,54 @@ export function TestPanel({
   onSpeakerChange,
   onPlay,
   error,
+  charactersEnabled,
+  characters,
+  audioRef,
 }: TestPanelProps) {
+  const volume = useAudioVolume(audioRef, !hidden && charactersEnabled);
+
+  const selectedSpeaker = useMemo(
+    () =>
+      speakers.find((s) => s.id === Number(selectedSpeakerId)) ?? null,
+    [speakers, selectedSpeakerId],
+  );
+
+  const matchedCharacter = useMemo(
+    () =>
+      selectedSpeaker
+        ? characters.find(
+            (c) =>
+              c.speakerName === selectedSpeaker.speakerName &&
+              c.styleName === selectedSpeaker.styleName,
+          ) ?? null
+        : null,
+    [selectedSpeaker, characters],
+  );
+
   return (
     <section
       id="panel-test"
       role="tabpanel"
       aria-labelledby="tab-test"
       hidden={hidden}
-      className="mt-2"
+      className={charactersEnabled ? "flex h-full flex-col gap-4" : "mt-2"}
     >
+      {charactersEnabled && (
+        <div className="flex min-h-0 flex-1 items-center justify-center rounded-md bg-ctp-surface p-4">
+          {matchedCharacter ? (
+            <LipSyncImage
+              mouthClosedUrl={`/assets/images/characters/${encodeURIComponent(matchedCharacter.mouthClosed)}`}
+              mouthOpenUrl={`/assets/images/characters/${encodeURIComponent(matchedCharacter.mouthOpen)}`}
+              volume={volume}
+            />
+          ) : (
+            <div
+              className="h-full w-auto max-w-full"
+              style={{ aspectRatio: "3 / 4", backgroundColor: "var(--ctp-base)" }}
+            />
+          )}
+        </div>
+      )}
       <TestControls
         speakers={speakers}
         selectedSpeakerId={selectedSpeakerId}


### PR DESCRIPTION
## Summary

音声テストタブにキャラクター画像と口パク表示を追加しました。キャラ機能有効時にテストパネル内でキャラクター画像を表示し、選択した話者に対応するキャラが音量に応じて口パクするようになります。

- TestPanel に character display 機能を統合
- 選択中の話者から character entry をマッチング
- useAudioVolume hook で リアルタイム音量取得して LipSyncImage に連動
- useMemo で パフォーマンス最適化

## Test Plan

以下のテストで受け入れ条件をカバーしています:

- [x] キャラ機能OFF時はキャラ表示エリアが表示されない
- [x] キャラ機能ON時で一致キャラがある場合、口パク画像が表示される
- [x] キャラ機能ON時で一致キャラがない場合、プレースホルダーが表示される
- [x] TestControls の props が正しく渡される
- [x] パネルの hidden state が正しく動作する

## Closing Issue

Closes #333

---
🤖 Generated with [Claude Code](https://claude.ai/code)
