### PR TITLE
fix(viewer): useAudioVolumeをApp.tsxに一元化してAudioContext二重接続を修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { type TabName, Tabs } from "./components/Tabs";
 import { TestPanel } from "./components/TestPanel";
 import { CharacterPanel } from "./components/CharacterPanel";
 import { VolumeControls } from "./components/VolumeControls";
+import { useAudioVolume } from "./hooks/useAudioVolume";
 import { useEventSource } from "./hooks/useEventSource";
 import { usePersistedState } from "./hooks/usePersistedState";
 import { usePlaybackQueue } from "./hooks/usePlaybackQueue";
@@ -126,6 +127,11 @@ export function App() {
   const { playingClipId, enqueue } = usePlaybackQueue(
     audioRef,
     activeTab === "stream" || activeTab === "character",
+  );
+  const audioVolume = useAudioVolume(
+    audioRef,
+    activeTab === "character" ||
+      (activeTab === "test" && charactersEnabled),
   );
   const playingClipIdRef = useRef<number | null>(null);
   playingClipIdRef.current = playingClipId;
@@ -353,7 +359,7 @@ export function App() {
             characters={characters}
             playingClipId={playingClipId}
             entries={entries}
-            audioRef={audioRef}
+            volume={audioVolume}
           />
         )}
         {!silent && (
@@ -366,7 +372,7 @@ export function App() {
             error={testError}
             charactersEnabled={charactersEnabled}
             characters={characters}
-            audioRef={audioRef}
+            volume={audioVolume}
           />
         )}
       </div>

--- a/frontend/src/components/CharacterPanel.tsx
+++ b/frontend/src/components/CharacterPanel.tsx
@@ -1,6 +1,5 @@
 import type { CharacterEntry, TimelineEntry } from "../types/api";
 import { LipSyncImage } from "./LipSyncImage";
-import { useAudioVolume } from "../hooks/useAudioVolume";
 import { useCharacterStage } from "../hooks/useCharacterStage";
 
 interface CharacterPanelProps {
@@ -8,7 +7,7 @@ interface CharacterPanelProps {
   characters: CharacterEntry[];
   playingClipId: number | null;
   entries: TimelineEntry[];
-  audioRef: React.RefObject<HTMLAudioElement>;
+  volume: number;
 }
 
 const MULTI_SLOT_LAYOUT = [
@@ -42,9 +41,8 @@ export function CharacterPanel({
   characters,
   playingClipId,
   entries,
-  audioRef,
+  volume,
 }: CharacterPanelProps) {
-  const volume = useAudioVolume(audioRef, !hidden);
   const { slots, isMultiSlot } = useCharacterStage(
     playingClipId,
     entries,

--- a/frontend/src/components/TestPanel.test.tsx
+++ b/frontend/src/components/TestPanel.test.tsx
@@ -1,12 +1,7 @@
-import { createRef } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { Speaker, CharacterEntry } from "../types/api";
 import { TestPanel } from "./TestPanel";
-
-vi.mock("../hooks/useAudioVolume", () => ({
-  useAudioVolume: vi.fn(() => 0),
-}));
 
 describe("TestPanel", () => {
   const mockSpeakers: Speaker[] = [
@@ -19,8 +14,6 @@ describe("TestPanel", () => {
     onPlay: vi.fn(),
   };
 
-  const mockAudioRef = createRef<HTMLAudioElement>();
-
   const baseProps = {
     speakers: mockSpeakers,
     selectedSpeakerId: "1",
@@ -29,7 +22,7 @@ describe("TestPanel", () => {
     error: "",
     charactersEnabled: false,
     characters: [] as CharacterEntry[],
-    audioRef: mockAudioRef,
+    volume: 0,
   };
 
   it("hidden=false で表示される", () => {

--- a/frontend/src/components/TestPanel.tsx
+++ b/frontend/src/components/TestPanel.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import type { Speaker, CharacterEntry } from "../types/api";
 import { TestControls } from "./TestControls";
 import { LipSyncImage } from "./LipSyncImage";
-import { useAudioVolume } from "../hooks/useAudioVolume";
 
 interface TestPanelProps {
   hidden: boolean;
@@ -13,7 +12,7 @@ interface TestPanelProps {
   error: string;
   charactersEnabled: boolean;
   characters: CharacterEntry[];
-  audioRef: React.RefObject<HTMLAudioElement>;
+  volume: number;
 }
 
 export function TestPanel({
@@ -25,9 +24,8 @@ export function TestPanel({
   error,
   charactersEnabled,
   characters,
-  audioRef,
+  volume,
 }: TestPanelProps) {
-  const volume = useAudioVolume(audioRef, !hidden && charactersEnabled);
 
   const selectedSpeaker = useMemo(
     () => speakers.find((s) => s.id === Number(selectedSpeakerId)) ?? null,


### PR DESCRIPTION
## Summary

AudioContextの二重接続エラーを修正します。

### 問題
CharacterPanelとTestPanelがそれぞれ別のhookインスタンスで同じaudio要素に対してMediaElementSourceを作成しようとしていたため、Web Audio APIが`InvalidStateError`を投げていました。

### 修正内容
`useAudioVolume`をApp.tsxで一元的に呼び出すことで、AudioContextとMediaElementSourceの作成を唯一無二の状態に統一しました。

- App.tsx: `useAudioVolume`を import して一元管理
- CharacterPanel: audioRef prop削除、volume prop追加
- TestPanel: audioRef prop削除、volume prop追加
- TestPanel.test.tsx: mock削除、テスト更新

## Test plan

- [ ] 音声テストタブを開き「テスト再生」をクリック
- [ ] キャラタブに切り替え（エラーが発生しないことを確認）
- [ ] タブを複数回往復（一貫してエラーなし）
- [ ] npm run test:unit で全テスト通過を確認
- [ ] npm run typecheck でエラーなし

Closes #353

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)