### PR TITLE
feat: mainブランチへの直接コミットをブロックするPreToolUse hookを追加

### DIFF
--- a/.claude/hooks/block-commit-on-main.sh
+++ b/.claude/hooks/block-commit-on-main.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# PreToolUse hook: block `git commit` when current branch is main
+
+branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+if [ "$branch" = "main" ]; then
+  printf 'Error: mainブランチへの直接コミットは禁止です。\n' >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,6 +65,19 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "command": "./.claude/hooks/block-commit-on-main.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

- `.claude/hooks/block-commit-on-main.sh` を新規追加: `git commit` 実行時に現在のブランチが `main` であればブロックする
- `.claude/settings.json` の `hooks.PreToolUse` にhookを登録: `if: "Bash(git commit *)"` で git commit コマンドのみを対象とする

## Test plan

- [ ] `worktree-issue-338` ブランチでは `git commit` が正常に実行できること（他ブランチ確認）
- [ ] `main` ブランチで `git commit` を試みると PreToolUse hookによりブロックされること（手動確認）
- [ ] `main` ブランチで `git status` など他のgitコマンドは影響を受けないこと

Closes #338

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
