### PR TITLE
fix(viewer): 同話者スタイル変更時の別キャラ扱い・画像高さ不揃い・セリフ長による画像サイズ変動を修正する

### DIFF
--- a/frontend/src/components/CharacterPanel.tsx
+++ b/frontend/src/components/CharacterPanel.tsx
@@ -104,7 +104,7 @@ export function CharacterPanel({
             />
           )
         ) : (
-          <div className="grid h-full w-full grid-cols-4 gap-2">
+          <div className="flex h-full items-end justify-center gap-2">
             {MULTI_SLOT_LAYOUT.map(({ slotIndex, flip }) => {
               const slot = slots[slotIndex];
               const urls = slot ? getCharacterImageUrls(slot.character) : null;
@@ -113,7 +113,7 @@ export function CharacterPanel({
                 : {};
 
               return (
-                <div key={slotIndex} style={wrapperStyle}>
+                <div key={slotIndex} className="h-full" style={wrapperStyle}>
                   {slot && urls ? (
                     <LipSyncImage
                       mouthClosedUrl={urls.closed}
@@ -121,7 +121,7 @@ export function CharacterPanel({
                       volume={isPlayingCharacter(slot.character) ? volume : 0}
                     />
                   ) : (
-                    <div className="h-full w-full" style={placeholderStyle} />
+                    <div className="h-full" style={placeholderStyle} />
                   )}
                 </div>
               );
@@ -130,7 +130,7 @@ export function CharacterPanel({
         )}
       </div>
 
-      <div className="flex max-h-32 min-h-[4rem] shrink-0 items-center overflow-y-auto rounded-md bg-ctp-surface p-4">
+      <div className="flex h-32 shrink-0 items-center overflow-y-auto rounded-md bg-ctp-surface p-4">
         {playingClipData ? (
           <p className="break-words text-lg font-medium text-ctp-text">
             {playingClipData.text}

--- a/frontend/src/components/LipSyncImage.tsx
+++ b/frontend/src/components/LipSyncImage.tsx
@@ -72,17 +72,17 @@ export function LipSyncImage({
   }, [volume, hysteresisMs]);
 
   return (
-    <div className="relative h-full w-full overflow-hidden">
+    <div className="h-full">
       <img
         src={mouthClosedUrl}
         alt="character mouth closed"
-        className="absolute inset-0 h-full w-full object-contain"
+        className="h-full w-auto"
         style={{ display: isOpen ? "none" : "block" }}
       />
       <img
         src={mouthOpenUrl}
         alt="character mouth open"
-        className="absolute inset-0 h-full w-full object-contain"
+        className="h-full w-auto"
         style={{ display: isOpen ? "block" : "none" }}
       />
     </div>

--- a/frontend/src/hooks/useCharacterStage.test.ts
+++ b/frontend/src/hooks/useCharacterStage.test.ts
@@ -444,6 +444,50 @@ describe("useCharacterStage", () => {
     expect(result.current.slots[0]?.character.speakerName).toBe("キャラA");
   });
 
+  it("同一話者がスタイルを変えて発話しても同じスロットを維持し画像が更新される", async () => {
+    const charANormal = makeChar("キャラA", "ノーマル");
+    const charASweet = {
+      ...makeChar("キャラA", "あまあま"),
+      mouthClosed: "キャラA-sweet-closed.png",
+      mouthOpen: "キャラA-sweet-open.png",
+    };
+    const entries: TimelineEntry[] = [
+      makeClipEntry(1, "キャラA", "ノーマル"),
+      makeClipEntry(2, "キャラA", "あまあま"),
+    ];
+    const chars = [charANormal, charASweet];
+
+    const { result, rerender } = renderHook(
+      ({
+        playingClipId,
+        entries,
+        characters,
+      }: {
+        playingClipId: number | null;
+        entries: TimelineEntry[];
+        characters: CharacterEntry[];
+      }) => useCharacterStage(playingClipId, entries, characters),
+      { initialProps: { playingClipId: null, entries, characters: chars } },
+    );
+
+    await act(async () => {
+      rerender({ playingClipId: 1, entries, characters: chars });
+    });
+    expect(result.current.slots[0]?.character).toEqual(charANormal);
+    expect(result.current.isMultiSlot).toBe(false);
+
+    await act(async () => {
+      rerender({ playingClipId: 2, entries, characters: chars });
+    });
+
+    expect(result.current.slots[0]?.character).toEqual(charASweet);
+    expect(result.current.slots[1]).toBeNull();
+    expect(result.current.slots[2]).toBeNull();
+    expect(result.current.slots[3]).toBeNull();
+    // スタイル変更だけでは2人目入場にならないため
+    expect(result.current.isMultiSlot).toBe(false);
+  });
+
   it("キャラクター設定に存在しないスピーカーは無視される", async () => {
     const charA = makeChar("キャラA");
     const entries: TimelineEntry[] = [makeClipEntry(1, "存在しないキャラ")];

--- a/frontend/src/hooks/useCharacterStage.ts
+++ b/frontend/src/hooks/useCharacterStage.ts
@@ -29,8 +29,8 @@ const SLOT_PRIORITY: SlotIndex[] = [0, 1, 2, 3];
 const OTHER_CLIPS_LIMIT = 5;
 export const QUEUE_EMPTY_MS = 15_000;
 
-function charKey(speakerName: string, styleName: string): string {
-  return `${speakerName}\0${styleName}`;
+function charKey(speakerName: string): string {
+  return speakerName;
 }
 
 function availableSlot(chars: StageChar[]): SlotIndex {
@@ -46,8 +46,7 @@ function stageReducer(state: StageState, action: StageAction): StageState {
       if (action.completedCharKey !== null) {
         chars = chars
           .map((c) =>
-            charKey(c.character.speakerName, c.character.styleName) ===
-            action.completedCharKey
+            charKey(c.character.speakerName) === action.completedCharKey
               ? c
               : { ...c, otherClipsCount: c.otherClipsCount + 1 },
           )
@@ -56,14 +55,14 @@ function stageReducer(state: StageState, action: StageAction): StageState {
 
       if (action.startedCharKey !== null && action.startedCharacter !== null) {
         const existingIdx = chars.findIndex(
-          (c) =>
-            charKey(c.character.speakerName, c.character.styleName) ===
-            action.startedCharKey,
+          (c) => charKey(c.character.speakerName) === action.startedCharKey,
         );
 
         if (existingIdx >= 0) {
           chars = chars.map((c, i) =>
-            i === existingIdx ? { ...c, otherClipsCount: 0 } : c,
+            i === existingIdx
+              ? { ...c, character: action.startedCharacter!, otherClipsCount: 0 }
+              : c,
           );
         } else {
           let updated = [...chars];
@@ -145,7 +144,7 @@ export function useCharacterStage(
     if (prev !== null) {
       const e = entries.find((e) => e.kind === "clip" && e.id === prev);
       if (e?.kind === "clip") {
-        completedCharKey = charKey(e.speakerName, e.styleName);
+        completedCharKey = charKey(e.speakerName);
       }
     }
 
@@ -156,7 +155,7 @@ export function useCharacterStage(
     if (curr !== null) {
       const e = entries.find((e) => e.kind === "clip" && e.id === curr);
       if (e?.kind === "clip") {
-        startedCharKey = charKey(e.speakerName, e.styleName);
+        startedCharKey = charKey(e.speakerName);
         startedCharacter =
           characters.find(
             (c) =>


### PR DESCRIPTION
## Summary

- **バグ1**: `charKey` を `speakerName` のみで構成するよう変更し、同一話者がスタイルを変更しても同一スロットを維持・画像を差し替えるよう修正
- **バグ2**: マルチスロットのレイアウトを `grid-cols-4` から横並び flex に変更し、`LipSyncImage` を `h-full w-auto` ベースに変更。画像高さが常に揃うようになった
- **バグ3**: セリフエリアの高さを `min-h-[4rem]`〜`max-h-32` の可変から固定 `h-32` に変更し、セリフ長による画像サイズ変動を解消

Closes #352

## Test plan

- [ ] `npm run test:unit` が全件通過することを確認済み（113 tests passed）
- [ ] `npm run typecheck` が通過することを確認済み
- [ ] 同一話者スタイル変更シナリオのテストを追加
- [ ] VOICEVOX接続環境での目視確認は手動で行うこと
  - 同一話者のスタイルを変えながら再生し、スロットが1つのまま維持されることを確認
  - 複数キャラ表示時に画像高さが揃っていることを確認
  - セリフが長くても画像サイズが変わらないことを確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)
