### PR TITLE
refactor: 画像配置先を .vox-actor/characters から .vox-actor/assets へリネーム

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## Unreleased
+
+### Breaking Changes
+
+#### 画像配置先ディレクトリを `.vox-actor/characters/` から `.vox-actor/assets/` へ変更
+
+キャラクター画像の配置先ディレクトリが変更されました。
+
+**変更前:**
+```
+.vox-actor/
+└── characters/
+    ├── zundamon_closed.png
+    └── zundamon_open.png
+```
+
+**変更後:**
+```
+.vox-actor/
+└── assets/
+    ├── zundamon_closed.png
+    └── zundamon_open.png
+```
+
+**マイグレーション手順:**
+
+既存の `.vox-actor/characters/` ディレクトリを `.vox-actor/assets/` へ移動してください。
+
+```bash
+mv .vox-actor/characters .vox-actor/assets
+```
+
+また、画像配信エンドポイントも変更されています:
+
+- 変更前: `/assets/images/characters/<filename>`
+- 変更後: `/assets/images/<filename>`

--- a/frontend/src/components/CharacterPanel.tsx
+++ b/frontend/src/components/CharacterPanel.tsx
@@ -22,10 +22,10 @@ function getCharacterImageUrls(character: CharacterEntry): {
   open: string;
 } {
   return {
-    closed: `/assets/images/characters/${encodeURIComponent(
+    closed: `/assets/images/${encodeURIComponent(
       character.mouthClosed,
     )}`,
-    open: `/assets/images/characters/${encodeURIComponent(
+    open: `/assets/images/${encodeURIComponent(
       character.mouthOpen,
     )}`,
   };

--- a/frontend/src/components/TestPanel.tsx
+++ b/frontend/src/components/TestPanel.tsx
@@ -63,8 +63,8 @@ export function TestPanel({
         <div className="flex min-h-0 flex-1 items-center justify-center rounded-md bg-ctp-surface p-4">
           {matchedCharacter ? (
             <LipSyncImage
-              mouthClosedUrl={`/assets/images/characters/${encodeURIComponent(matchedCharacter.mouthClosed)}`}
-              mouthOpenUrl={`/assets/images/characters/${encodeURIComponent(matchedCharacter.mouthOpen)}`}
+              mouthClosedUrl={`/assets/images/${encodeURIComponent(matchedCharacter.mouthClosed)}`}
+              mouthOpenUrl={`/assets/images/${encodeURIComponent(matchedCharacter.mouthOpen)}`}
               volume={volume}
             />
           ) : (

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -256,7 +256,7 @@ func (p *HTTPStreamPlayer) Start(_ context.Context) error {
 	mux.HandleFunc("/events", p.handleEvents)
 	mux.HandleFunc("/api/status", p.handleAPIStatus)
 	mux.HandleFunc("/api/characters", p.handleAPICharacters)
-	mux.HandleFunc("/assets/images/characters/", p.handleCharacterImage)
+	mux.HandleFunc("/assets/images/", p.handleCharacterImage)
 	mux.HandleFunc("/test-clip", p.handleTestClip)
 	mux.HandleFunc(clipPathPrefix, p.handleClip)
 
@@ -639,7 +639,7 @@ func loadCharacterSettings(workspacePath string, logger *slog.Logger) ([]charact
 	}
 
 	validEntries := []characterEntry{}
-	charactersDir := filepath.Join(workspacePath, "characters")
+	charactersDir := filepath.Join(workspacePath, "assets")
 
 	for _, entry := range settingsPayload.Characters {
 		if err := validateCharacterEntry(entry, charactersDir); err != nil {
@@ -717,18 +717,18 @@ func (p *HTTPStreamPlayer) handleCharacterImage(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	relPath := strings.TrimPrefix(r.URL.Path, "/assets/images/characters/")
+	relPath := strings.TrimPrefix(r.URL.Path, "/assets/images/")
 	if relPath == r.URL.Path {
 		http.NotFound(w, r)
 		return
 	}
 
-	if err := validateImagePath(relPath, filepath.Join(p.workspacePath, "characters")); err != nil {
+	if err := validateImagePath(relPath, filepath.Join(p.workspacePath, "assets")); err != nil {
 		http.Error(w, "invalid path", http.StatusBadRequest)
 		return
 	}
 
-	fullPath := filepath.Join(p.workspacePath, "characters", relPath)
+	fullPath := filepath.Join(p.workspacePath, "assets", relPath)
 	http.ServeFile(w, r, fullPath)
 }
 

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -639,10 +639,10 @@ func loadCharacterSettings(workspacePath string, logger *slog.Logger) ([]charact
 	}
 
 	validEntries := []characterEntry{}
-	charactersDir := filepath.Join(workspacePath, "assets")
+	assetsDir := filepath.Join(workspacePath, "assets")
 
 	for _, entry := range settingsPayload.Characters {
-		if err := validateCharacterEntry(entry, charactersDir); err != nil {
+		if err := validateCharacterEntry(entry, assetsDir); err != nil {
 			logger.Warn("skipping invalid character entry", "speakerName", entry.SpeakerName, "styleName", entry.StyleName, "error", err)
 			continue
 		}

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -1630,8 +1630,8 @@ func TestHTTPStreamPlayer_ImplementsErrorBroadcaster(t *testing.T) {
 // TODO: 画像パスに `..` を含む場合は該当エントリを無視し enabled=false になる
 // TODO: 画像ファイル不在の場合は該当エントリを無視する
 // TODO: 全エントリが無効な場合は enabled=false を返す
-// TODO: GET /assets/images/characters/<relative-path> が画像ファイルを配信する
-// TODO: GET /assets/images/characters/<relative-path> でパス検証（..や先頭/拒否）
+// TODO: GET /assets/images/<relative-path> が画像ファイルを配信する
+// TODO: GET /assets/images/<relative-path> でパス検証（..や先頭/拒否）
 // TODO: speakerName + styleName が重複する場合はエラー（startup 時）
 // TODO: ミュート中でも画像キャッシュは読み込まれる（lazy load on start）
 


### PR DESCRIPTION
## Summary

- Go: `handleCharacterImage` の HTTP エンドポイントを `/assets/images/characters/` → `/assets/images/` に変更
- Go: 画像ファイルの読み取りパスを `workspacePath/characters` → `workspacePath/assets` に変更
- Go: 変数名 `charactersDir` → `assetsDir` にリネーム（名前と実態を一致）
- Frontend: `CharacterPanel.tsx` / `TestPanel.tsx` の画像 URL を `/assets/images/characters/` → `/assets/images/` に変更
- `CHANGELOG.md` を新規作成し、既存ユーザー向けマイグレーション手順を記載

Closes #358

## Test plan

- [x] `gofmt -l .` 指摘なし
- [x] `golangci-lint run` 指摘なし
- [x] `npm run typecheck` エラーなし
- [ ] `.vox-actor/assets/` に画像ファイルを配置し、viewer 起動後に `/assets/images/<filename>` で画像が配信されることを手動確認（VOICEVOX 環境が必要）

---
🤖 Generated with [Claude Code](https://claude.ai/code)
