### PR TITLE
feat: speakers profile コマンド実装 (#377)

### DIFF
--- a/cmd/speakers.go
+++ b/cmd/speakers.go
@@ -22,6 +22,18 @@ type SpeakerListItem struct {
 	Name string `json:"name"`
 }
 
+// SpeakerProfileOutput は speakers profile コマンドの出力形式を表す。
+type SpeakerProfileOutput struct {
+	ID           string         `json:"id"`
+	Name         string         `json:"name"`
+	Pronoun      string         `json:"pronoun"`
+	SpeechSuffix []string       `json:"speechSuffix"`
+	Personality  []string       `json:"personality"`
+	Speakers     map[string]int `json:"speakers"`
+	Styles       []string       `json:"styles"`
+	Description  string         `json:"description"`
+}
+
 func makeSpeakersCmd(deps *SpeakersDeps) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "speakers",
@@ -32,6 +44,7 @@ func makeSpeakersCmd(deps *SpeakersDeps) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(makeSpeakersListCmd(deps))
+	cmd.AddCommand(makeSpeakersProfileCmd(deps))
 	return cmd
 }
 
@@ -108,6 +121,137 @@ func outputSpeakerList(cmd *cobra.Command, items []SpeakerListItem) error {
 		return fmt.Errorf("failed to marshal speaker list: %w", err)
 	}
 	if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(data)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func makeSpeakersProfileCmd(deps *SpeakersDeps) *cobra.Command {
+	var id string
+	var name string
+
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "指定したキャラクターのプロフィールをJSON形式で返す",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSpeakersProfile(cmd, deps, id, name)
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "assets配下のディレクトリ名")
+	cmd.Flags().StringVar(&name, "name", "", "speaker.json の name フィールド")
+	return cmd
+}
+
+func runSpeakersProfile(cmd *cobra.Command, deps *SpeakersDeps, id string, name string) error {
+	// Flag validation
+	if (id != "" && name != "") || (id == "" && name == "") {
+		return fmt.Errorf("either --id or --name must be specified (not both)")
+	}
+
+	assetsDir, err := resolveAssetsDirForSpeakers(deps)
+	if err != nil {
+		return err
+	}
+
+	var characterID string
+	if id != "" {
+		characterID = id
+	} else {
+		// Search by name
+		var matches []string
+		entries, err := os.ReadDir(assetsDir)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read assets dir: %w", err)
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			dirID := entry.Name()
+			speakerJSONPath := filepath.Join(assetsDir, dirID, "speaker.json")
+
+			data, err := os.ReadFile(speakerJSONPath)
+			if err != nil {
+				continue
+			}
+
+			s, err := entity.ParseSpeakerJSON(data)
+			if err != nil {
+				continue
+			}
+
+			if s.GetSpeakerName() == name {
+				matches = append(matches, dirID)
+			}
+		}
+
+		if len(matches) == 0 {
+			return fmt.Errorf("character not found: %q", name)
+		}
+		if len(matches) > 1 {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "error: multiple characters found with name %q: %v\n", name, matches)
+			return fmt.Errorf("duplicate character name")
+		}
+		characterID = matches[0]
+	}
+
+	speakerJSONPath := filepath.Join(assetsDir, characterID, "speaker.json")
+	data, err := os.ReadFile(speakerJSONPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("character not found: %q", characterID)
+		}
+		return fmt.Errorf("failed to read speaker.json: %w", err)
+	}
+
+	speaker, err := entity.ParseSpeakerJSON(data)
+	if err != nil {
+		return fmt.Errorf("failed to parse speaker.json: %w", err)
+	}
+
+	// Build output
+	output := SpeakerProfileOutput{
+		ID:   characterID,
+		Name: speaker.GetSpeakerName(),
+	}
+
+	// Add profile fields if available
+	if speaker.Profile != nil {
+		output.Pronoun = speaker.Profile.Pronoun
+		output.SpeechSuffix = speaker.Profile.SpeechSuffix
+		output.Personality = speaker.Profile.Personality
+		output.Speakers = speaker.Profile.Speakers
+
+		// Read description file
+		if speaker.Profile.DescriptionPath != "" {
+			descPath := filepath.Join(assetsDir, characterID, speaker.Profile.DescriptionPath)
+			descData, err := os.ReadFile(descPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: description file not found: %s\n", speaker.Profile.DescriptionPath)
+				} else {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to read description file: %v\n", err)
+				}
+			} else {
+				output.Description = string(descData)
+			}
+		}
+	}
+
+	// Build styles array from speaker.Profile.Speakers keys
+	if output.Speakers != nil {
+		for styleName := range output.Speakers {
+			output.Styles = append(output.Styles, styleName)
+		}
+	}
+
+	// Output JSON
+	resultData, err := json.Marshal(output)
+	if err != nil {
+		return fmt.Errorf("failed to marshal profile: %w", err)
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(resultData)); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/speakers_test.go
+++ b/cmd/speakers_test.go
@@ -254,3 +254,306 @@ func TestSpeakersListCmd_LegacySpeakerName_Listed(t *testing.T) {
 		t.Errorf("expected legacy speakerName to work, got items: %+v", items)
 	}
 }
