### PR TITLE
fix: image file not found エラーに絶対パスを表示する

### DIFF
--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -607,7 +607,7 @@ func (p *HTTPStreamPlayer) buildAPICharactersJSON() error {
 
 	if p.workspacePath != "" {
 		fsys := os.DirFS(p.workspacePath)
-		loadedEntries, loadErr := loadCharacterSettingsFromSpeakerJSON(fsys, workspaceAssetsDir, p.logger)
+		loadedEntries, loadErr := loadCharacterSettingsFromSpeakerJSON(fsys, p.workspacePath, workspaceAssetsDir, p.logger)
 		if loadErr != nil {
 			p.logger.Warn("failed to load character settings",
 				"workspacePath", p.workspacePath,
@@ -634,7 +634,7 @@ func (p *HTTPStreamPlayer) buildAPICharactersJSON() error {
 // loadCharacterSettingsFromSpeakerJSON はfsys内のassetsDir/*/speaker.jsonを走査し、
 // キャラクター設定を読み込む。JSON パース失敗、画像不在、パス検証エラーなどで
 // 無効なエントリは自動的に除外される。有効なエントリが 0 件の場合はエラーを返す。
-func loadCharacterSettingsFromSpeakerJSON(fsys fs.FS, assetsDir string, logger *slog.Logger) ([]characterEntry, error) {
+func loadCharacterSettingsFromSpeakerJSON(fsys fs.FS, basePath string, assetsDir string, logger *slog.Logger) ([]characterEntry, error) {
 	entries := []characterEntry{}
 
 	assetsDirFS, err := fs.Sub(fsys, assetsDir)
@@ -681,7 +681,8 @@ func loadCharacterSettingsFromSpeakerJSON(fsys fs.FS, assetsDir string, logger *
 				MouthOpen:   style.MouthOpened,
 			}
 
-			if err := validateCharacterEntryInFS(entry, assetsDirFS); err != nil {
+			baseDir := filepath.Join(basePath, assetsDir)
+			if err := validateCharacterEntryInFS(entry, assetsDirFS, baseDir); err != nil {
 				logger.Warn("skipping invalid character entry", "speakerName", entry.SpeakerName, "styleName", entry.StyleName, "error", err)
 				continue
 			}
@@ -700,12 +701,12 @@ func loadCharacterSettingsFromSpeakerJSON(fsys fs.FS, assetsDir string, logger *
 // validateCharacterEntryInFS は単一のキャラクター設定を fs.FS に対して検証する。
 // パス検証: .. や先頭 / を含む、セグメントが [A-Za-z0-9._-]+ 以外を含む場合はエラー。
 // 画像ファイル存在確認。
-func validateCharacterEntryInFS(entry characterEntry, fsys fs.FS) error {
+func validateCharacterEntryInFS(entry characterEntry, fsys fs.FS, baseDir string) error {
 	for _, imgPath := range []string{entry.MouthClosed, entry.MouthOpen} {
 		if imgPath == "" {
 			return fmt.Errorf("image path is empty")
 		}
-		if err := validateImagePathInFS(imgPath, fsys); err != nil {
+		if err := validateImagePathInFS(imgPath, fsys, baseDir); err != nil {
 			return err
 		}
 	}
@@ -715,7 +716,7 @@ func validateCharacterEntryInFS(entry characterEntry, fsys fs.FS) error {
 // validateImagePathInFS は相対パスの検証と fs.FS に対する存在確認を行う。
 // パストラバーサル (..を含む、/で始まる) を拒否し、
 // 各セグメントが [A-Za-z0-9._-]+ にマッチするか確認する。
-func validateImagePathInFS(relPath string, fsys fs.FS) error {
+func validateImagePathInFS(relPath string, fsys fs.FS, baseDir string) error {
 	if strings.HasPrefix(relPath, "/") || strings.HasPrefix(relPath, "../") || strings.Contains(relPath, "/../") || strings.Contains(relPath, "..") {
 		return fmt.Errorf("path traversal detected")
 	}
@@ -729,7 +730,8 @@ func validateImagePathInFS(relPath string, fsys fs.FS) error {
 
 	if _, err := fs.Stat(fsys, relPath); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("image file not found: %s", relPath)
+			fullPath := filepath.Join(baseDir, relPath)
+			return fmt.Errorf("image file not found: %s", fullPath)
 		}
 		return err
 	}
@@ -755,7 +757,7 @@ func validateImagePath(relPath string, baseDir string) error {
 	fullPath := filepath.Join(baseDir, relPath)
 	if _, err := os.Stat(fullPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("image file not found: %s", relPath)
+			return fmt.Errorf("image file not found: %s", fullPath)
 		}
 		return err
 	}

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -1684,7 +1684,7 @@ func TestLoadCharacterSettingsFromSpeakerJSON_SingleValidSpeaker(t *testing.T) {
 		"assets/zundamon/normal_opened.png": {Data: []byte("")},
 	}
 
-	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "/", "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatalf("loadCharacterSettingsFromSpeakerJSON failed: %v", err)
 	}
@@ -1731,7 +1731,7 @@ func TestLoadCharacterSettingsFromSpeakerJSON_MultipleStyles(t *testing.T) {
 		"assets/zundamon/happy_opened.png":  {Data: []byte("")},
 	}
 
-	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "/", "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatalf("loadCharacterSettingsFromSpeakerJSON failed: %v", err)
 	}
@@ -1750,7 +1750,7 @@ func TestLoadCharacterSettingsFromSpeakerJSON_NoSpeakerJSON(t *testing.T) {
 	t.Parallel()
 	fsys := fstest.MapFS{}
 
-	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "/", "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err == nil {
 		t.Fatal("expected error when no speaker.json found")
 	}
@@ -1781,7 +1781,7 @@ func TestLoadCharacterSettingsFromSpeakerJSON_SkipInvalidSpeakerJSON(t *testing.
 		"assets/zundamon/normal_opened.png": {Data: []byte("")},
 	}
 
-	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "/", "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err != nil {
 		t.Fatalf("loadCharacterSettingsFromSpeakerJSON failed: %v", err)
 	}
@@ -1810,7 +1810,7 @@ func TestLoadCharacterSettingsFromSpeakerJSON_SkipMissingImageFiles(t *testing.T
 		},
 	}
 
-	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	entries, err := loadCharacterSettingsFromSpeakerJSON(fsys, "/", "assets", slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if err == nil {
 		t.Fatal("expected error when image files don't exist")
 	}


### PR DESCRIPTION
## 概要

キャラクター画像ファイルが見つからないエラーメッセージに絶対パスを表示し、調査を容易にします。

## 変更内容

### 改善対象
- `validateImagePath()` (line 758)：相対パスから絶対パスへ変更
- `validateImagePathInFS()` (line 732)：ベースディレクトリを受け取り、絶対パスを表示

### 実装方法

1. `validateImagePathInFS()` 関数シグネチャに `baseDir` パラメータを追加
2. `validateCharacterEntryInFS()` で `baseDir` を受け取って渡す
3. `loadCharacterSettingsFromSpeakerJSON()` で `basePath` パラメータを追加し、`baseDir` を構築して渡す
4. 呼び出し元の `buildAPICharactersJSON()` で `p.workspacePath` を新たなパラメータとして渡す
5. テストケース（5つ）を更新

### 例

**改善前:**
```
image file not found: zundamon/normal_closed.png
```

**改善後:**
```
image file not found: /path/to/workspace/assets/character/zundamon/normal_closed.png
```

## テスト状況

- 既存テスト：全て成功 (8/8 PASS)
- gofmt：問題なし
- golangci-lint：問題なし

Closes #373

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)