### PR TITLE
feat(viewer): 音声テストタブで操作UIをキャラ画像の上に配置する (#348)

### DIFF
--- a/frontend/src/components/TestPanel.tsx
+++ b/frontend/src/components/TestPanel.tsx
@@ -55,6 +55,13 @@ export function TestPanel({
       hidden={hidden}
       className={charactersEnabled ? "flex h-full flex-col gap-4" : "mt-2"}
     >
+      <TestControls
+        speakers={speakers}
+        selectedSpeakerId={selectedSpeakerId}
+        onSpeakerChange={onSpeakerChange}
+        onPlay={onPlay}
+        error={error}
+      />
       {charactersEnabled && (
         <div className="flex min-h-0 flex-1 items-center justify-center rounded-md bg-ctp-surface p-4">
           {matchedCharacter ? (
@@ -71,13 +78,6 @@ export function TestPanel({
           )}
         </div>
       )}
-      <TestControls
-        speakers={speakers}
-        selectedSpeakerId={selectedSpeakerId}
-        onSpeakerChange={onSpeakerChange}
-        onPlay={onPlay}
-        error={error}
-      />
     </section>
   );
 }


### PR DESCRIPTION
## 概要

音声テストタブのレイアウトを改善し、操作UI（TestControls）をキャラ画像（LipSyncImage）の上に配置しました。これにより、スクロール不要で操作UIに到達できるようになりました。

## 変更内容

- `TestPanel.tsx` の JSX 内で、TestControls と LipSyncImage の表示順を入れ替え
- TestControls をタブの直下に配置
- LipSyncImage を TestControls の下に配置（flex-1 で残り領域を埋める）

## 検証

- ✅ 全ユニットテスト（100/100）が合格
- ✅ TestPanel テスト（6/6）が合格
- ✅ `charactersEnabled=false` の場合の表示に変更なし
- ✅ `charactersEnabled=true` の場合、操作UI が先に表示され、キャラ画像が残り領域を埋める

## 受け入れ条件

- [x] キャラクター機能有効時に「音声テスト」タブ直下に話者選択と再生ボタンが表示される
- [x] その下にキャラ画像が表示され、残り縦領域を埋める
- [x] キャラクター機能無効時の表示は現状と変わらない
- [x] 既存テストがすべて通る

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)