### PR TITLE
fix: block-commit-on-main.sh が git commit 以外をブロックしないよう修正する

### DIFF
--- a/.claude/hooks/block-commit-on-main.sh
+++ b/.claude/hooks/block-commit-on-main.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 # PreToolUse hook: block `git commit` when current branch is main
 
+command=$(jq -r '.tool_input.command // ""' 2>/dev/null)
+
+case "$command" in
+  "git commit"*) ;;
+  *) exit 0 ;;
+esac
+
 branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
 if [ "$branch" = "main" ]; then
   printf 'Error: mainブランチへの直接コミットは禁止です。\n' >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,7 +71,6 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git commit *)",
             "command": "./.claude/hooks/block-commit-on-main.sh",
             "timeout": 10
           }


### PR DESCRIPTION
## Summary

- `block-commit-on-main.sh` に stdin JSON から `tool_input.command` を読む処理を追加し、`git commit` で始まるコマンドのみブロック対象とする
- `.claude/settings.json` から Claude Code 仕様外の `if` フィールドを削除する

## 背景

`matcher: "Bash"` はすべての Bash 呼び出しにマッチするが、`if` フィールドは Claude Code hook 仕様にないため silently ignored されていた。  
その結果、スクリプトは `git commit` かどうかを判定せず、main ブランチ上ではあらゆる Bash 実行をブロックしていた。

Closes #344

## Test plan

- [ ] main ブランチ上で `ls` / `echo` / `gh issue list` などの Bash コマンドがブロックされないこと（手動確認）
- [ ] main ブランチ上で `git commit -m "test"` を実行すると hook がブロックすること（手動確認）
- [ ] main 以外のブランチ上では `git commit` がブロックされないこと（手動確認）

🤖 Generated with [Claude Code](https://claude.ai/code)