+
+// speakers profile コマンド テストリスト
+// TODO: profileサブコマンドがspeakersに登録されている
+// TODO: --idフラグで指定したキャラクターのプロフィールをJSON形式で返す
+// TODO: --nameフラグで指定したキャラクターのプロフィールをJSON形式で返す
+// TODO: descriptionPathのmdファイル内容がdescriptionフィールドに含まれる
+// TODO: --idと--nameを両方指定した場合は usage error
+// TODO: --idと--nameを両方指定しなかった場合は usage error
+// TODO: --nameで複数キャラクターが一致した場合は exit 1 エラー（stderrにidリスト）
+// TODO: 存在しないキャラクターは "character not found" エラー（exit 1）
+// TODO: descriptionPathが存在しない場合は description="" で継続し stderr に警告
+
+func findSpeakersProfileCmdFromRoot(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
+	t.Helper()
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "speakers" {
+			for _, sc := range c.Commands() {
+				if sc.Name() == "profile" {
+					return sc
+				}
+			}
+		}
+	}
+	t.Fatal("speakers profile subcommand not found")
+	return nil
+}
+
+func TestSpeakersProfileCmd_RegisteredUnderSpeakers(t *testing.T) {
+	rootCmd := makeRootCmd()
+	_ = findSpeakersProfileCmdFromRoot(t, rootCmd)
+}
+
+func TestSpeakersProfileCmd_WithID_ReturnsProfile(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	// zundamon のキャラクター設定
+	zundaDir := filepath.Join(assetsDir, "zundamon")
+	if err := os.MkdirAll(zundaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	descriptionFile := filepath.Join(zundaDir, "character.md")
+	descContent := "# ずんだもん キャラクター設定\n\n## 口調の特徴\n\n- 語尾に「のだ」を付ける"
+	if err := os.WriteFile(descriptionFile, []byte(descContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	speakerJSON := `{
+		"name": "ずんだもん",
+		"profile": {
+			"pronoun": "ボク",
+			"speechSuffix": ["〜のだ", "〜なのだ"],
+			"personality": ["元気", "明るい"],
+			"speakers": {
+				"ノーマル": 3,
+				"ツンツン": 7
+			},
+			"descriptionPath": "character.md"
+		},
+		"styles": []
+	}`
+
+	if err := os.WriteFile(filepath.Join(zundaDir, "speaker.json"), []byte(speakerJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"speakers", "profile", "--id", "zundamon"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("expected valid JSON, got: %v (output: %s)", err, buf.String())
+	}
+
+	if result["id"] != "zundamon" {
+		t.Errorf("expected id 'zundamon', got %v", result["id"])
+	}
+	if result["name"] != "ずんだもん" {
+		t.Errorf("expected name 'ずんだもん', got %v", result["name"])
+	}
+	if result["description"] != descContent {
+		t.Errorf("expected description content to be included, got: %v", result["description"])
+	}
+}
+
+func TestSpeakersProfileCmd_WithName_ReturnsProfile(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	// zundamon のキャラクター設定
+	zundaDir := filepath.Join(assetsDir, "zundamon")
+	if err := os.MkdirAll(zundaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	descriptionFile := filepath.Join(zundaDir, "character.md")
+	descContent := "# ずんだもん"
+	if err := os.WriteFile(descriptionFile, []byte(descContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	speakerJSON := `{
+		"name": "ずんだもん",
+		"profile": {
+			"pronoun": "ボク",
+			"speechSuffix": ["〜のだ"],
+			"personality": ["元気"],
+			"speakers": {"ノーマル": 3},
+			"descriptionPath": "character.md"
+		},
+		"styles": []
+	}`
+
+	if err := os.WriteFile(filepath.Join(zundaDir, "speaker.json"), []byte(speakerJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"speakers", "profile", "--name", "ずんだもん"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("expected valid JSON, got: %v", err)
+	}
+
+	if result["id"] != "zundamon" {
+		t.Errorf("expected id 'zundamon', got %v", result["id"])
+	}
+	if result["name"] != "ずんだもん" {
+		t.Errorf("expected name 'ずんだもん', got %v", result["name"])
+	}
+}
+
+func TestSpeakersProfileCmd_BothFlagsSpecified_UsageError(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"speakers", "profile", "--id", "zundamon", "--name", "ずんだもん"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error when both --id and --name specified")
+	}
+}
+
+func TestSpeakersProfileCmd_NoFlagsSpecified_UsageError(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"speakers", "profile"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error when neither --id nor --name specified")
+	}
+}
+
+func TestSpeakersProfileCmd_CharacterNotFound_Error(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	rootCmd.SetArgs([]string{"speakers", "profile", "--id", "nonexistent"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error for nonexistent character")
+	}
+}
+
+func TestSpeakersProfileCmd_NameDuplicate_Error(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	// zundamon
+	zundaDir := filepath.Join(assetsDir, "zundamon")
+	if err := os.MkdirAll(zundaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	speakerJSON := `{"name": "ずんだもん", "profile": {}, "styles": []}`
+	if err := os.WriteFile(filepath.Join(zundaDir, "speaker.json"), []byte(speakerJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// another dir with same name
+	otherDir := filepath.Join(assetsDir, "other")
+	if err := os.MkdirAll(otherDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "speaker.json"), []byte(speakerJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"speakers", "profile", "--name", "ずんだもん"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Error("expected error when multiple characters have same name")
+	}
+	if !strings.Contains(errBuf.String(), "zundamon") && !strings.Contains(errBuf.String(), "other") {
+		t.Errorf("expected matched IDs in stderr, got: %s", errBuf.String())
+	}
+}
+
+func TestSpeakersProfileCmd_DescriptionFileMissing_ContinuesWithWarning(t *testing.T) {
+	assetsDir := t.TempDir()
+
+	zundaDir := filepath.Join(assetsDir, "zundamon")
+	if err := os.MkdirAll(zundaDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	speakerJSON := `{
+		"name": "ずんだもん",
+		"profile": {
+			"pronoun": "ボク",
+			"speechSuffix": ["〜のだ"],
+			"personality": ["元気"],
+			"speakers": {"ノーマル": 3},
+			"descriptionPath": "nonexistent.md"
+		},
+		"styles": []
+	}`
+
+	if err := os.WriteFile(filepath.Join(zundaDir, "speaker.json"), []byte(speakerJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"speakers", "profile", "--id", "zundamon"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error (should continue with warning), got: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("expected valid JSON, got: %v", err)
+	}
+
+	if result["description"] != "" {
+		t.Errorf("expected empty description when file missing, got: %v", result["description"])
+	}
+
+	if !strings.Contains(errBuf.String(), "nonexistent.md") {
+		t.Errorf("expected warning about missing file in stderr, got: %s", errBuf.String())
+	}
+}


### PR DESCRIPTION
## Summary

`vox-actor speakers profile` コマンドを実装しました。指定したキャラクターの設定をJSON形式で返します。

- `--id` フラグで ID 指定
- `--name` フラグで名前指定（重複時はエラー）
- description フィールドに md ファイル本文を含める

## Test plan

- [x] `--id` フラグで正常に取得できる
- [x] `--name` フラグで正常に取得できる
- [x] 両方指定で usage error
- [x] 両方未指定で usage error
- [x] 存在しないキャラクター → error
- [x] `--name` で複数一致 → error（stderr に ID リスト）
- [x] description ファイル存在しない → 警告で継続
- [x] go test ./cmd/... 全テスト pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)