### PR TITLE
feat: vox-actor assets download コマンドを実装する (#360)

### DIFF
--- a/cmd/assets.go
+++ b/cmd/assets.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func makeAssetsCmd(deps *AssetsDownloadDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "assets",
+		Short: "アセット管理コマンド",
+		Long:  "キャラクター画像などのアセットを管理するサブコマンド群。",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(makeAssetsDownloadCmd(deps))
+	return cmd
+}

--- a/cmd/assets_download.go
+++ b/cmd/assets_download.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/spf13/cobra"
+)
+
+// AssetsDownloadDeps はassets downloadコマンドの依存を保持する。
+type AssetsDownloadDeps struct {
+	Cloner app.GitCloner
+	// AssetsDirFunc はアセットの配置先ルートディレクトリを返す。nil の場合はワークスペース解決を使う。
+	AssetsDirFunc func() (string, error)
+}
+
+func makeAssetsDownloadCmd(deps *AssetsDownloadDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download <repo-url>",
+		Short: "git リポジトリからキャラクター画像をダウンロードする",
+		Long:  "指定した git リポジトリから vox-actor-assets.json を読み取り、キャラクター画像を .vox-actor/assets/ へコピーする。",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return fmt.Errorf("%w: %s", ErrUsage, err)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAssetsDownload(cmd, args, deps)
+		},
+	}
+
+	cmd.Flags().StringArray("speaker", nil, "ダウンロード対象の speaker 名（リピート可、カンマ区切り可）")
+	cmd.Flags().Bool("force", false, "ローカルに同名 speaker が存在する場合に上書き")
+
+	return cmd
+}
+
+func runAssetsDownload(cmd *cobra.Command, args []string, deps *AssetsDownloadDeps) error {
+	if deps == nil || deps.Cloner == nil {
+		return fmt.Errorf("assets download command dependencies are not initialized")
+	}
+
+	repoURL := args[0]
+
+	speakerRaw, _ := cmd.Flags().GetStringArray("speaker")
+	speakers := splitSpeakers(speakerRaw)
+
+	force, _ := cmd.Flags().GetBool("force")
+
+	assetsDir, err := resolveAssetsDir(deps)
+	if err != nil {
+		return err
+	}
+
+	logger := buildLoggerFromFlags(cmd)
+
+	uc := app.NewAssetsDownloadUsecase(deps.Cloner, app.WithAssetsDownloadLogger(logger))
+	return uc.Run(cmd.Context(), app.AssetsDownloadParams{
+		RepoURL:   repoURL,
+		Speakers:  speakers,
+		Force:     force,
+		AssetsDir: assetsDir,
+	})
+}
+
+// splitSpeakers はカンマ区切りを含む speaker 文字列スライスを個々の speaker 名に展開する。
+func splitSpeakers(raw []string) []string {
+	var result []string
+	for _, s := range raw {
+		for _, name := range strings.Split(s, ",") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				result = append(result, name)
+			}
+		}
+	}
+	return result
+}
+
+func resolveAssetsDir(deps *AssetsDownloadDeps) (string, error) {
+	if deps.AssetsDirFunc != nil {
+		return deps.AssetsDirFunc()
+	}
+	ws, err := resolveWorkspaceWithFallback()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(ws, ".vox-actor", "assets"), nil
+}

