### PR TITLE
fix(viewer): キャラタブで再生終了後もセリフ表示を維持する

### DIFF
--- a/frontend/src/components/CharacterPanel.tsx
+++ b/frontend/src/components/CharacterPanel.tsx
@@ -43,7 +43,7 @@ export function CharacterPanel({
   entries,
   volume,
 }: CharacterPanelProps) {
-  const { slots, isMultiSlot } = useCharacterStage(
+  const { slots, isMultiSlot, lastClipText } = useCharacterStage(
     playingClipId,
     entries,
     characters,
@@ -129,9 +129,9 @@ export function CharacterPanel({
       </div>
 
       <div className="flex h-32 shrink-0 items-center overflow-y-auto rounded-md bg-ctp-surface p-4">
-        {playingClipData ? (
+        {lastClipText !== null ? (
           <p className="break-words text-lg font-medium text-ctp-text">
-            {playingClipData.text}
+            {lastClipText}
           </p>
         ) : (
           <p className="text-ctp-subtext">

--- a/frontend/src/hooks/useCharacterStage.test.ts
+++ b/frontend/src/hooks/useCharacterStage.test.ts
@@ -512,4 +512,184 @@ describe("useCharacterStage", () => {
 
     expect(result.current.slots).toEqual([null, null, null, null]);
   });
+
+  describe("lastClipText", () => {
+    it("初期状態ではlastClipTextがnull", () => {
+      const { result } = renderHook(() => useCharacterStage(null, [], []));
+      expect(result.current.lastClipText).toBeNull();
+    });
+
+    it("クリップ再生開始でlastClipTextが更新される", async () => {
+      const charA = makeChar("キャラA");
+      const entry1 = makeClipEntry(1, "キャラA");
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipId,
+          entries,
+          characters,
+        }: {
+          playingClipId: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipId, entries, characters),
+        {
+          initialProps: {
+            playingClipId: null,
+            entries: [entry1],
+            characters: [charA],
+          },
+        },
+      );
+
+      await act(async () => {
+        rerender({ playingClipId: 1, entries: [entry1], characters: [charA] });
+      });
+
+      expect(result.current.lastClipText).toBe("text 1");
+    });
+
+    it("クリップ再生終了後もlastClipTextが保持される", async () => {
+      const charA = makeChar("キャラA");
+      const entry1 = makeClipEntry(1, "キャラA");
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipId,
+          entries,
+          characters,
+        }: {
+          playingClipId: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipId, entries, characters),
+        {
+          initialProps: {
+            playingClipId: null,
+            entries: [entry1],
+            characters: [charA],
+          },
+        },
+      );
+
+      await act(async () => {
+        rerender({ playingClipId: 1, entries: [entry1], characters: [charA] });
+      });
+      await act(async () => {
+        rerender({
+          playingClipId: null,
+          entries: [entry1],
+          characters: [charA],
+        });
+      });
+
+      expect(result.current.lastClipText).toBe("text 1");
+    });
+
+    it("次のクリップ再生開始でlastClipTextが切り替わる", async () => {
+      const charA = makeChar("キャラA");
+      const charB = makeChar("キャラB");
+      const entries = [makeClipEntry(1, "キャラA"), makeClipEntry(2, "キャラB")];
+      const chars = [charA, charB];
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipId,
+          entries,
+          characters,
+        }: {
+          playingClipId: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipId, entries, characters),
+        { initialProps: { playingClipId: null, entries, characters: chars } },
+      );
+
+      await act(async () => {
+        rerender({ playingClipId: 1, entries, characters: chars });
+      });
+      expect(result.current.lastClipText).toBe("text 1");
+
+      await act(async () => {
+        rerender({ playingClipId: 2, entries, characters: chars });
+      });
+      expect(result.current.lastClipText).toBe("text 2");
+    });
+
+    it("ALL_EXIT後にlastClipTextがnullになる", async () => {
+      const charA = makeChar("キャラA");
+      const entry1 = makeClipEntry(1, "キャラA");
+      const chars = [charA];
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipId,
+          entries,
+          characters,
+        }: {
+          playingClipId: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipId, entries, characters),
+        {
+          initialProps: {
+            playingClipId: null,
+            entries: [entry1],
+            characters: chars,
+          },
+        },
+      );
+
+      await act(async () => {
+        rerender({ playingClipId: 1, entries: [entry1], characters: chars });
+      });
+      await act(async () => {
+        rerender({ playingClipId: null, entries: [entry1], characters: chars });
+      });
+      expect(result.current.lastClipText).toBe("text 1");
+
+      await act(async () => {
+        vi.advanceTimersByTime(QUEUE_EMPTY_MS);
+      });
+      expect(result.current.lastClipText).toBeNull();
+    });
+
+    it("話者本人がステージを退場してもlastClipTextが保持される", async () => {
+      const charA = makeChar("キャラA");
+      const charB = makeChar("キャラB");
+      // charA speaks clip 1, then charB speaks clips 2-7 to evict charA
+      const entries: TimelineEntry[] = [
+        makeClipEntry(1, "キャラA"),
+        ...Array.from({ length: 7 }, (_, i) => makeClipEntry(i + 2, "キャラB")),
+      ];
+      const chars = [charA, charB];
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipId,
+          entries,
+          characters,
+        }: {
+          playingClipId: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipId, entries, characters),
+        { initialProps: { playingClipId: null, entries, characters: chars } },
+      );
+
+      await act(async () => {
+        rerender({ playingClipId: 1, entries, characters: chars });
+      });
+      // charB speaks clips 2-7 (charA gets evicted after 5 charB clips)
+      for (let id = 2; id <= 7; id++) {
+        await act(async () => {
+          rerender({ playingClipId: id, entries, characters: chars });
+        });
+      }
+
+      // charA was evicted from stage but lastClipText still holds the last played text
+      expect(result.current.slots[0]).toBeNull(); // charA evicted
+      expect(result.current.lastClipText).toBe("text 7"); // last played clip
+    });
+  });
 });

