### PR TITLE
feat(entity): vox-actor-assets.json/speaker.json のスキーマと読み込み実装

### DIFF
--- a/internal/domain/entity/assets.go
+++ b/internal/domain/entity/assets.go
@@ -1,0 +1,35 @@
+package entity
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// AssetsJSON は vox-actor-assets.json のトップレベル構造を表す。
+type AssetsJSON struct {
+	Assets map[string]AssetEntry `json:"assets"`
+}
+
+// AssetEntry は assets マップの各エントリを表す。
+type AssetEntry struct {
+	Path string `json:"path"`
+}
+
+// ParseAssetsJSON は JSON バイト列を AssetsJSON にパースする。
+func ParseAssetsJSON(data []byte) (*AssetsJSON, error) {
+	var a AssetsJSON
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, fmt.Errorf("failed to parse assets JSON: %w", err)
+	}
+	return &a, nil
+}
+
+// Validate は AssetsJSON の必須フィールドを検証する。
+func (a *AssetsJSON) Validate() error {
+	for name, entry := range a.Assets {
+		if entry.Path == "" {
+			return fmt.Errorf("assets[%q].path is required", name)
+		}
+	}
+	return nil
+}

--- a/internal/domain/entity/assets_test.go
+++ b/internal/domain/entity/assets_test.go
@@ -1,0 +1,66 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+func TestParseAssetsJSON_Valid(t *testing.T) {
+	input := `{
+		"assets": {
+			"zundamon": { "path": "groups/zundamon" },
+			"metan":    { "path": "groups/metan" }
+		}
+	}`
+
+	got, err := entity.ParseAssetsJSON([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Assets) != 2 {
+		t.Fatalf("len(Assets) = %d, want 2", len(got.Assets))
+	}
+	if got.Assets["zundamon"].Path != "groups/zundamon" {
+		t.Errorf(`Assets["zundamon"].Path = %q, want "groups/zundamon"`, got.Assets["zundamon"].Path)
+	}
+	if got.Assets["metan"].Path != "groups/metan" {
+		t.Errorf(`Assets["metan"].Path = %q, want "groups/metan"`, got.Assets["metan"].Path)
+	}
+}
+
+func TestParseAssetsJSON_InvalidJSON(t *testing.T) {
+	_, err := entity.ParseAssetsJSON([]byte(`{invalid}`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestValidateAssetsJSON_Valid(t *testing.T) {
+	a := &entity.AssetsJSON{
+		Assets: map[string]entity.AssetEntry{
+			"zundamon": {Path: "groups/zundamon"},
+		},
+	}
+	if err := a.Validate(); err != nil {
+		t.Errorf("unexpected validation error: %v", err)
+	}
+}
+
+func TestValidateAssetsJSON_EmptyAssets(t *testing.T) {
+	a := &entity.AssetsJSON{Assets: map[string]entity.AssetEntry{}}
+	if err := a.Validate(); err != nil {
+		t.Errorf("empty assets should be valid: %v", err)
+	}
+}
+
+func TestValidateAssetsJSON_MissingPath(t *testing.T) {
+	a := &entity.AssetsJSON{
+		Assets: map[string]entity.AssetEntry{
+			"zundamon": {Path: ""},
+		},
+	}
+	if err := a.Validate(); err == nil {
+		t.Error("expected validation error for missing path, got nil")
+	}
+}

--- a/internal/domain/entity/speaker_json.go
+++ b/internal/domain/entity/speaker_json.go
@@ -1,0 +1,47 @@
+package entity
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// SpeakerJSON は speaker.json のトップレベル構造を表す。
+type SpeakerJSON struct {
+	SpeakerName string           `json:"speakerName"`
+	Styles      []CharacterStyle `json:"styles"`
+}
+
+// CharacterStyle は speaker.json の styles 配列の各要素を表す。
+type CharacterStyle struct {
+	StyleName   string `json:"styleName"`
+	MouthClosed string `json:"mouthClosed"`
+	MouthOpened string `json:"mouthOpened"`
+}
+
+// ParseSpeakerJSON は JSON バイト列を SpeakerJSON にパースする。
+func ParseSpeakerJSON(data []byte) (*SpeakerJSON, error) {
+	var s SpeakerJSON
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("failed to parse speaker JSON: %w", err)
+	}
+	return &s, nil
+}
+
+// Validate は SpeakerJSON の必須フィールドを検証する。
+func (s *SpeakerJSON) Validate() error {
+	if s.SpeakerName == "" {
+		return fmt.Errorf("speakerName is required")
+	}
+	for i, st := range s.Styles {
+		if st.StyleName == "" {
+			return fmt.Errorf("styles[%d].styleName is required", i)
+		}
+		if st.MouthClosed == "" {
+			return fmt.Errorf("styles[%d].mouthClosed is required", i)
+		}
+		if st.MouthOpened == "" {
+			return fmt.Errorf("styles[%d].mouthOpened is required", i)
+		}
+	}
+	return nil
+}

--- a/internal/domain/entity/speaker_json_test.go
+++ b/internal/domain/entity/speaker_json_test.go
@@ -1,0 +1,117 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+func TestParseSpeakerJSON_Valid(t *testing.T) {
+	input := `{
+		"speakerName": "ずんだもん",
+		"styles": [
+			{ "styleName": "ノーマル", "mouthClosed": "normal/close.png", "mouthOpened": "normal/open.png" },
+			{ "styleName": "あまあま", "mouthClosed": "amaama/close.png", "mouthOpened": "amaama/open.png" }
+		]
+	}`
+
+	got, err := entity.ParseSpeakerJSON([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.SpeakerName != "ずんだもん" {
+		t.Errorf("SpeakerName = %q, want %q", got.SpeakerName, "ずんだもん")
+	}
+	if len(got.Styles) != 2 {
+		t.Fatalf("len(Styles) = %d, want 2", len(got.Styles))
+	}
+	if got.Styles[0].StyleName != "ノーマル" {
+		t.Errorf("Styles[0].StyleName = %q, want %q", got.Styles[0].StyleName, "ノーマル")
+	}
+	if got.Styles[0].MouthClosed != "normal/close.png" {
+		t.Errorf("Styles[0].MouthClosed = %q, want %q", got.Styles[0].MouthClosed, "normal/close.png")
+	}
+	if got.Styles[0].MouthOpened != "normal/open.png" {
+		t.Errorf("Styles[0].MouthOpened = %q, want %q", got.Styles[0].MouthOpened, "normal/open.png")
+	}
+}
+
+func TestParseSpeakerJSON_InvalidJSON(t *testing.T) {
+	_, err := entity.ParseSpeakerJSON([]byte(`{invalid}`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestValidateSpeakerJSON_Valid(t *testing.T) {
+	s := &entity.SpeakerJSON{
+		SpeakerName: "ずんだもん",
+		Styles: []entity.CharacterStyle{
+			{StyleName: "ノーマル", MouthClosed: "normal/close.png", MouthOpened: "normal/open.png"},
+		},
+	}
+	if err := s.Validate(); err != nil {
+		t.Errorf("unexpected validation error: %v", err)
+	}
+}
+
+func TestValidateSpeakerJSON_MissingSpeakerName(t *testing.T) {
+	s := &entity.SpeakerJSON{
+		SpeakerName: "",
+		Styles: []entity.CharacterStyle{
+			{StyleName: "ノーマル", MouthClosed: "normal/close.png", MouthOpened: "normal/open.png"},
+		},
+	}
+	if err := s.Validate(); err == nil {
+		t.Error("expected validation error for missing speakerName, got nil")
+	}
+}
+
+func TestValidateSpeakerJSON_MissingStyleName(t *testing.T) {
+	s := &entity.SpeakerJSON{
+		SpeakerName: "ずんだもん",
+		Styles: []entity.CharacterStyle{
+			{StyleName: "", MouthClosed: "normal/close.png", MouthOpened: "normal/open.png"},
+		},
+	}
+	if err := s.Validate(); err == nil {
+		t.Error("expected validation error for missing styleName, got nil")
+	}
+}
+
+func TestValidateSpeakerJSON_MissingMouthClosed(t *testing.T) {
+	s := &entity.SpeakerJSON{
+		SpeakerName: "ずんだもん",
+		Styles: []entity.CharacterStyle{
+			{StyleName: "ノーマル", MouthClosed: "", MouthOpened: "normal/open.png"},
+		},
+	}
+	if err := s.Validate(); err == nil {
+		t.Error("expected validation error for missing mouthClosed, got nil")
+	}
+}
+
+func TestValidateSpeakerJSON_MissingMouthOpened(t *testing.T) {
+	s := &entity.SpeakerJSON{
+		SpeakerName: "ずんだもん",
+		Styles: []entity.CharacterStyle{
+			{StyleName: "ノーマル", MouthClosed: "normal/close.png", MouthOpened: ""},
+		},
+	}
+	if err := s.Validate(); err == nil {
+		t.Error("expected validation error for missing mouthOpened, got nil")
+	}
+}
+
+func TestValidateSpeakerJSON_DuplicateStyleName(t *testing.T) {
+	s := &entity.SpeakerJSON{
+		SpeakerName: "ずんだもん",
+		Styles: []entity.CharacterStyle{
+			{StyleName: "ノーマル", MouthClosed: "a/close.png", MouthOpened: "a/open.png"},
+			{StyleName: "ノーマル", MouthClosed: "b/close.png", MouthOpened: "b/open.png"},
+		},
+	}
+	if err := s.Validate(); err != nil {
+		t.Errorf("duplicate styleName should be valid, got error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `vox-actor-assets.json` の Go 型（`AssetsJSON` / `AssetEntry`）・パーサ（`ParseAssetsJSON`）・バリデータ（`Validate`）を追加
- `speaker.json` の Go 型（`SpeakerJSON` / `CharacterStyle`）・パーサ（`ParseSpeakerJSON`）・バリデータ（`Validate`）を追加
- 受け入れ条件6項目すべてに対応する単体テストを追加（TDD）

## Test plan

- [x] `go test ./internal/domain/entity/...` で全テスト PASS 確認済み
- [x] `gofmt -l .` / `golangci-lint run` でコード品質確認済み

Closes #357

---
🤖 Generated with [Claude Code](https://claude.ai/code)
