### PR TITLE
chore: .playwright-cli/ を .gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ frontend/dist/*
 frontend/node_modules/
 
 # Playwright
+.playwright-cli/
 frontend/test-results/
 frontend/playwright-report/
 frontend/playwright/.cache/


### PR DESCRIPTION
## 概要

`.playwright-cli/` ディレクトリをルート直下の `.gitignore` に追加します。

`playwright-cli` スキル実行時に生成される以下のファイルをリポジトリから除外します：
- `console-<timestamp>.log` : ブラウザのコンソールログ
- `page-<timestamp>.yml`    : ページの aria スナップショット

これらはローカル開発時のデバッグ用一時出力で、リポジトリで共有する成果物ではありません。

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)