--- a/cmd/assets_download_test.go
+++ b/cmd/assets_download_test.go
@@ -1,0 +1,220 @@
+package cmd
+
+// assets download コマンド テストリスト
+// DONE: assetsサブコマンドがrootに登録されている
+// DONE: downloadサブコマンドがassetsに登録されている
+// DONE: 引数なし（URL未指定）でErrUsageを返す
+// DONE: --speakerフラグが存在する
+// DONE: --forceフラグが存在する（デフォルトfalse）
+// DONE: deps=nilでエラーを返す
+// DONE: --speaker a,b のカンマ区切りが正しく分割される（両speakerがDLされる）
+// DONE: --speaker a --speaker b のリピートが正しく動作する（両speakerがDLされる）
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// testGitCloner はテスト用の GitCloner 実装。
+// Clone 時に指定の vox-actor-assets.json とファイル群を dest に作成する。
+type testGitCloner struct {
+	assetsJSONContent string
+	files             map[string]string
+}
+
+func (c *testGitCloner) Clone(_ context.Context, _ string, destDir string) error {
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return err
+	}
+	if c.assetsJSONContent != "" {
+		if err := os.WriteFile(filepath.Join(destDir, "vox-actor-assets.json"), []byte(c.assetsJSONContent), 0644); err != nil {
+			return err
+		}
+	}
+	for rel, content := range c.files {
+		fullPath := filepath.Join(destDir, rel)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findAssetsDownloadCmdFromRoot(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
+	t.Helper()
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "assets" {
+			for _, sc := range c.Commands() {
+				if sc.Name() == "download" {
+					return sc
+				}
+			}
+		}
+	}
+	t.Fatal("assets download subcommand not found")
+	return nil
+}
+
+func TestAssetsCmd_RegisteredAsSubcommand(t *testing.T) {
+	rootCmd := makeRootCmd()
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "assets" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'assets' subcommand to be registered")
+	}
+}
+
+func TestAssetsDownloadCmd_RegisteredUnderAssets(t *testing.T) {
+	rootCmd := makeRootCmd()
+	_ = findAssetsDownloadCmdFromRoot(t, rootCmd)
+}
+
+func TestAssetsDownloadCmd_NoArgs_ReturnsUsageError(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"assets", "download"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error with no args, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func TestAssetsDownloadCmd_HasSpeakerFlag(t *testing.T) {
+	rootCmd := makeRootCmd()
+	cmd := findAssetsDownloadCmdFromRoot(t, rootCmd)
+	if cmd.Flags().Lookup("speaker") == nil {
+		t.Error("expected --speaker flag to exist")
+	}
+}
+
+func TestAssetsDownloadCmd_HasForceFlag(t *testing.T) {
+	rootCmd := makeRootCmd()
+	cmd := findAssetsDownloadCmdFromRoot(t, rootCmd)
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		t.Fatalf("expected --force flag to exist, got error: %v", err)
+	}
+	if force {
+		t.Error("expected --force default to be false")
+	}
+}
+
+func TestAssetsDownloadCmd_NilDeps_ReturnsError(t *testing.T) {
+	deps := &Deps{
+		Assets: nil,
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"assets", "download", "https://example.com/repo.git"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error with nil AssetsDownloadDeps, got nil")
+	}
+}
+
+func TestAssetsDownloadCmd_CommaSeparatedSpeakers(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	cloner := &testGitCloner{
+		assetsJSONContent: `{"assets": {"a": {"path": "img/a"}, "b": {"path": "img/b"}}}`,
+		files: map[string]string{
+			"img/a/f.png": "data-a",
+			"img/b/f.png": "data-b",
+		},
+	}
+
+	deps := &Deps{
+		Assets: &AssetsDownloadDeps{
+			Cloner:        cloner,
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"assets", "download", "--speaker", "a,b", "https://example.com/repo.git"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	for _, name := range []string{"a", "b"} {
+		if _, err := os.Stat(filepath.Join(assetsDir, name)); err != nil {
+			t.Errorf("expected speaker %q dir to exist, got: %v", name, err)
+		}
+	}
+}
+
+func TestAssetsDownloadCmd_RepeatSpeakerFlag(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	cloner := &testGitCloner{
+		assetsJSONContent: `{"assets": {"a": {"path": "img/a"}, "b": {"path": "img/b"}}}`,
+		files: map[string]string{
+			"img/a/f.png": "data-a",
+			"img/b/f.png": "data-b",
+		},
+	}
+
+	deps := &Deps{
+		Assets: &AssetsDownloadDeps{
+			Cloner:        cloner,
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"assets", "download", "--speaker", "a", "--speaker", "b", "https://example.com/repo.git"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	for _, name := range []string{"a", "b"} {
+		if _, err := os.Stat(filepath.Join(assetsDir, name)); err != nil {
+			t.Errorf("expected speaker %q dir to exist, got: %v", name, err)
+		}
+	}
+}
+
+func TestAssetsDownloadCmd_HelpContainsExpectedFlags(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"assets", "download", "--help"})
+	_ = rootCmd.Execute()
+
+	output := buf.String()
+	for _, flag := range []string{"--speaker", "--force"} {
+		if !strings.Contains(output, flag) {
+			t.Errorf("expected %q in help output, got: %s", flag, output)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ type Deps struct {
 	Say        *SayDeps
 	AudioCheck *AudioCheckDeps
 	Viewer     *ViewerDeps
+	Assets     *AssetsDownloadDeps
 }
 
 func makeRootCmd(deps ...*Deps) *cobra.Command {
@@ -41,11 +42,13 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	var watchDeps *WatchDeps
 	var sayDeps *SayDeps
 	var audioCheckDeps *AudioCheckDeps
+	var assetsDeps *AssetsDownloadDeps
 	if d != nil {
 		actDeps = d.Act
 		watchDeps = d.Watch
 		sayDeps = d.Say
 		audioCheckDeps = d.AudioCheck
+		assetsDeps = d.Assets
 	}
 	var viewerDeps *ViewerDeps
 	if d != nil {
@@ -57,6 +60,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	cmd.AddCommand(makeConfigCmd())
 	cmd.AddCommand(makeAudioCheckCmd(audioCheckDeps))
 	cmd.AddCommand(makeViewerCmd(viewerDeps))
+	cmd.AddCommand(makeAssetsCmd(assetsDeps))
 
 	return cmd
 }

--- a/internal/app/assets_download_usecase.go
+++ b/internal/app/assets_download_usecase.go
@@ -1,0 +1,150 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+// AssetsDownloadParams はassetsダウンロードユースケースのパラメータ。
+type AssetsDownloadParams struct {
+	RepoURL   string
+	Speakers  []string // 空の場合は全asset対象
+	Force     bool
+	AssetsDir string // コピー先のルートディレクトリ（.vox-actor/assets/）
+}
+
+// AssetsDownloadOption はAssetsDownloadUsecaseの生成時オプション。
+type AssetsDownloadOption func(*AssetsDownloadUsecase)
+
+// WithAssetsDownloadLogger はロガーを設定するオプション。
+func WithAssetsDownloadLogger(logger *slog.Logger) AssetsDownloadOption {
+	return func(u *AssetsDownloadUsecase) {
+		if logger != nil {
+			u.logger = logger
+		}
+	}
+}
+
+// AssetsDownloadUsecase はassets downloadサブコマンドのユースケース。
+type AssetsDownloadUsecase struct {
+	cloner GitCloner
+	logger *slog.Logger
+}
+
+// NewAssetsDownloadUsecase は新しいAssetsDownloadUsecaseを生成する。
+func NewAssetsDownloadUsecase(cloner GitCloner, opts ...AssetsDownloadOption) *AssetsDownloadUsecase {
+	u := &AssetsDownloadUsecase{
+		cloner: cloner,
+		logger: discardLogger(),
+	}
+	for _, opt := range opts {
+		opt(u)
+	}
+	return u
+}
+
+// Run はassets downloadユースケースを実行する。
+func (u *AssetsDownloadUsecase) Run(ctx context.Context, params AssetsDownloadParams) error {
+	tmpParent, err := os.MkdirTemp("", "vox-actor-assets-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpParent) }()
+
+	repoDir := filepath.Join(tmpParent, "repo")
+
+	u.logger.Info("cloning repository", "url", params.RepoURL)
+	if err := u.cloner.Clone(ctx, params.RepoURL, repoDir); err != nil {
+		return fmt.Errorf("failed to clone repository: %w", err)
+	}
+
+	assetsJSONPath := filepath.Join(repoDir, "vox-actor-assets.json")
+	data, err := os.ReadFile(assetsJSONPath)
+	if err != nil {
+		return fmt.Errorf("vox-actor-assets.json not found in repository: %w", err)
+	}
+
+	assetsJSON, err := entity.ParseAssetsJSON(data)
+	if err != nil {
+		return err
+	}
+	if err := assetsJSON.Validate(); err != nil {
+		return err
+	}
+
+	targets, err := filterAssets(assetsJSON, params.Speakers)
+	if err != nil {
+		return err
+	}
+
+	for name, entry := range targets {
+		srcPath := filepath.Join(repoDir, entry.Path)
+		destPath := filepath.Join(params.AssetsDir, name)
+
+		if _, err := os.Stat(srcPath); err != nil {
+			return fmt.Errorf("assets[%q].path %q not found in repository", name, entry.Path)
+		}
+
+		if _, err := os.Stat(destPath); err == nil {
+			if !params.Force {
+				return fmt.Errorf("assets[%q] already exists at %s: use --force to overwrite", name, destPath)
+			}
+			if err := os.RemoveAll(destPath); err != nil {
+				return fmt.Errorf("failed to remove existing assets[%q]: %w", name, err)
+			}
+		}
+
+		u.logger.Info("copying asset", "name", name, "src", entry.Path)
+		if err := copyDir(srcPath, destPath); err != nil {
+			return fmt.Errorf("failed to copy assets[%q]: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func filterAssets(assetsJSON *entity.AssetsJSON, speakers []string) (map[string]entity.AssetEntry, error) {
+	if len(speakers) == 0 {
+		return assetsJSON.Assets, nil
+	}
+	result := make(map[string]entity.AssetEntry)
+	for _, name := range speakers {
+		entry, ok := assetsJSON.Assets[name]
+		if !ok {
+			return nil, fmt.Errorf("speaker %q not found in vox-actor-assets.json", name)
+		}
+		result[name] = entry
+	}
+	return result, nil
+}
+
+func copyDir(src, dest string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		destPath := filepath.Join(dest, rel)
+		if d.IsDir() {
+			return os.MkdirAll(destPath, 0755)
+		}
+		return copyFile(path, destPath)
+	})
+}
+
+func copyFile(src, dest string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dest, data, 0644)
+}

--- a/internal/app/assets_download_usecase.go
+++ b/internal/app/assets_download_usecase.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -78,7 +79,7 @@ func (u *AssetsDownloadUsecase) Run(ctx context.Context, params AssetsDownloadPa
 		return err
 	}
 
-	targets, err := filterAssets(assetsJSON, params.Speakers)
+	targets, err := assetsJSON.FilterBySpeakers(params.Speakers)
 	if err != nil {
 		return err
 	}
@@ -109,21 +110,6 @@ func (u *AssetsDownloadUsecase) Run(ctx context.Context, params AssetsDownloadPa
 	return nil
 }
 
-func filterAssets(assetsJSON *entity.AssetsJSON, speakers []string) (map[string]entity.AssetEntry, error) {
-	if len(speakers) == 0 {
-		return assetsJSON.Assets, nil
-	}
-	result := make(map[string]entity.AssetEntry)
-	for _, name := range speakers {
-		entry, ok := assetsJSON.Assets[name]
-		if !ok {
-			return nil, fmt.Errorf("speaker %q not found in vox-actor-assets.json", name)
-		}
-		result[name] = entry
-	}
-	return result, nil
-}
-
 func copyDir(src, dest string) error {
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -142,9 +128,18 @@ func copyDir(src, dest string) error {
 }
 
 func copyFile(src, dest string) error {
-	data, err := os.ReadFile(src)
+	srcFile, err := os.Open(src)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(dest, data, 0644)
+	defer func() { _ = srcFile.Close() }()
+
+	destFile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = destFile.Close() }()
+
+	_, err = io.Copy(destFile, srcFile)
+	return err
 }

--- a/internal/app/assets_download_usecase_test.go
+++ b/internal/app/assets_download_usecase_test.go
@@ -1,0 +1,330 @@
+package app_test
+
+// assets_download_usecase テストリスト
+// DONE: 正常系: 全assetをダウンロードできる
+// DONE: 正常系: --speakerで対象を絞ってダウンロードできる
+// DONE: 正常系: --forceで既存assetを上書きできる
+// DONE: 異常系: --speaker指定でassetが見つからない場合はエラー
+// DONE: 異常系: ローカルに同名assetが存在し--forceなしの場合はエラー
+// DONE: 異常系: vox-actor-assets.jsonが存在しない場合はエラー
+// DONE: 異常系: vox-actor-assets.jsonのJSONパース失敗でエラー
+// DONE: 異常系: asset.pathがリポジトリ内に存在しない場合はエラー
+// DONE: 正常系: ダウンロード後に一時ディレクトリが削除される
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/app"
+)
+
+type fakeGitCloner struct {
+	cloneErr  error
+	setupFunc func(destDir string) error
+}
+
+func (f *fakeGitCloner) Clone(_ context.Context, _ string, destDir string) error {
+	if f.cloneErr != nil {
+		return f.cloneErr
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return err
+	}
+	if f.setupFunc != nil {
+		return f.setupFunc(destDir)
+	}
+	return nil
+}
+
+func setupTestRepo(destDir string, assetsJSONContent string, files map[string]string) error {
+	if err := os.WriteFile(filepath.Join(destDir, "vox-actor-assets.json"), []byte(assetsJSONContent), 0644); err != nil {
+		return err
+	}
+	for relPath, content := range files {
+		fullPath := filepath.Join(destDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestAssetsDownloadUsecase_Run_DownloadsAllAssets(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	cloner := &fakeGitCloner{
+		setupFunc: func(destDir string) error {
+			return setupTestRepo(destDir,
+				`{"assets": {"zundamon": {"path": "images/zundamon"}}}`,
+				map[string]string{
+					"images/zundamon/normal.png": "fake-image-data",
+				})
+		},
+	}
+
+	uc := app.NewAssetsDownloadUsecase(cloner)
+	params := app.AssetsDownloadParams{
+		RepoURL:   "https://example.com/repo.git",
+		AssetsDir: assetsDir,
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	destFile := filepath.Join(assetsDir, "zundamon", "normal.png")
+	data, err := os.ReadFile(destFile)
+	if err != nil {
+		t.Fatalf("expected file at %s, got error: %v", destFile, err)
+	}
+	if string(data) != "fake-image-data" {
+		t.Errorf("expected 'fake-image-data', got: %s", string(data))
+	}
+}
+
+func TestAssetsDownloadUsecase_Run_FiltersBySpeaker(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	cloner := &fakeGitCloner{
+		setupFunc: func(destDir string) error {
+			return setupTestRepo(destDir,
+				`{"assets": {"zundamon": {"path": "images/zundamon"}, "metan": {"path": "images/metan"}}}`,
+				map[string]string{
+					"images/zundamon/normal.png": "zundamon-image",
+					"images/metan/normal.png":    "metan-image",
+				})
+		},
+	}
+
+	uc := app.NewAssetsDownloadUsecase(cloner)
+	params := app.AssetsDownloadParams{
+		RepoURL:   "https://example.com/repo.git",
+		Speakers:  []string{"zundamon"},
+		AssetsDir: assetsDir,
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// zundamon は存在するはず
+	if _, err := os.Stat(filepath.Join(assetsDir, "zundamon")); err != nil {
+		t.Errorf("expected zundamon dir, got error: %v", err)
+	}
+	// metan は存在しないはず
+	if _, err := os.Stat(filepath.Join(assetsDir, "metan")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected metan dir to not exist, got: %v", err)
+	}
+}
+
+func TestAssetsDownloadUsecase_Run_ForceOverwrite(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	// 事前に同名ディレクトリを作成
+	existing := filepath.Join(assetsDir, "zundamon")
+	if err := os.MkdirAll(existing, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(existing, "old.png"), []byte("old-data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cloner := &fakeGitCloner{
+		setupFunc: func(destDir string) error {
+			return setupTestRepo(destDir,
+				`{"assets": {"zundamon": {"path": "images/zundamon"}}}`,
+				map[string]string{
+					"images/zundamon/new.png": "new-data",
+				})
+		},
+	}
+
+	uc := app.NewAssetsDownloadUsecase(cloner)
+	params := app.AssetsDownloadParams{
+		RepoURL:   "https://example.com/repo.git",
+		Force:     true,
+		AssetsDir: assetsDir,
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error with --force, got: %v", err)
+	}
+
+	// 新ファイルが存在する
+	newFile := filepath.Join(assetsDir, "zundamon", "new.png")
+	data, err := os.ReadFile(newFile)
+	if err != nil {
+		t.Fatalf("expected new file at %s, got: %v", newFile, err)
+	}
+	if string(data) != "new-data" {
+		t.Errorf("expected 'new-data', got: %s", string(data))
+	}
+
+	// 古いファイルは存在しない
+	oldFile := filepath.Join(assetsDir, "zundamon", "old.png")
+	if _, err := os.Stat(oldFile); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected old file to be removed, got: %v", err)
+	}
+}
+
+func TestAssetsDownloadUsecase_Run_SpeakerNotFound_Error(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	cloner := &fakeGitCloner{
+		setupFunc: func(destDir string) error {
+			return setupTestRepo(destDir,
+				`{"assets": {"zundamon": {"path": "images/zundamon"}}}`,
+				nil)
+		},
+	}
+
+	uc := app.NewAssetsDownloadUsecase(cloner)
+	params := app.AssetsDownloadParams{
+		RepoURL:   "https://example.com/repo.git",
+		Speakers:  []string{"unknown-speaker"},
+		AssetsDir: assetsDir,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for unknown speaker, got nil")
+	}
+}
+
+func TestAssetsDownloadUsecase_Run_DuplicateWithoutForce_Error(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	// 事前に同名ディレクトリを作成
+	existing := filepath.Join(assetsDir, "zundamon")
+	if err := os.MkdirAll(existing, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cloner := &fakeGitCloner{
+		setupFunc: func(destDir string) error {
+			return setupTestRepo(destDir,
+				`{"assets": {"zundamon": {"path": "images/zundamon"}}}`,
+				map[string]string{
+					"images/zundamon/normal.png": "image-data",
+				})
+		},
+	}
+
+	uc := app.NewAssetsDownloadUsecase(cloner)
+	params := app.AssetsDownloadParams{
+		RepoURL:   "https://example.com/repo.git",
+		AssetsDir: assetsDir,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for duplicate without --force, got nil")
+	}
+}
+
+func TestAssetsDownloadUsecase_Run_AssetsJSONNotFound_Error(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	cloner := &fakeGitCloner{
+		setupFunc: func(destDir string) error {
+			// vox-actor-assets.json を作成しない
+			return nil
+		},
+	}
+
+	uc := app.NewAssetsDownloadUsecase(cloner)
+	params := app.AssetsDownloadParams{
+		RepoURL:   "https://example.com/repo.git",
+		AssetsDir: assetsDir,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error when vox-actor-assets.json not found, got nil")
+	}
+}
+
+func TestAssetsDownloadUsecase_Run_InvalidAssetsJSON_Error(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	cloner := &fakeGitCloner{
+		setupFunc: func(destDir string) error {
+			return os.WriteFile(filepath.Join(destDir, "vox-actor-assets.json"), []byte("invalid json"), 0644)
+		},
+	}
+
+	uc := app.NewAssetsDownloadUsecase(cloner)
+	params := app.AssetsDownloadParams{
+		RepoURL:   "https://example.com/repo.git",
+		AssetsDir: assetsDir,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestAssetsDownloadUsecase_Run_AssetPathNotFound_Error(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	cloner := &fakeGitCloner{
+		setupFunc: func(destDir string) error {
+			// vox-actor-assets.json には path を記載するが実際のディレクトリは作らない
+			return setupTestRepo(destDir,
+				`{"assets": {"zundamon": {"path": "images/zundamon"}}}`,
+				nil)
+		},
+	}
+
+	uc := app.NewAssetsDownloadUsecase(cloner)
+	params := app.AssetsDownloadParams{
+		RepoURL:   "https://example.com/repo.git",
+		AssetsDir: assetsDir,
+	}
+
+	err := uc.Run(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error when asset path not found in repo, got nil")
+	}
+}
+
+func TestAssetsDownloadUsecase_Run_NoGitDirInDest(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	cloner := &fakeGitCloner{
+		setupFunc: func(destDir string) error {
+			// .git ディレクトリを含む偽リポジトリを作成
+			if err := os.MkdirAll(filepath.Join(destDir, ".git"), 0755); err != nil {
+				return err
+			}
+			return setupTestRepo(destDir,
+				`{"assets": {"zundamon": {"path": "images/zundamon"}}}`,
+				map[string]string{
+					"images/zundamon/normal.png": "fake-image",
+				})
+		},
+	}
+
+	uc := app.NewAssetsDownloadUsecase(cloner)
+	params := app.AssetsDownloadParams{
+		RepoURL:   "https://example.com/repo.git",
+		AssetsDir: assetsDir,
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// dest に .git は存在しないはず
+	gitDir := filepath.Join(assetsDir, ".git")
+	if _, err := os.Stat(gitDir); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected no .git in dest, but it exists")
+	}
+}

--- a/internal/app/port.go
+++ b/internal/app/port.go
@@ -38,6 +38,12 @@ type DirWatcher interface {
 	Watch(ctx context.Context, dir string) (<-chan string, <-chan error)
 }
 
+// GitCloner は git リポジトリを clone するインターフェース。
+type GitCloner interface {
+	// Clone は repoURL を destDir へ clone する。destDir は Clone が作成する。
+	Clone(ctx context.Context, repoURL string, destDir string) error
+}
+
 // VoicevoxClient はVOICEVOXエンジンとの通信を抽象化するインターフェース。
 type VoicevoxClient interface {
 	// HealthCheck はエンジンの疎通確認を行う。

--- a/internal/domain/entity/assets.go
+++ b/internal/domain/entity/assets.go
@@ -33,3 +33,21 @@ func (a *AssetsJSON) Validate() error {
 	}
 	return nil
 }
+
+// FilterBySpeakers は speakers で指定した名前の asset エントリのみを返す。
+// speakers が空の場合は全エントリを返す。
+// 存在しない speaker 名が指定された場合はエラーを返す。
+func (a *AssetsJSON) FilterBySpeakers(speakers []string) (map[string]AssetEntry, error) {
+	if len(speakers) == 0 {
+		return a.Assets, nil
+	}
+	result := make(map[string]AssetEntry)
+	for _, name := range speakers {
+		entry, ok := a.Assets[name]
+		if !ok {
+			return nil, fmt.Errorf("speaker %q not found in vox-actor-assets.json", name)
+		}
+		result[name] = entry
+	}
+	return result, nil
+}

--- a/internal/infra/git_cloner.go
+++ b/internal/infra/git_cloner.go
@@ -1,0 +1,20 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// GitCloner は git コマンドを使って git clone を実行する。
+type GitCloner struct{}
+
+// Clone は repoURL を destDir へ git clone --depth=1 で clone する。
+func (g *GitCloner) Clone(ctx context.Context, repoURL string, destDir string) error {
+	cmd := exec.CommandContext(ctx, "git", "clone", "--depth=1", repoURL, destDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git clone failed: %w\n%s", err, out)
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -52,6 +52,9 @@ func main() {
 	}
 
 	deps := &cmd.Deps{
+		Assets: &cmd.AssetsDownloadDeps{
+			Cloner: &infra.GitCloner{},
+		},
 		Act: &cmd.ActDeps{
 			Reader:            reader,
 			ClientFactory:     clientFactory,


### PR DESCRIPTION
## Summary

`vox-actor assets download` サブコマンドを新設し、git リポジトリからキャラクター画像（asset）をダウンロードできるようにしました。

実装により、以下の受け入れ条件をすべて満たしています:

- `vox-actor assets download <url>` で `vox-actor-assets.json` 記載の全 asset をダウンロード可能
- `--speaker zundamon` のように対象を絞ってダウンロード可能
- `--speaker a,b` および `--speaker a --speaker b` の両形式に対応
- ローカル重複時は `--force` なしでエラー、`--force` で上書き
- ダウンロード後に `.git` ディレクトリが残らない（一時ディレクトリは完全削除）
- バリデーションエラー時に適切なエラーメッセージを表示
- `gofmt -l .` / `golangci-lint run` で指摘なし

## Implementation Details

### Layer 構成

- **cmd層**: `assets` 親コマンドと `assets download` サブコマンド、フラグ解析
- **app層**: `AssetsDownloadUsecase` でダウンロードロジックを実装
- **entity層**: `AssetsJSON.FilterBySpeakers()` で speaker 絞り込みロジックを配置
- **infra層**: `GitCloner` で git clone を実行

### 主な実装箇所

1. **GitCloner interface** (port.go): Git 操作を抽象化し、テスト時の mock を容易に
2. **FilterBySpeakers()** (assets.go): entity 層に責務を寄せたメソッド
3. **copyFile()**: 大ファイル対応として io.Copy によるストリーミング方式に
4. **flag 処理**: `--speaker a,b` と `--speaker a --speaker b` の両形式に対応

## Test Coverage

- **usecase 層**: 9 テストケース（全 asset DL、speaker 絞り込み、force 上書き、エラーケース等）
- **cmd 層**: 8 テストケース（コマンド登録、フラグ、引数検証、カンマ区切り、リピート等）
- 全テストが PASS、golangci-lint・gofmt ともに指摘なし

Closes #360

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
