### PR TITLE
fix: assets download が .vox-actor/.vox-actor/assets に配置してしまう問題を修正

### DIFF
--- a/cmd/assets_download.go
+++ b/cmd/assets_download.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var resolveWorkspaceFunc = resolveWorkspaceWithFallback
+
 // AssetsDownloadDeps はassets downloadコマンドの依存を保持する。
 type AssetsDownloadDeps struct {
 	Cloner app.GitCloner
@@ -84,9 +86,9 @@ func resolveAssetsDir(deps *AssetsDownloadDeps) (string, error) {
 	if deps.AssetsDirFunc != nil {
 		return deps.AssetsDirFunc()
 	}
-	ws, err := resolveWorkspaceWithFallback()
+	ws, err := resolveWorkspaceFunc()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(ws, ".vox-actor", "assets"), nil
+	return filepath.Join(ws, "assets"), nil
 }

--- a/cmd/assets_download_test.go
+++ b/cmd/assets_download_test.go
@@ -218,3 +218,39 @@ func TestAssetsDownloadCmd_HelpContainsExpectedFlags(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveAssetsDir_WithAssetsDirFunc_ReturnsCustomPath(t *testing.T) {
+	expectedPath := "/custom/assets"
+	deps := &AssetsDownloadDeps{
+		AssetsDirFunc: func() (string, error) { return expectedPath, nil },
+	}
+
+	result, err := resolveAssetsDir(deps)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result != expectedPath {
+		t.Errorf("expected %q, got: %q", expectedPath, result)
+	}
+}
+
+func TestResolveAssetsDir_WithoutAssetsDirFunc_ReturnsWorkspacePlusAssets(t *testing.T) {
+	workspacePath := "/repo/.vox-actor"
+	deps := &AssetsDownloadDeps{
+		AssetsDirFunc: nil,
+	}
+
+	originalResolveFunc := resolveWorkspaceFunc
+	resolveWorkspaceFunc = func() (string, error) { return workspacePath, nil }
+	defer func() { resolveWorkspaceFunc = originalResolveFunc }()
+
+	result, err := resolveAssetsDir(deps)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	expectedPath := filepath.Join(workspacePath, "assets")
+	if result != expectedPath {
+		t.Errorf("expected %q, got: %q", expectedPath, result)
+	}
+}


### PR DESCRIPTION
## 概要
`assets download`コマンドでアセットが間違ったディレクトリに配置される問題を修正しました。

## 問題
- `resolveAssetsDir()`関数が`.vox-actor`ディレクトリを二重に追加していた
- `resolveWorkspaceWithFallback()`は既に`<repo>/.vox-actor`を返すのに対し、さらに`.vox-actor`を追加
- 結果として`.vox-actor/.vox-actor/assets`に配置されていた

## 修正内容
- `filepath.Join(ws, ".vox-actor", "assets")` → `filepath.Join(ws, "assets")`に変更
- テスト用に`resolveWorkspaceFunc`パッケージ変数を追加して、`resolveAssetsDir()`をテスト可能に
- 両パターン（AssetsDirFunc有無）をテストで検証

## テスト
- ✓ 全cmd テスト合格
- ✓ gofmt チェック合格
- ✓ golangci-lint チェック合格

Closes #389

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)