### PR TITLE
feat(cli): vox-actor say -o を既存ファイル追記モードに変更

### DIFF
--- a/cmd/say.go
+++ b/cmd/say.go
@@ -39,7 +39,7 @@ func makeSayCmd(deps *SayDeps) *cobra.Command {
 	}
 
 	registerCommonFlags(cmd)
-	cmd.Flags().StringP("output", "o", "", "セリフをファイル出力する（指定時はVOICEVOX接続・音声再生を行わない）")
+	cmd.Flags().StringP("output", "o", "", "セリフをファイル出力する（既存ファイルには追記）（指定時はVOICEVOX接続・音声再生を行わない）")
 
 	return cmd
 }

--- a/internal/infra/file_writer.go
+++ b/internal/infra/file_writer.go
@@ -166,7 +166,6 @@ func toJSONScript(script entity.Script) jsonScriptOut {
 	}
 }
 
-// writeJSONLine は1行JSON（末尾改行付き）を追記モードで書き出す。
 func writeJSONLine(path string, script entity.Script) error {
 	data, err := json.Marshal(toJSONScript(script))
 	if err != nil {
@@ -183,11 +182,11 @@ func writeText(path string, text string) error {
 func appendToFile(path string, data []byte) error {
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return fmt.Errorf("failed to open file: %w", err)
+		return fmt.Errorf("failed to open %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
 	if _, err := f.Write(data); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
 	return nil
 }

--- a/internal/infra/file_writer.go
+++ b/internal/infra/file_writer.go
@@ -65,7 +65,7 @@ func NewFileWriter(opts ...FileWriterOption) *FileWriter {
 // ディレクトリ指定時に末尾が "/" で未存在ならば os.MkdirAll で作成する。
 // path がファイル名の場合、拡張子で書き出し形式を判定：.json / .jsonl のみ JSON 出力、.txt は本文のみ。
 // ファイル指定時は拡張子必須で、.json / .jsonl / .txt 以外はエラーで返す。
-// 既存ファイルがある場合は <name>_<UnixNano><ext> で連番を付与する。
+// 既存ファイルがある場合は末尾に追記する。
 // 戻り値は実際の書き出し先パス。
 func (w *FileWriter) Write(path string, script entity.Script) (string, error) {
 	// ディレクトリ判定：末尾が "/" または os.Stat で IsDir
@@ -110,7 +110,7 @@ func (w *FileWriter) Write(path string, script entity.Script) (string, error) {
 		return "", fmt.Errorf("parent path is not a directory: %s", parent)
 	}
 
-	dest := w.resolveDest(path)
+	dest := path
 
 	ext := strings.ToLower(filepath.Ext(dest))
 	switch ext {
@@ -120,18 +120,6 @@ func (w *FileWriter) Write(path string, script entity.Script) (string, error) {
 		w.warnUnsavedParams(dest, script)
 		return dest, writeText(dest, script.Text)
 	}
-}
-
-// resolveDest は出力先パスを返す。同名ファイルが既に存在する場合は <name>_<UnixNano><ext> を付与する。
-func (w *FileWriter) resolveDest(path string) string {
-	if _, err := os.Stat(path); err != nil {
-		return path
-	}
-	dir := filepath.Dir(path)
-	base := filepath.Base(path)
-	ext := filepath.Ext(base)
-	name := strings.TrimSuffix(base, ext)
-	return filepath.Join(dir, fmt.Sprintf("%s_%d%s", name, w.now().UnixNano(), ext))
 }
 
 // warnUnsavedParams は .txt / 未知拡張子の出力時に保存できないパラメータが指定されていれば WARN ログを出す。
@@ -178,17 +166,28 @@ func toJSONScript(script entity.Script) jsonScriptOut {
 	}
 }
 
-// writeJSONLine は1行JSON（末尾改行付き）を書き出す。
-// .json / .jsonl で同じ実装。.jsonl が将来複数行追記をサポートする場合は分岐させる。
+// writeJSONLine は1行JSON（末尾改行付き）を追記モードで書き出す。
 func writeJSONLine(path string, script entity.Script) error {
 	data, err := json.Marshal(toJSONScript(script))
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 	data = append(data, '\n')
-	return os.WriteFile(path, data, 0o644)
+	return appendToFile(path, data)
 }
 
 func writeText(path string, text string) error {
-	return os.WriteFile(path, []byte(text), 0o644)
+	return appendToFile(path, []byte(text))
+}
+
+func appendToFile(path string, data []byte) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	return nil
 }

--- a/internal/infra/file_writer_test.go
+++ b/internal/infra/file_writer_test.go
@@ -11,7 +11,8 @@ package infra_test
 // - 未知拡張子は本文のみ書き出される           → TestFileWriter_Write_UnknownExt_TextOnly
 // - .txt + speaker指定 で WARN ログ          → TestFileWriter_Write_Txt_WithSpeaker_LogsWarn
 // - .txt で全パラメータnilなら WARN なし      → TestFileWriter_Write_Txt_NoParams_NoWarn
-// - 既存ファイル衝突時 <name>_<UnixNano><ext> → TestFileWriter_Write_CollisionAddsSuffix
+// - 既存ファイルがある場合は末尾に追記される    → TestFileWriter_Write_ExistingFile_Appends
+// - 既存ファイルがある場合に別ファイルを作らない  → TestFileWriter_Write_ExistingFile_NoSuffix
 // - 親ディレクトリ未存在時はエラー             → TestFileWriter_Write_MissingParentDir_ReturnsError
 
 import (
@@ -284,12 +285,78 @@ func filterLines(output, needle string) []string {
 	return matched
 }
 
-func TestFileWriter_Write_CollisionAddsSuffix(t *testing.T) {
+func TestFileWriter_Write_ExistingFile_Appends(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	dest := filepath.Join(dir, "out.txt")
-	if err := os.WriteFile(dest, []byte("既存"), 0o644); err != nil {
+	dest := filepath.Join(dir, "out.jsonl")
+
+	w := infra.NewFileWriter()
+
+	// 1回目
+	written1, err := w.Write(dest, entity.Script{Text: "A"})
+	if err != nil {
+		t.Fatalf("first Write failed: %v", err)
+	}
+	if written1 != dest {
+		t.Errorf("expected written=%q, got %q", dest, written1)
+	}
+
+	// 2回目（既存ファイルへの追記）
+	written2, err := w.Write(dest, entity.Script{Text: "B"})
+	if err != nil {
+		t.Fatalf("second Write failed: %v", err)
+	}
+	if written2 != dest {
+		t.Errorf("expected written=%q, got %q", dest, written2)
+	}
+
+	// ファイルが1つだけ存在すること
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("expected 1 file, got %d: %v", len(entries), names)
+	}
+
+	// 2行記録されていること
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), string(data))
+	}
+
+	var got1 map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &got1); err != nil {
+		t.Fatalf("invalid JSON line 0: %v", err)
+	}
+	if got1["text"] != "A" {
+		t.Errorf("line 0 text mismatch: %v", got1["text"])
+	}
+
+	var got2 map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &got2); err != nil {
+		t.Fatalf("invalid JSON line 1: %v", err)
+	}
+	if got2["text"] != "B" {
+		t.Errorf("line 1 text mismatch: %v", got2["text"])
+	}
+}
+
+func TestFileWriter_Write_ExistingFile_NoSuffix(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.jsonl")
+	if err := os.WriteFile(dest, []byte(""), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -299,34 +366,22 @@ func TestFileWriter_Write_CollisionAddsSuffix(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if written == dest {
-		t.Fatalf("expected renamed path, got original: %s", written)
+	// 別ファイルが作られず、同一パスが返ること
+	if written != dest {
+		t.Errorf("expected same path %q, got %q", dest, written)
 	}
 
-	// 末尾は .txt で、ベース名は out_<UnixNano>.txt 形式
-	if filepath.Ext(written) != ".txt" {
-		t.Errorf("expected extension .txt, got: %s", written)
-	}
-	if !strings.HasPrefix(filepath.Base(written), "out_") {
-		t.Errorf("expected basename to start with 'out_', got: %s", filepath.Base(written))
-	}
-
-	// 既存ファイルは変更されていない
-	existing, err := os.ReadFile(dest)
+	// ディレクトリに1ファイルだけ存在すること
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("existing file unreadable: %v", err)
+		t.Fatalf("ReadDir failed: %v", err)
 	}
-	if string(existing) != "既存" {
-		t.Errorf("existing file changed unexpectedly: %s", string(existing))
-	}
-
-	// 新ファイルには新規内容
-	newContents, err := os.ReadFile(written)
-	if err != nil {
-		t.Fatalf("new file unreadable: %v", err)
-	}
-	if string(newContents) != "新規" {
-		t.Errorf("new file content mismatch: %s", string(newContents))
+	if len(entries) != 1 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("expected 1 file, got %d: %v", len(entries), names)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `vox-actor say -o <path>` で出力先が既存ファイルの場合に別名ファイル（`<name>_<timestamp>.jsonl`）を作成していた挙動を、末尾への追記に変更
- `internal/infra/file_writer.go`: `resolveDest()` を削除し、`os.OpenFile` の `O_APPEND|O_CREATE|O_WRONLY` フラグを使う `appendToFile()` を追加
- `cmd/say.go`: `-o` フラグのヘルプ文言に「（既存ファイルには追記）」を追記

## Test plan

- [x] `TestFileWriter_Write_ExistingFile_Appends` — 同一ファイルへの2回連続書き込みで2行記録されることを確認
- [x] `TestFileWriter_Write_ExistingFile_NoSuffix` — 既存ファイルへの書き込み後に別ファイルが作られないことを確認
- [x] 既存テスト全件パス確認

Closes #391

---
🤖 Generated with [Claude Code](https://claude.ai/code)
