### PR TITLE
fix(viewer): AudioContext.resume()を呼び出してリップシンク機能を復旧する

### DIFF
--- a/frontend/src/hooks/useAudioVolume.ts
+++ b/frontend/src/hooks/useAudioVolume.ts
@@ -28,6 +28,8 @@ export function useAudioVolume(
         (window as unknown as { webkitAudioContext: typeof AudioContext })
           .webkitAudioContext) as typeof AudioContext;
       const audioContext = new AudioContextConstructor();
+      audioContext.resume();
+
       const analyser = audioContext.createAnalyser();
       analyser.fftSize = 512;
 


### PR DESCRIPTION
## Summary

音声テストタブでキャラクター画像のリップシンク（口パク）機能が動作しない不具合を修正します。

### 問題
Web Audio APIのautoplay policyにより、AudioContextがsuspended状態で開始される場合があります。この状態ではAnalyserNodeが音声信号を取得できないため、RMS音量計算が失敗し、リップシンク機能が動作しません。

### 修正内容
`frontend/src/hooks/useAudioVolume.ts`の`initAudioContext`メソッドで、AudioContext作成直後に`.resume()`を呼び出すことで、suspended状態を解決し、AnalyserNodeが音声信号を正常に取得できるようにします。

### 受け入れ条件
- [x] `useAudioVolume`フックの`initAudioContext`でAudioContext.resume()を呼び出す
- [ ] 音声テストタブで音声再生時にキャラクター画像の口が正しく開閉する（手動確認）
- [ ] 複数回の再生でも一貫して口パクが動作する（手動確認）

## Test Plan

音声テストタブでVOICEVOXを選択し、テキストを入力して再生ボタンを押します。キャラクター画像の口が音声に合わせて開閉することを確認してください。

Closes #342

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)