--- a/frontend/src/hooks/useCharacterStage.ts
+++ b/frontend/src/hooks/useCharacterStage.ts
@@ -13,6 +13,7 @@ interface StageChar {
 interface StageState {
   chars: StageChar[];
   isMultiSlot: boolean;
+  lastClipText: string | null;
 }
 
 type StageAction =
@@ -22,6 +23,7 @@ type StageAction =
       startedCharKey: string | null;
       startedCharacter: CharacterEntry | null;
       startedEntryOrder: number;
+      startedClipText: string | null;
     }
   | { type: "ALL_EXIT" };
 
@@ -94,11 +96,16 @@ function stageReducer(state: StageState, action: StageAction): StageState {
       const isMultiSlot =
         chars.length === 0 ? false : state.isMultiSlot || chars.length >= 2;
 
-      return { chars, isMultiSlot };
+      const lastClipText =
+        action.startedClipText !== null
+          ? action.startedClipText
+          : state.lastClipText;
+
+      return { chars, isMultiSlot, lastClipText };
     }
 
     case "ALL_EXIT":
-      return { chars: [], isMultiSlot: false };
+      return { chars: [], isMultiSlot: false, lastClipText: null };
 
     default:
       return state;
@@ -112,6 +119,7 @@ export interface CharacterStageSlot {
 export interface CharacterStageResult {
   slots: (CharacterStageSlot | null)[];
   isMultiSlot: boolean;
+  lastClipText: string | null;
 }
 
 export function useCharacterStage(
@@ -122,6 +130,7 @@ export function useCharacterStage(
   const [state, dispatch] = useReducer(stageReducer, {
     chars: [],
     isMultiSlot: false,
+    lastClipText: null,
   });
 
   const prevPlayingClipIdRef = useRef<number | null>(null);
@@ -150,12 +159,14 @@ export function useCharacterStage(
 
     let startedCharKey: string | null = null;
     let startedCharacter: CharacterEntry | null = null;
+    let startedClipText: string | null = null;
     const startedEntryOrder = entryCounterRef.current;
 
     if (curr !== null) {
       const e = entries.find((e) => e.kind === "clip" && e.id === curr);
       if (e?.kind === "clip") {
         startedCharKey = charKey(e.speakerName);
+        startedClipText = e.text;
         startedCharacter =
           characters.find(
             (c) =>
@@ -173,6 +184,7 @@ export function useCharacterStage(
       startedCharKey,
       startedCharacter,
       startedEntryOrder,
+      startedClipText,
     });
 
     if (curr === null && prev !== null) {
@@ -196,5 +208,9 @@ export function useCharacterStage(
     slots[c.slotIndex] = { character: c.character };
   }
 
-  return { slots, isMultiSlot: state.isMultiSlot };
+  return {
+    slots,
+    isMultiSlot: state.isMultiSlot,
+    lastClipText: state.lastClipText,
+  };
 }

--- a/frontend/src/hooks/useCharacterStage.ts
+++ b/frontend/src/hooks/useCharacterStage.ts
@@ -96,10 +96,7 @@ function stageReducer(state: StageState, action: StageAction): StageState {
       const isMultiSlot =
         chars.length === 0 ? false : state.isMultiSlot || chars.length >= 2;
 
-      const lastClipText =
-        action.startedClipText !== null
-          ? action.startedClipText
-          : state.lastClipText;
+      const lastClipText = action.startedClipText ?? state.lastClipText;
 
       return { chars, isMultiSlot, lastClipText };
     }


### PR DESCRIPTION
## Summary

- `useCharacterStage` フックの内部状態に `lastClipText: string | null` を追加
- クリップ再生開始時に `lastClipText` を更新し、再生終了後もステージにキャラが残る間は値を保持
- `ALL_EXIT`（`QUEUE_EMPTY_MS` 経過でステージ全員退場）のタイミングで `lastClipText` をクリア
- `CharacterPanel` のセリフ表示を `playingClipData.text` から `lastClipText` に切り替え

## Test plan

- [x] `useCharacterStage.test.ts` に `lastClipText` の動作を検証する 6 テストを追加（全 19 テスト通過）
  - 初期状態で `null`
  - クリップ再生開始で更新される
  - 再生終了後も保持される
  - 次のクリップ再生開始で切り替わる
  - `ALL_EXIT` 後に `null` になる
  - 話者本人がステージを退場しても保持される
- [x] `npm run typecheck` 通過
- [x] `npm run test:unit` 全 119 テスト通過
- [ ] VOICEVOX エンジン起動環境での手動確認（外部サービス接続必要）
  - クリップ再生後にステージにキャラが残っている間、セリフが表示され続けること
  - 15 秒経過後にプレースホルダー文に戻ること

Closes #361

---
🤖 Generated with [Claude Code](https://claude.ai/code)
