### PR TITLE
fix: block-commit-on-main.sh が stdin 異常時にコミットを素通ししてしまう

### DIFF
--- a/.claude/hooks/block-commit-on-main.sh
+++ b/.claude/hooks/block-commit-on-main.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 # PreToolUse hook: block `git commit` when current branch is main
 
-command=$(jq -r '.tool_input.command // ""' 2>/dev/null)
+set -eu
+
+input=$(cat)
+if [ -z "$input" ]; then
+  printf 'Error: hook に stdin が渡されていません。\n' >&2
+  exit 2
+fi
+
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 
 case "$command" in
   "git commit"*) ;;


### PR DESCRIPTION
## Summary

stdin が渡されない、または JSON が不正な場合に、hook スクリプトがコミットをブロックできないバグを修正しました。

## Changes

- stdin を先に `cat` で読み取り、空の場合は非0終了（exit 2）する
- `jq` エラーを抑制しない（`2>/dev/null` を削除）して、エラーメッセージを表示
- `set -eu` を追加してシェルスクリプトの安全性を向上

## Verification

✅ stdin 空時に exit 2
✅ 不正 JSON 時に jq エラー出力＋非0終了
✅ git commit 以外は exit 0（素通り）
✅ main ブランチで git commit は exit 2（ブロック）
✅ shellcheck で指摘なし

---
🤖 Generated with [Claude Code](https://claude.ai/code)
