### PR TITLE
feat(cli): assets を ~/.vox-actor/assets にも配置可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,13 @@ export VOX_ACTOR_MONOLOGUE_MODE=file
 [MIT License](LICENSE)
 
 キャラクター設定は `vox-actor assets download` で別リポジトリから取得します。利用規約とクレジット表記は取得元リポジトリの案内に従ってください。
+
+`--scope` フラグで配置先を切り替えられます。
+
+| `--scope` | 配置先 |
+|-----------|--------|
+| 省略（既定） | `<repoRoot>/.vox-actor/assets/`（git リポジトリ外は `<cwd>/.vox-actor/assets/`） |
+| `project` | 同上 |
+| `home` | `~/.vox-actor/assets/`（複数プロジェクト共用に便利） |
+
+`speakers list` / `speakers profile` / viewer 画面はプロジェクト・ホーム両方の assets をマージして返します（同一 ID はプロジェクト優先）。

--- a/cmd/assets_download.go
+++ b/cmd/assets_download.go
@@ -6,10 +6,12 @@ import (
 	"strings"
 
 	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
 
 var resolveWorkspaceFunc = resolveWorkspaceWithFallback
+var resolveHomeAssetsFunc = infra.ResolveHomeAssetsPath
 
 // AssetsDownloadDeps はassets downloadコマンドの依存を保持する。
 type AssetsDownloadDeps struct {
@@ -36,6 +38,7 @@ func makeAssetsDownloadCmd(deps *AssetsDownloadDeps) *cobra.Command {
 
 	cmd.Flags().StringArray("speaker", nil, "ダウンロード対象の speaker 名（リピート可、カンマ区切り可）")
 	cmd.Flags().Bool("force", false, "ローカルに同名 speaker が存在する場合に上書き")
+	cmd.Flags().String("scope", "project", "配置先スコープ（home: ~/.vox-actor/assets/、project: プロジェクト配下）")
 
 	return cmd
 }
@@ -51,8 +54,13 @@ func runAssetsDownload(cmd *cobra.Command, args []string, deps *AssetsDownloadDe
 	speakers := splitSpeakers(speakerRaw)
 
 	force, _ := cmd.Flags().GetBool("force")
+	scope, _ := cmd.Flags().GetString("scope")
 
-	assetsDir, err := resolveAssetsDir(deps)
+	if scope != "home" && scope != "project" {
+		return fmt.Errorf("%w: --scope must be \"home\" or \"project\", got %q", ErrUsage, scope)
+	}
+
+	assetsDir, err := resolveAssetsDir(deps, scope)
 	if err != nil {
 		return err
 	}
@@ -82,9 +90,12 @@ func splitSpeakers(raw []string) []string {
 	return result
 }
 
-func resolveAssetsDir(deps *AssetsDownloadDeps) (string, error) {
+func resolveAssetsDir(deps *AssetsDownloadDeps, scope string) (string, error) {
 	if deps.AssetsDirFunc != nil {
 		return deps.AssetsDirFunc()
+	}
+	if scope == "home" {
+		return resolveHomeAssetsFunc()
 	}
 	ws, err := resolveWorkspaceFunc()
 	if err != nil {

--- a/cmd/assets_download.go
+++ b/cmd/assets_download.go
@@ -13,6 +13,11 @@ import (
 var resolveWorkspaceFunc = resolveWorkspaceWithFallback
 var resolveHomeAssetsFunc = infra.ResolveHomeAssetsPath
 
+const (
+	scopeHome    = "home"
+	scopeProject = "project"
+)
+
 // AssetsDownloadDeps はassets downloadコマンドの依存を保持する。
 type AssetsDownloadDeps struct {
 	Cloner app.GitCloner
@@ -56,8 +61,8 @@ func runAssetsDownload(cmd *cobra.Command, args []string, deps *AssetsDownloadDe
 	force, _ := cmd.Flags().GetBool("force")
 	scope, _ := cmd.Flags().GetString("scope")
 
-	if scope != "home" && scope != "project" {
-		return fmt.Errorf("%w: --scope must be \"home\" or \"project\", got %q", ErrUsage, scope)
+	if scope != scopeHome && scope != scopeProject {
+		return fmt.Errorf("%w: --scope must be %q or %q, got %q", ErrUsage, scopeHome, scopeProject, scope)
 	}
 
 	assetsDir, err := resolveAssetsDir(deps, scope)
@@ -94,7 +99,7 @@ func resolveAssetsDir(deps *AssetsDownloadDeps, scope string) (string, error) {
 	if deps.AssetsDirFunc != nil {
 		return deps.AssetsDirFunc()
 	}
-	if scope == "home" {
+	if scope == scopeHome {
 		return resolveHomeAssetsFunc()
 	}
 	ws, err := resolveWorkspaceFunc()

--- a/cmd/assets_download_test.go
+++ b/cmd/assets_download_test.go
@@ -225,7 +225,7 @@ func TestResolveAssetsDir_WithAssetsDirFunc_ReturnsCustomPath(t *testing.T) {
 		AssetsDirFunc: func() (string, error) { return expectedPath, nil },
 	}
 
-	result, err := resolveAssetsDir(deps)
+	result, err := resolveAssetsDir(deps, "project")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestResolveAssetsDir_WithoutAssetsDirFunc_ReturnsWorkspacePlusAssets(t *tes
 	resolveWorkspaceFunc = func() (string, error) { return workspacePath, nil }
 	defer func() { resolveWorkspaceFunc = originalResolveFunc }()
 
-	result, err := resolveAssetsDir(deps)
+	result, err := resolveAssetsDir(deps, "project")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -252,5 +252,118 @@ func TestResolveAssetsDir_WithoutAssetsDirFunc_ReturnsWorkspacePlusAssets(t *tes
 	expectedPath := filepath.Join(workspacePath, "assets")
 	if result != expectedPath {
 		t.Errorf("expected %q, got: %q", expectedPath, result)
+	}
+}
+
+func TestAssetsDownloadCmd_HasScopeFlag(t *testing.T) {
+	rootCmd := makeRootCmd()
+	cmd := findAssetsDownloadCmdFromRoot(t, rootCmd)
+	f := cmd.Flags().Lookup("scope")
+	if f == nil {
+		t.Fatal("expected --scope flag to exist")
+	}
+	if f.DefValue != "project" {
+		t.Errorf("expected --scope default to be %q, got %q", "project", f.DefValue)
+	}
+}
+
+func TestAssetsDownloadCmd_InvalidScope_ReturnsUsageError(t *testing.T) {
+	assetsDir := t.TempDir()
+	deps := &Deps{
+		Assets: &AssetsDownloadDeps{
+			Cloner:        &testGitCloner{},
+			AssetsDirFunc: func() (string, error) { return assetsDir, nil },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"assets", "download", "--scope", "invalid", "https://example.com/repo.git"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid scope, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func TestAssetsDownloadCmd_ScopeHome_UsesHomeAssetsDir(t *testing.T) {
+	homeAssetsDir := t.TempDir()
+	cloner := &testGitCloner{
+		assetsJSONContent: `{"assets": {"charA": {"path": "img/charA"}}}`,
+		files:             map[string]string{"img/charA/icon.png": "data"},
+	}
+
+	deps := &Deps{
+		Assets: &AssetsDownloadDeps{
+			Cloner: cloner,
+		},
+	}
+
+	origHome := resolveHomeAssetsFunc
+	resolveHomeAssetsFunc = func() (string, error) { return homeAssetsDir, nil }
+	defer func() { resolveHomeAssetsFunc = origHome }()
+
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"assets", "download", "--scope", "home", "https://example.com/repo.git"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(homeAssetsDir, "charA")); err != nil {
+		t.Errorf("expected charA dir in home assets, got: %v", err)
+	}
+}
+
+func TestAssetsDownloadCmd_ScopeProject_UsesProjectAssetsDir(t *testing.T) {
+	projectWorkspace := t.TempDir()
+	projectAssetsDir := filepath.Join(projectWorkspace, "assets")
+	cloner := &testGitCloner{
+		assetsJSONContent: `{"assets": {"charB": {"path": "img/charB"}}}`,
+		files:             map[string]string{"img/charB/icon.png": "data"},
+	}
+
+	deps := &Deps{
+		Assets: &AssetsDownloadDeps{
+			Cloner: cloner,
+		},
+	}
+
+	origWorkspace := resolveWorkspaceFunc
+	resolveWorkspaceFunc = func() (string, error) { return projectWorkspace, nil }
+	defer func() { resolveWorkspaceFunc = origWorkspace }()
+
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"assets", "download", "--scope", "project", "https://example.com/repo.git"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(projectAssetsDir, "charB")); err != nil {
+		t.Errorf("expected charB dir in project assets, got: %v", err)
+	}
+}
+
+func TestAssetsDownloadCmd_HelpContainsScopeFlag(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"assets", "download", "--help"})
+	_ = rootCmd.Execute()
+
+	output := buf.String()
+	if !strings.Contains(output, "--scope") {
+		t.Errorf("expected --scope in help output, got: %s", output)
 	}
 }

--- a/cmd/speakers.go
+++ b/cmd/speakers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/canpok1/vox-actor/internal/domain/entity"
 	"github.com/canpok1/vox-actor/internal/infra"
@@ -84,6 +85,7 @@ func runSpeakersList(cmd *cobra.Command, deps *SpeakersDeps) error {
 		items = append(items, SpeakerListItem{ID: id, Name: s.GetSpeakerName()})
 	}
 
+	sort.Slice(items, func(i, j int) bool { return items[i].ID < items[j].ID })
 	return outputSpeakerList(cmd, items)
 }
 

--- a/cmd/speakers.go
+++ b/cmd/speakers.go
@@ -7,13 +7,17 @@ import (
 	"path/filepath"
 
 	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
 
 // SpeakersDeps は speakers コマンドの依存を保持する。
 type SpeakersDeps struct {
-	// AssetsDirFunc はアセットの配置先ルートディレクトリを返す。nil の場合はワークスペース解決を使う。
+	// AssetsDirFunc はアセットの配置先ルートディレクトリを返す（後方互換）。nil の場合はワークスペース解決を使う。
 	AssetsDirFunc func() (string, error)
+	// AssetsDirsMergedFunc は優先順位付きのアセットディレクトリ一覧を返す（index 0 が最高優先）。
+	// 設定されると AssetsDirFunc より優先される。
+	AssetsDirsMergedFunc func() ([]string, error)
 }
 
 // SpeakerListItem は speakers list コマンドの出力要素を表す。
@@ -59,57 +63,84 @@ func makeSpeakersListCmd(deps *SpeakersDeps) *cobra.Command {
 }
 
 func runSpeakersList(cmd *cobra.Command, deps *SpeakersDeps) error {
-	assetsDir, err := resolveAssetsDirForSpeakers(deps)
+	charDirMap, err := buildCharacterDirMap(cmd, deps)
 	if err != nil {
 		return err
 	}
 
-	entries, err := os.ReadDir(assetsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return outputSpeakerList(cmd, []SpeakerListItem{})
-		}
-		return fmt.Errorf("failed to read assets dir: %w", err)
-	}
-
 	var items []SpeakerListItem
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		id := entry.Name()
+	for id, assetsDir := range charDirMap {
 		speakerJSONPath := filepath.Join(assetsDir, id, "speaker.json")
-
 		data, err := os.ReadFile(speakerJSONPath)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping %s: failed to read speaker.json: %v\n", id, err)
 			continue
 		}
-
 		s, err := entity.ParseSpeakerJSON(data)
 		if err != nil {
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping %s: failed to parse speaker.json: %v\n", id, err)
 			continue
 		}
-
-		items = append(items, SpeakerListItem{
-			ID:   id,
-			Name: s.GetSpeakerName(),
-		})
+		items = append(items, SpeakerListItem{ID: id, Name: s.GetSpeakerName()})
 	}
 
 	return outputSpeakerList(cmd, items)
 }
 
-func resolveAssetsDirForSpeakers(deps *SpeakersDeps) (string, error) {
-	if deps != nil && deps.AssetsDirFunc != nil {
-		return deps.AssetsDirFunc()
-	}
-	ws, err := resolveWorkspaceWithFallback()
+// buildCharacterDirMap はマージされた charID → assetsDir マップを返す。
+// dirs は優先順位順（index 0 が最高優先）。同一 ID は先に登録された dir が優先される。
+func buildCharacterDirMap(cmd *cobra.Command, deps *SpeakersDeps) (map[string]string, error) {
+	dirs, err := resolveAssetsDirsForSpeakers(deps)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return filepath.Join(ws, "assets"), nil
+
+	result := make(map[string]string)
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			if cmd != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping assets dir %s: %v\n", dir, err)
+			}
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			if _, exists := result[e.Name()]; !exists {
+				result[e.Name()] = dir
+			}
+		}
+	}
+	return result, nil
+}
+
+// resolveAssetsDirsForSpeakers は優先順位付きのアセットディレクトリ一覧を返す（index 0 が最高優先）。
+func resolveAssetsDirsForSpeakers(deps *SpeakersDeps) ([]string, error) {
+	if deps != nil && deps.AssetsDirsMergedFunc != nil {
+		return deps.AssetsDirsMergedFunc()
+	}
+	if deps != nil && deps.AssetsDirFunc != nil {
+		dir, err := deps.AssetsDirFunc()
+		if err != nil {
+			return nil, err
+		}
+		return []string{dir}, nil
+	}
+
+	projectDir, err := infra.ResolveProjectAssetsPath()
+	if err != nil {
+		return nil, err
+	}
+	homeDir, err := infra.ResolveHomeAssetsPath()
+	if err != nil {
+		return nil, err
+	}
+	return []string{projectDir, homeDir}, nil
 }
 
 func outputSpeakerList(cmd *cobra.Command, items []SpeakerListItem) error {
@@ -148,44 +179,37 @@ func runSpeakersProfile(cmd *cobra.Command, deps *SpeakersDeps, id string, name 
 		return fmt.Errorf("either --id or --name must be specified (not both)")
 	}
 
-	assetsDir, err := resolveAssetsDirForSpeakers(deps)
+	charDirMap, err := buildCharacterDirMap(cmd, deps)
 	if err != nil {
 		return err
 	}
 
 	var characterID string
+	var assetsDir string
 	if id != "" {
-		characterID = id
-	} else {
-		// Search by name
-		var matches []string
-		entries, err := os.ReadDir(assetsDir)
-		if err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to read assets dir: %w", err)
+		dir, exists := charDirMap[id]
+		if !exists {
+			return fmt.Errorf("character not found: %q", id)
 		}
-
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			dirID := entry.Name()
-			speakerJSONPath := filepath.Join(assetsDir, dirID, "speaker.json")
-
+		characterID = id
+		assetsDir = dir
+	} else {
+		// Search by name across merged dirs
+		var matches []string
+		for charID, charDir := range charDirMap {
+			speakerJSONPath := filepath.Join(charDir, charID, "speaker.json")
 			data, err := os.ReadFile(speakerJSONPath)
 			if err != nil {
 				continue
 			}
-
 			s, err := entity.ParseSpeakerJSON(data)
 			if err != nil {
 				continue
 			}
-
 			if s.GetSpeakerName() == name {
-				matches = append(matches, dirID)
+				matches = append(matches, charID)
 			}
 		}
-
 		if len(matches) == 0 {
 			return fmt.Errorf("character not found: %q", name)
 		}
@@ -194,6 +218,7 @@ func runSpeakersProfile(cmd *cobra.Command, deps *SpeakersDeps, id string, name 
 			return fmt.Errorf("duplicate character name")
 		}
 		characterID = matches[0]
+		assetsDir = charDirMap[characterID]
 	}
 
 	speakerJSONPath := filepath.Join(assetsDir, characterID, "speaker.json")
@@ -210,20 +235,17 @@ func runSpeakersProfile(cmd *cobra.Command, deps *SpeakersDeps, id string, name 
 		return fmt.Errorf("failed to parse speaker.json: %w", err)
 	}
 
-	// Build output
 	output := SpeakerProfileOutput{
 		ID:   characterID,
 		Name: speaker.GetSpeakerName(),
 	}
 
-	// Add profile fields if available
 	if speaker.Profile != nil {
 		output.Pronoun = speaker.Profile.Pronoun
 		output.SpeechSuffix = speaker.Profile.SpeechSuffix
 		output.Personality = speaker.Profile.Personality
 		output.Speakers = speaker.Profile.Speakers
 
-		// Read description file
 		if speaker.Profile.DescriptionPath != "" {
 			descPath := filepath.Join(assetsDir, characterID, speaker.Profile.DescriptionPath)
 			descData, err := os.ReadFile(descPath)
@@ -239,14 +261,12 @@ func runSpeakersProfile(cmd *cobra.Command, deps *SpeakersDeps, id string, name 
 		}
 	}
 
-	// Build styles array from speaker.Profile.Speakers keys
 	if output.Speakers != nil {
 		for styleName := range output.Speakers {
 			output.Styles = append(output.Styles, styleName)
 		}
 	}
 
-	// Output JSON
 	resultData, err := json.Marshal(output)
 	if err != nil {
 		return fmt.Errorf("failed to marshal profile: %w", err)

--- a/cmd/speakers.go
+++ b/cmd/speakers.go
@@ -102,9 +102,7 @@ func buildCharacterDirMap(cmd *cobra.Command, deps *SpeakersDeps) (map[string]st
 			if os.IsNotExist(err) {
 				continue
 			}
-			if cmd != nil {
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping assets dir %s: %v\n", dir, err)
-			}
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: skipping assets dir %s: %v\n", dir, err)
 			continue
 		}
 		for _, e := range entries {

--- a/cmd/speakers_test.go
+++ b/cmd/speakers_test.go
@@ -504,6 +504,186 @@ func TestSpeakersProfileCmd_NameDuplicate_Error(t *testing.T) {
 	}
 }
 
+func TestSpeakersListCmd_HomeOnly_ReturnsSpeakers(t *testing.T) {
+	homeDir := t.TempDir()
+
+	dir := filepath.Join(homeDir, "homechar")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "speaker.json"), []byte(`{"name": "ホームキャラ", "styles": []}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirsMergedFunc: func() ([]string, error) {
+				return []string{homeDir}, nil
+			},
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"speakers", "list"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var items []SpeakerListItem
+	if err := json.Unmarshal(buf.Bytes(), &items); err != nil {
+		t.Fatalf("expected valid JSON, got: %v (output: %s)", err, buf.String())
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].ID != "homechar" {
+		t.Errorf("expected id 'homechar', got %q", items[0].ID)
+	}
+}
+
+func TestSpeakersListCmd_MergeProjectAndHome_ReturnsBoth(t *testing.T) {
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	// project: charA
+	dirA := filepath.Join(projectDir, "charA")
+	if err := os.MkdirAll(dirA, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirA, "speaker.json"), []byte(`{"name": "キャラA", "styles": []}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// home: charB
+	dirB := filepath.Join(homeDir, "charB")
+	if err := os.MkdirAll(dirB, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirB, "speaker.json"), []byte(`{"name": "キャラB", "styles": []}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirsMergedFunc: func() ([]string, error) {
+				return []string{projectDir, homeDir}, nil
+			},
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"speakers", "list"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var items []SpeakerListItem
+	if err := json.Unmarshal(buf.Bytes(), &items); err != nil {
+		t.Fatalf("expected valid JSON, got: %v (output: %s)", err, buf.String())
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d: %+v", len(items), items)
+	}
+	found := map[string]string{}
+	for _, item := range items {
+		found[item.ID] = item.Name
+	}
+	if found["charA"] != "キャラA" {
+		t.Errorf("expected charA name 'キャラA', got %q", found["charA"])
+	}
+	if found["charB"] != "キャラB" {
+		t.Errorf("expected charB name 'キャラB', got %q", found["charB"])
+	}
+}
+
+func TestSpeakersListCmd_ProjectPriority_WhenSameID(t *testing.T) {
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	// Both have "shared" but different names
+	for dir, name := range map[string]string{projectDir: "プロジェクト版", homeDir: "ホーム版"} {
+		d := filepath.Join(dir, "shared")
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+		content := `{"name": "` + name + `", "styles": []}`
+		if err := os.WriteFile(filepath.Join(d, "speaker.json"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirsMergedFunc: func() ([]string, error) {
+				return []string{projectDir, homeDir}, nil
+			},
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"speakers", "list"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var items []SpeakerListItem
+	if err := json.Unmarshal(buf.Bytes(), &items); err != nil {
+		t.Fatalf("expected valid JSON, got: %v (output: %s)", err, buf.String())
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (merged), got %d: %+v", len(items), items)
+	}
+	if items[0].Name != "プロジェクト版" {
+		t.Errorf("expected project name 'プロジェクト版', got %q", items[0].Name)
+	}
+}
+
+func TestSpeakersProfileCmd_ProjectPriority_WhenSameID(t *testing.T) {
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	for dir, name := range map[string]string{projectDir: "プロジェクト版", homeDir: "ホーム版"} {
+		d := filepath.Join(dir, "shared")
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+		content := `{"name": "` + name + `", "styles": []}`
+		if err := os.WriteFile(filepath.Join(d, "speaker.json"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	deps := &Deps{
+		Speakers: &SpeakersDeps{
+			AssetsDirsMergedFunc: func() ([]string, error) {
+				return []string{projectDir, homeDir}, nil
+			},
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"speakers", "profile", "--id", "shared"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("expected valid JSON, got: %v", err)
+	}
+	if result["name"] != "プロジェクト版" {
+		t.Errorf("expected project name 'プロジェクト版', got %v", result["name"])
+	}
+}
+
 func TestSpeakersProfileCmd_DescriptionFileMissing_ContinuesWithWarning(t *testing.T) {
 	assetsDir := t.TempDir()
 

--- a/internal/infra/git_workspace.go
+++ b/internal/infra/git_workspace.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -62,4 +63,30 @@ func ResolveQueuePath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(workspace, "queue"), nil
+}
+
+// ResolveHomeAssetsPath はホームスコープのアセットルートパス (~/.vox-actor/assets/) を返す。
+func ResolveHomeAssetsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".vox-actor", "assets"), nil
+}
+
+// ResolveProjectAssetsPath はプロジェクトスコープのアセットルートパスを返す。
+// git リポジトリ内なら <repoRoot>/.vox-actor/assets/、それ以外は <cwd>/.vox-actor/assets/。
+func ResolveProjectAssetsPath() (string, error) {
+	path, err := ResolveWorkspacePath()
+	if errors.Is(err, ErrNotInGitRepo) {
+		cwd, cwdErr := os.Getwd()
+		if cwdErr != nil {
+			return "", cwdErr
+		}
+		return filepath.Join(cwd, ".vox-actor", "assets"), nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(path, "assets"), nil
 }

--- a/internal/infra/git_workspace_test.go
+++ b/internal/infra/git_workspace_test.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -189,5 +190,71 @@ func TestResolveWorkspacePath_ReturnsErrGitNotFound_WhenRunnerReportsCommandMiss
 	_, err := ResolveWorkspacePath()
 	if !errors.Is(err, ErrGitNotFound) {
 		t.Errorf("expected ErrGitNotFound, got: %v", err)
+	}
+}
+
+func TestResolveHomeAssetsPath_ReturnsDotVoxActorAssetsUnderHome(t *testing.T) {
+	got, err := ResolveHomeAssetsPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".vox-actor", "assets")
+	if got != want {
+		t.Errorf("ResolveHomeAssetsPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveProjectAssetsPath_ReturnsGitRepoAssetsDir_WhenInGitRepo(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	repoRoot := t.TempDir()
+	gitCommonDir := filepath.Join(repoRoot, ".git")
+
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("echo", gitCommonDir)
+	})
+
+	got, err := ResolveProjectAssetsPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(repoRoot, ".vox-actor", "assets")
+	if got != want {
+		t.Errorf("ResolveProjectAssetsPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveProjectAssetsPath_ReturnsCwdAssetsDir_WhenOutsideGitRepo(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	})
+
+	cwd, _ := os.Getwd()
+	got, err := ResolveProjectAssetsPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(cwd, ".vox-actor", "assets")
+	if got != want {
+		t.Errorf("ResolveProjectAssetsPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveProjectAssetsPath_RespectsVoxActorWorkspaceEnv(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", workspace)
+
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	})
+
+	got, err := ResolveProjectAssetsPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(workspace, "assets")
+	if got != want {
+		t.Errorf("ResolveProjectAssetsPath() = %q, want %q", got, want)
 	}
 }

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -37,8 +37,11 @@ type HTTPStreamPlayer struct {
 	apiStatusJSON []byte
 
 	// workspacePath はキャラクター設定ファイルの読み込み先ワークスペースルート。
-	// 空文字の場合はキャラクター機能は無効。
+	// 空文字の場合はキャラクター機能は無効。WithWorkspacePath で設定される。
 	workspacePath string
+	// assetsDirs はキャラクター資産ディレクトリのリスト（優先順: index 0 が最高優先）。
+	// 設定されている場合、workspacePath の代わりにこちらが使われる。
+	assetsDirs []string
 	// apiCharactersJSON は Start 時に characters 設定から一度だけマーシャルしたレスポンス。
 	apiCharactersJSON []byte
 
@@ -193,6 +196,16 @@ func WithWorkspacePath(path string) HTTPStreamOption {
 	return func(p *HTTPStreamPlayer) {
 		if path != "" {
 			p.workspacePath = path
+			p.assetsDirs = []string{filepath.Join(path, workspaceAssetsDir)}
+		}
+	}
+}
+
+// WithAssetsDirs はキャラクター資産ディレクトリのリストを設定するオプション（index 0 が最高優先）。
+func WithAssetsDirs(dirs []string) HTTPStreamOption {
+	return func(p *HTTPStreamPlayer) {
+		if len(dirs) > 0 {
+			p.assetsDirs = dirs
 		}
 	}
 }
@@ -599,13 +612,21 @@ func (p *HTTPStreamPlayer) buildAPIStatusJSON() error {
 
 // buildAPICharactersJSON はキャラクター設定から /api/characters のレスポンスを
 // Start 時に一度だけマーシャルしてキャッシュする。
-// workspacePath が空の場合は enabled=false で固定する。
+// assetsDirs が空の場合は enabled=false で固定する。
 // speaker.json から読み込み、有効なエントリが見つからない場合は enabled=false。
 func (p *HTTPStreamPlayer) buildAPICharactersJSON() error {
 	entries := []characterEntry{}
 	enabled := false
 
-	if p.workspacePath != "" {
+	if len(p.assetsDirs) > 0 {
+		mergedEntries := p.loadMergedCharacterSettings()
+		if len(mergedEntries) > 0 {
+			entries = mergedEntries
+			enabled = true
+			p.logger.Info("character settings loaded", "count", len(entries))
+		}
+	} else if p.workspacePath != "" {
+		// backward compat: WithWorkspacePath 呼び出しで assetsDirs が未設定の場合
 		fsys := os.DirFS(p.workspacePath)
 		loadedEntries, loadErr := loadCharacterSettingsFromSpeakerJSON(fsys, p.workspacePath, workspaceAssetsDir, p.logger)
 		if loadErr != nil {
@@ -629,6 +650,38 @@ func (p *HTTPStreamPlayer) buildAPICharactersJSON() error {
 	}
 	p.apiCharactersJSON = payload
 	return nil
+}
+
+// loadMergedCharacterSettings は assetsDirs から優先順にキャラクター設定を読み込み、
+// 同一 charID の重複は高優先側（index 0）で上書きしたエントリリストを返す。
+func (p *HTTPStreamPlayer) loadMergedCharacterSettings() []characterEntry {
+	// charID → entries のマップ。高優先順に走査し、初回登録のみ採用。
+	seen := make(map[string]bool)
+	var result []characterEntry
+
+	for _, assetsDir := range p.assetsDirs {
+		fsys := os.DirFS(assetsDir)
+		loadedEntries, loadErr := loadCharacterSettingsFromSpeakerJSON(fsys, assetsDir, ".", p.logger)
+		if loadErr != nil {
+			p.logger.Warn("failed to load character settings",
+				"assetsDir", assetsDir,
+				"error", loadErr)
+			continue
+		}
+		// Group entries by charID (first path segment)
+		charGroups := make(map[string][]characterEntry)
+		for _, entry := range loadedEntries {
+			charID := strings.SplitN(entry.MouthClosed, "/", 2)[0]
+			charGroups[charID] = append(charGroups[charID], entry)
+		}
+		for charID, group := range charGroups {
+			if !seen[charID] {
+				seen[charID] = true
+				result = append(result, group...)
+			}
+		}
+	}
+	return result
 }
 
 // loadCharacterSettingsFromSpeakerJSON はfsys内のassetsDir/*/speaker.jsonを走査し、
@@ -776,24 +829,45 @@ func (p *HTTPStreamPlayer) handleAPICharacters(w http.ResponseWriter, _ *http.Re
 }
 
 func (p *HTTPStreamPlayer) handleCharacterImage(w http.ResponseWriter, r *http.Request) {
-	if p.workspacePath == "" {
-		http.NotFound(w, r)
-		return
-	}
-
 	relPath := strings.TrimPrefix(r.URL.Path, "/assets/images/")
 	if relPath == r.URL.Path {
 		http.NotFound(w, r)
 		return
 	}
 
+	if len(p.assetsDirs) > 0 {
+		// assetsDirs を優先順に検索し、charID が存在する最初の dir から配信する
+		segments := strings.SplitN(relPath, "/", 2)
+		if len(segments) < 2 {
+			http.NotFound(w, r)
+			return
+		}
+		charID := segments[0]
+		for _, assetsDir := range p.assetsDirs {
+			if _, err := os.Stat(filepath.Join(assetsDir, charID)); err != nil {
+				continue
+			}
+			if err := validateImagePath(relPath, assetsDir); err != nil {
+				http.Error(w, "invalid path", http.StatusBadRequest)
+				return
+			}
+			http.ServeFile(w, r, filepath.Join(assetsDir, relPath))
+			return
+		}
+		http.NotFound(w, r)
+		return
+	}
+
+	// backward compat: assetsDirs 未設定時は workspacePath から解決
+	if p.workspacePath == "" {
+		http.NotFound(w, r)
+		return
+	}
 	if err := validateImagePath(relPath, filepath.Join(p.workspacePath, workspaceAssetsDir)); err != nil {
 		http.Error(w, "invalid path", http.StatusBadRequest)
 		return
 	}
-
-	fullPath := filepath.Join(p.workspacePath, workspaceAssetsDir, relPath)
-	http.ServeFile(w, r, fullPath)
+	http.ServeFile(w, r, filepath.Join(p.workspacePath, workspaceAssetsDir, relPath))
 }
 
 func (p *HTTPStreamPlayer) handleTestClip(w http.ResponseWriter, r *http.Request) {

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -625,20 +625,6 @@ func (p *HTTPStreamPlayer) buildAPICharactersJSON() error {
 			enabled = true
 			p.logger.Info("character settings loaded", "count", len(entries))
 		}
-	} else if p.workspacePath != "" {
-		// backward compat: WithWorkspacePath 呼び出しで assetsDirs が未設定の場合
-		fsys := os.DirFS(p.workspacePath)
-		loadedEntries, loadErr := loadCharacterSettingsFromSpeakerJSON(fsys, p.workspacePath, workspaceAssetsDir, p.logger)
-		if loadErr != nil {
-			p.logger.Warn("failed to load character settings",
-				"workspacePath", p.workspacePath,
-				"assetsDir", workspaceAssetsDir,
-				"error", loadErr)
-		} else if len(loadedEntries) > 0 {
-			entries = loadedEntries
-			enabled = true
-			p.logger.Info("character settings loaded", "count", len(entries))
-		}
 	}
 
 	payload, err := json.Marshal(apiCharactersJSON{
@@ -858,16 +844,7 @@ func (p *HTTPStreamPlayer) handleCharacterImage(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// backward compat: assetsDirs 未設定時は workspacePath から解決
-	if p.workspacePath == "" {
-		http.NotFound(w, r)
-		return
-	}
-	if err := validateImagePath(relPath, filepath.Join(p.workspacePath, workspaceAssetsDir)); err != nil {
-		http.Error(w, "invalid path", http.StatusBadRequest)
-		return
-	}
-	http.ServeFile(w, r, filepath.Join(p.workspacePath, workspaceAssetsDir, relPath))
+	http.NotFound(w, r)
 }
 
 func (p *HTTPStreamPlayer) handleTestClip(w http.ResponseWriter, r *http.Request) {

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -641,7 +641,6 @@ func (p *HTTPStreamPlayer) buildAPICharactersJSON() error {
 // loadMergedCharacterSettings は assetsDirs から優先順にキャラクター設定を読み込み、
 // 同一 charID の重複は高優先側（index 0）で上書きしたエントリリストを返す。
 func (p *HTTPStreamPlayer) loadMergedCharacterSettings() []characterEntry {
-	// charID → entries のマップ。高優先順に走査し、初回登録のみ採用。
 	seen := make(map[string]bool)
 	var result []characterEntry
 

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -1974,3 +1974,238 @@ func TestBuildAPICharactersJSON_LogsInfoOnSuccess(t *testing.T) {
 		t.Errorf("expected 'character settings loaded' in log, got: %s", logOutput)
 	}
 }
+
+// newValidAssetsDir は assets ディレクトリを直接作成する（workspacePath なしで WithAssetsDirs で使用）。
+func newValidAssetsDir(t *testing.T) string {
+	t.Helper()
+	assetsDir := t.TempDir()
+	speakerDir := filepath.Join(assetsDir, "zundamon")
+	if err := os.MkdirAll(speakerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	speakerJSON := `{"speakerName":"ずんだもん","styles":[{"styleName":"ノーマル","mouthClosed":"normal_closed.png","mouthOpened":"normal_opened.png"}]}`
+	if err := os.WriteFile(filepath.Join(speakerDir, "speaker.json"), []byte(speakerJSON), 0o644); err != nil {
+		t.Fatalf("WriteFile speaker.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(speakerDir, "normal_closed.png"), []byte(""), 0o644); err != nil {
+		t.Fatalf("WriteFile normal_closed.png: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(speakerDir, "normal_opened.png"), []byte(""), 0o644); err != nil {
+		t.Fatalf("WriteFile normal_opened.png: %v", err)
+	}
+	return assetsDir
+}
+
+func TestHTTPStreamPlayer_WithAssetsDirs_EnablesCharacters(t *testing.T) {
+	t.Parallel()
+	assetsDir := newValidAssetsDir(t)
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(), WithAssetsDirs([]string{assetsDir}))
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/characters")
+	if err != nil {
+		t.Fatalf("GET /api/characters: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if enabled, _ := result["enabled"].(bool); !enabled {
+		t.Errorf("expected enabled=true, got %v", result)
+	}
+}
+
+func TestHTTPStreamPlayer_WithAssetsDirs_MergesProjectAndHome(t *testing.T) {
+	t.Parallel()
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	// project: charA
+	charADir := filepath.Join(projectDir, "charA")
+	if err := os.MkdirAll(charADir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	speakerA := `{"speakerName":"キャラA","styles":[{"styleName":"ノーマル","mouthClosed":"a_closed.png","mouthOpened":"a_opened.png"}]}`
+	if err := os.WriteFile(filepath.Join(charADir, "speaker.json"), []byte(speakerA), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	for _, f := range []string{"a_closed.png", "a_opened.png"} {
+		if err := os.WriteFile(filepath.Join(charADir, f), []byte(""), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", f, err)
+		}
+	}
+
+	// home: charB
+	charBDir := filepath.Join(homeDir, "charB")
+	if err := os.MkdirAll(charBDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	speakerB := `{"speakerName":"キャラB","styles":[{"styleName":"ノーマル","mouthClosed":"b_closed.png","mouthOpened":"b_opened.png"}]}`
+	if err := os.WriteFile(filepath.Join(charBDir, "speaker.json"), []byte(speakerB), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	for _, f := range []string{"b_closed.png", "b_opened.png"} {
+		if err := os.WriteFile(filepath.Join(charBDir, f), []byte(""), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", f, err)
+		}
+	}
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithAssetsDirs([]string{projectDir, homeDir}),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/characters")
+	if err != nil {
+		t.Fatalf("GET /api/characters: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	chars, _ := result["characters"].([]interface{})
+	if len(chars) != 2 {
+		t.Errorf("expected 2 characters (merged), got %d: %v", len(chars), chars)
+	}
+}
+
+func TestHTTPStreamPlayer_WithAssetsDirs_ProjectPriorityOnDuplicateID(t *testing.T) {
+	t.Parallel()
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	// Both have "shared" but different speaker names
+	for dir, speakerName := range map[string]string{projectDir: "プロジェクト版", homeDir: "ホーム版"} {
+		d := filepath.Join(dir, "shared")
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		speakerJSON := `{"speakerName":"` + speakerName + `","styles":[{"styleName":"ノーマル","mouthClosed":"closed.png","mouthOpened":"opened.png"}]}`
+		if err := os.WriteFile(filepath.Join(d, "speaker.json"), []byte(speakerJSON), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		for _, f := range []string{"closed.png", "opened.png"} {
+			if err := os.WriteFile(filepath.Join(d, f), []byte(""), 0o644); err != nil {
+				t.Fatalf("WriteFile %s: %v", f, err)
+			}
+		}
+	}
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithAssetsDirs([]string{projectDir, homeDir}),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/characters")
+	if err != nil {
+		t.Fatalf("GET /api/characters: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	chars, _ := result["characters"].([]interface{})
+	if len(chars) != 1 {
+		t.Fatalf("expected 1 character (deduplicated), got %d", len(chars))
+	}
+	char, _ := chars[0].(map[string]interface{})
+	if char["speakerName"] != "プロジェクト版" {
+		t.Errorf("expected speakerName 'プロジェクト版', got %v", char["speakerName"])
+	}
+}
+
+func TestHTTPStreamPlayer_HandleCharacterImage_SearchesAcrossAssetsDirs(t *testing.T) {
+	t.Parallel()
+	projectDir := t.TempDir()
+	homeDir := t.TempDir()
+
+	// project: charA with image
+	charADir := filepath.Join(projectDir, "charA")
+	if err := os.MkdirAll(charADir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	imageContent := []byte("project-image-data")
+	if err := os.WriteFile(filepath.Join(charADir, "icon.png"), imageContent, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	speakerA := `{"speakerName":"キャラA","styles":[{"styleName":"ノーマル","mouthClosed":"icon.png","mouthOpened":"icon.png"}]}`
+	if err := os.WriteFile(filepath.Join(charADir, "speaker.json"), []byte(speakerA), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// home: charB with image
+	charBDir := filepath.Join(homeDir, "charB")
+	if err := os.MkdirAll(charBDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	imageBContent := []byte("home-image-data")
+	if err := os.WriteFile(filepath.Join(charBDir, "icon.png"), imageBContent, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	speakerB := `{"speakerName":"キャラB","styles":[{"styleName":"ノーマル","mouthClosed":"icon.png","mouthOpened":"icon.png"}]}`
+	if err := os.WriteFile(filepath.Join(charBDir, "speaker.json"), []byte(speakerB), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithAssetsDirs([]string{projectDir, homeDir}),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	// image from homeDir's charB should be served
+	resp, err := http.Get("http://" + p.Addr() + "/assets/images/charB/icon.png")
+	if err != nil {
+		t.Fatalf("GET /assets/images/charB/icon.png: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != string(imageBContent) {
+		t.Errorf("expected home image content %q, got %q", imageBContent, body)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -44,9 +44,15 @@ func main() {
 			infra.WithOrderedSpeakerIDs(orderedSpeakerIDs),
 			infra.WithVoicevoxClient(client),
 		}
-		workspacePath, wsErr := infra.ResolveWorkspacePath()
-		if wsErr == nil {
-			opts = append(opts, infra.WithWorkspacePath(workspacePath))
+		var assetsDirs []string
+		if projectAssets, err := infra.ResolveProjectAssetsPath(); err == nil {
+			assetsDirs = append(assetsDirs, projectAssets)
+		}
+		if homeAssets, err := infra.ResolveHomeAssetsPath(); err == nil {
+			assetsDirs = append(assetsDirs, homeAssets)
+		}
+		if len(assetsDirs) > 0 {
+			opts = append(opts, infra.WithAssetsDirs(assetsDirs))
 		}
 		return infra.NewHTTPStreamPlayer(addr, staticFS, opts...)
 	}


### PR DESCRIPTION
## Summary

- `vox-actor assets download --scope home` でホームディレクトリ (`~/.vox-actor/assets/`) にキャラクター資産を配置できるようにした
- `vox-actor speakers list` / `speakers profile` がプロジェクトとホーム両方の assets をマージして返すようにした（同一 ID はプロジェクト優先）
- HTTP サーバー（`vox-actor viewer`）もプロジェクト + ホームの assets をマージして読み込み・画像配信するようにした

## 主な変更

- `internal/infra`: `ResolveHomeAssetsPath()` / `ResolveProjectAssetsPath()` を追加（git リポジトリ外では CWD にフォールバック）
- `cmd/assets_download.go`: `--scope home|project` フラグを追加（既定: `project`）
- `cmd/speakers.go`: 単一 assetsDir → 優先順位付き複数 dirs のマージに変更
- `internal/infra/http_stream_player.go`: `WithAssetsDirs([]string{...})` オプションを追加、マージ読み込み・画像配信に対応

## Test plan

- [ ] `vox-actor assets download <repo> --scope home` → `~/.vox-actor/assets/` に配置されることを確認
- [ ] `vox-actor assets download <repo>` → `<repoRoot>/.vox-actor/assets/` に配置されることを確認（既存動作維持）
- [ ] `vox-actor speakers list` → project + home の両キャラが表示されることを確認
- [ ] `--scope` に不正値を渡すとエラーになることを確認
- ※ VOICEVOX 接続が必要なテストは手動確認

Closes #395

---
🤖 Generated with [Claude Code](https://claude.ai/code)
