### PR TITLE
feat(viewer): キャラ表示まわりのラベル統一と再生中セリフ表示への変更

### DIFF
--- a/frontend/src/components/StreamPanel.test.tsx
+++ b/frontend/src/components/StreamPanel.test.tsx
@@ -105,7 +105,7 @@ describe("StreamPanel", () => {
       />,
     );
     expect(
-      screen.queryByLabelText("キャラ画像を表示"),
+      screen.queryByLabelText("キャラ画像"),
     ).not.toBeInTheDocument();
   });
 
@@ -118,7 +118,7 @@ describe("StreamPanel", () => {
         showCharacters={false}
       />,
     );
-    expect(screen.getByLabelText("キャラ画像を表示")).toBeInTheDocument();
+    expect(screen.getByLabelText("キャラ画像")).toBeInTheDocument();
   });
 
   it("showCharacters=false のとき履歴モードで全エントリが表示される", () => {
@@ -154,7 +154,7 @@ describe("StreamPanel", () => {
     expect(screen.getByText("新しいテキスト")).toBeInTheDocument();
   });
 
-  it("キャラモード時は Timeline が latestOnly で最新 1 件のみ表示される", () => {
+  it("キャラモード時は再生中クリップのセリフのみ表示される", () => {
     const entries: TimelineEntry[] = [
       {
         kind: "clip",
@@ -190,5 +190,56 @@ describe("StreamPanel", () => {
     );
     expect(screen.queryByText("古いテキスト")).not.toBeInTheDocument();
     expect(screen.getByText("新しいテキスト")).toBeInTheDocument();
+  });
+
+  it("キャラモード時は再生中でない最新エントリではなく playingClipId のエントリが表示される", () => {
+    const entries: TimelineEntry[] = [
+      {
+        kind: "clip",
+        id: 1,
+        url: "http://example.com/1.mp3",
+        text: "古いテキスト",
+        speakerName: "話者A",
+        styleName: "ノーマル",
+        timestamp: 1700000000000,
+      },
+      {
+        kind: "clip",
+        id: 2,
+        url: "http://example.com/2.mp3",
+        text: "新しいテキスト",
+        speakerName: "話者A",
+        styleName: "ノーマル",
+        timestamp: 1700000001000,
+      },
+    ];
+    render(
+      <StreamPanel
+        {...defaultProps}
+        hidden={false}
+        entries={entries}
+        characters={mockCharacters}
+        charactersEnabled={true}
+        showCharacters={true}
+        playingClipId={1}
+      />,
+    );
+    expect(screen.getByText("古いテキスト")).toBeInTheDocument();
+    expect(screen.queryByText("新しいテキスト")).not.toBeInTheDocument();
+  });
+
+  it("キャラモード時は再生中ハイライト（▶）が表示されない", () => {
+    render(
+      <StreamPanel
+        {...defaultProps}
+        hidden={false}
+        entries={mockEntries}
+        characters={mockCharacters}
+        charactersEnabled={true}
+        showCharacters={true}
+        playingClipId={1}
+      />,
+    );
+    expect(screen.queryByText("▶")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/StreamPanel.tsx
+++ b/frontend/src/components/StreamPanel.tsx
@@ -212,7 +212,7 @@ export function StreamPanel(props: StreamPanelProps) {
         showSpeakerName={showSpeakerName}
         showStyleName={showStyleName}
         showTimestamp={showTimestamp}
-        latestOnly={isCharacterMode}
+        isCharacterMode={isCharacterMode}
       />
     </section>
   );

--- a/frontend/src/components/Timeline.test.tsx
+++ b/frontend/src/components/Timeline.test.tsx
@@ -83,34 +83,92 @@ describe("Timeline", () => {
     expect(screen.getByText("合成に失敗しました")).toBeInTheDocument();
   });
 
-  describe("latestOnly", () => {
+  describe("isCharacterMode", () => {
     const entries: TimelineEntry[] = [
       clipEntry(1, "古いテキスト"),
       clipEntry(2, "新しいテキスト"),
     ];
 
-    it("latestOnly=true のとき最後の 1 件のみ描画される", () => {
-      render(<Timeline {...defaultProps} entries={entries} latestOnly={true} />);
+    it("isCharacterMode=true のとき再生中クリップのみ描画される", () => {
+      render(
+        <Timeline
+          {...defaultProps}
+          entries={entries}
+          playingClipId={2}
+          isCharacterMode={true}
+        />,
+      );
       expect(screen.queryByText("古いテキスト")).not.toBeInTheDocument();
       expect(screen.getByText("新しいテキスト")).toBeInTheDocument();
       expect(screen.getAllByRole("listitem")).toHaveLength(1);
     });
 
-    it("latestOnly=false のとき全件描画される", () => {
-      render(<Timeline {...defaultProps} entries={entries} latestOnly={false} />);
+    it("isCharacterMode=true かつ playingClipId が最新でないエントリでも、そのエントリが描画される", () => {
+      render(
+        <Timeline
+          {...defaultProps}
+          entries={entries}
+          playingClipId={1}
+          isCharacterMode={true}
+        />,
+      );
+      expect(screen.getByText("古いテキスト")).toBeInTheDocument();
+      expect(screen.queryByText("新しいテキスト")).not.toBeInTheDocument();
+    });
+
+    it("isCharacterMode=true かつ playingClipId=null のとき何も描画されない", () => {
+      render(
+        <Timeline
+          {...defaultProps}
+          entries={entries}
+          playingClipId={null}
+          isCharacterMode={true}
+        />,
+      );
+      expect(screen.getByRole("list")).toBeEmptyDOMElement();
+    });
+
+    it("isCharacterMode=false のとき全件描画される", () => {
+      render(
+        <Timeline
+          {...defaultProps}
+          entries={entries}
+          isCharacterMode={false}
+        />,
+      );
       expect(screen.getByText("古いテキスト")).toBeInTheDocument();
       expect(screen.getByText("新しいテキスト")).toBeInTheDocument();
       expect(screen.getAllByRole("listitem")).toHaveLength(2);
     });
 
-    it("latestOnly を省略したとき全件描画される", () => {
+    it("isCharacterMode を省略したとき全件描画される", () => {
       render(<Timeline {...defaultProps} entries={entries} />);
       expect(screen.getAllByRole("listitem")).toHaveLength(2);
     });
 
-    it("latestOnly=true かつ entries が空のとき何も描画されない", () => {
-      render(<Timeline {...defaultProps} entries={[]} latestOnly={true} />);
-      expect(screen.getByRole("list")).toBeEmptyDOMElement();
+    it("isCharacterMode=true のとき再生中ハイライト（▶）が表示されない", () => {
+      render(
+        <Timeline
+          {...defaultProps}
+          entries={entries}
+          playingClipId={2}
+          isCharacterMode={true}
+        />,
+      );
+      expect(screen.queryByText("▶")).not.toBeInTheDocument();
+    });
+
+    it("isCharacterMode=true のとき話者名が常に表示される", () => {
+      render(
+        <Timeline
+          {...defaultProps}
+          entries={entries}
+          playingClipId={1}
+          showSpeakerName={false}
+          isCharacterMode={true}
+        />,
+      );
+      expect(screen.getByText("話者A")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { TimelineEntry } from "../types/api";
 import { TimelineItem } from "./TimelineItem";
 
@@ -7,7 +8,7 @@ interface TimelineProps {
   showSpeakerName: boolean;
   showStyleName: boolean;
   showTimestamp: boolean;
-  latestOnly?: boolean;
+  isCharacterMode?: boolean;
 }
 
 export function Timeline({
@@ -16,23 +17,43 @@ export function Timeline({
   showSpeakerName,
   showStyleName,
   showTimestamp,
-  latestOnly = false,
+  isCharacterMode = false,
 }: TimelineProps) {
-  const displayEntries = latestOnly ? entries.slice(-1) : entries;
+  const listRef = useRef<HTMLOListElement>(null);
+  const prevIsCharacterMode = useRef(isCharacterMode);
+
+  useEffect(() => {
+    if (!isCharacterMode && prevIsCharacterMode.current) {
+      const list = listRef.current;
+      if (list) {
+        list.scrollTop = list.scrollHeight;
+      }
+    }
+    prevIsCharacterMode.current = isCharacterMode;
+  }, [isCharacterMode]);
+
+  const displayEntries = isCharacterMode
+    ? playingClipId !== null
+      ? entries.filter((e) => e.kind === "clip" && e.id === playingClipId)
+      : []
+    : entries;
+
+  const listCls = isCharacterMode
+    ? "m-0 h-[7rem] list-none overflow-y-auto p-0"
+    : "m-0 max-h-[65vh] list-none overflow-y-auto p-0 md:max-h-[60vh]";
+
   return (
     <div className="rounded-md bg-ctp-base px-3 py-[0.75rem] sm:px-4">
-      <ol
-        aria-live="polite"
-        className="m-0 max-h-[65vh] list-none overflow-y-auto p-0 md:max-h-[60vh]"
-      >
+      <ol ref={listRef} aria-live="polite" className={listCls}>
         {displayEntries.map((entry) => (
           <TimelineItem
             key={`${entry.kind}-${entry.id}`}
             entry={entry}
             playing={entry.kind === "clip" && entry.id === playingClipId}
-            showSpeakerName={showSpeakerName}
-            showStyleName={showStyleName}
-            showTimestamp={showTimestamp}
+            showSpeakerName={isCharacterMode ? true : showSpeakerName}
+            showStyleName={isCharacterMode ? false : showStyleName}
+            showTimestamp={isCharacterMode ? false : showTimestamp}
+            highlightPlaying={!isCharacterMode}
           />
         ))}
       </ol>

--- a/frontend/src/components/TimelineControls.test.tsx
+++ b/frontend/src/components/TimelineControls.test.tsx
@@ -48,17 +48,17 @@ describe("TimelineControls - 履歴サイズ", () => {
 });
 
 describe("TimelineControls - チェックボックストグル", () => {
-  it("showSpeakerName=true のとき話者名チェックボックスが checked になる", () => {
+  it("showSpeakerName=true のときキャラ名チェックボックスが checked になる", () => {
     render(<TimelineControls {...defaultProps} showSpeakerName={true} />);
-    expect(screen.getByLabelText("話者名")).toBeChecked();
+    expect(screen.getByLabelText("キャラ名")).toBeChecked();
   });
 
-  it("showSpeakerName=false のとき話者名チェックボックスが unchecked になる", () => {
+  it("showSpeakerName=false のときキャラ名チェックボックスが unchecked になる", () => {
     render(<TimelineControls {...defaultProps} showSpeakerName={false} />);
-    expect(screen.getByLabelText("話者名")).not.toBeChecked();
+    expect(screen.getByLabelText("キャラ名")).not.toBeChecked();
   });
 
-  it("話者名チェックボックスをクリックすると onShowSpeakerNameChange が呼ばれる", async () => {
+  it("キャラ名チェックボックスをクリックすると onShowSpeakerNameChange が呼ばれる", async () => {
     const user = userEvent.setup();
     const onShowSpeakerNameChange = vi.fn();
     render(
@@ -67,7 +67,7 @@ describe("TimelineControls - チェックボックストグル", () => {
         onShowSpeakerNameChange={onShowSpeakerNameChange}
       />,
     );
-    await user.click(screen.getByLabelText("話者名"));
+    await user.click(screen.getByLabelText("キャラ名"));
     expect(onShowSpeakerNameChange).toHaveBeenCalledWith(true);
     expect(onShowSpeakerNameChange).toHaveBeenCalledTimes(1);
   });
@@ -115,7 +115,7 @@ describe("TimelineControls - キャラ画像チェックボックス", () => {
   it("charactersEnabled=false のときキャラ画像チェックボックスが描画されない", () => {
     render(<TimelineControls {...defaultProps} charactersEnabled={false} />);
     expect(
-      screen.queryByLabelText("キャラ画像を表示"),
+      screen.queryByLabelText("キャラ画像"),
     ).not.toBeInTheDocument();
   });
 
@@ -128,7 +128,7 @@ describe("TimelineControls - キャラ画像チェックボックス", () => {
         onShowCharactersChange={vi.fn()}
       />,
     );
-    expect(screen.getByLabelText("キャラ画像を表示")).toBeInTheDocument();
+    expect(screen.getByLabelText("キャラ画像")).toBeInTheDocument();
   });
 
   it("showCharacters=true のときキャラ画像チェックボックスが checked になる", () => {
@@ -140,7 +140,7 @@ describe("TimelineControls - キャラ画像チェックボックス", () => {
         onShowCharactersChange={vi.fn()}
       />,
     );
-    expect(screen.getByLabelText("キャラ画像を表示")).toBeChecked();
+    expect(screen.getByLabelText("キャラ画像")).toBeChecked();
   });
 
   it("showCharacters=false のときキャラ画像チェックボックスが unchecked になる", () => {
@@ -152,7 +152,7 @@ describe("TimelineControls - キャラ画像チェックボックス", () => {
         onShowCharactersChange={vi.fn()}
       />,
     );
-    expect(screen.getByLabelText("キャラ画像を表示")).not.toBeChecked();
+    expect(screen.getByLabelText("キャラ画像")).not.toBeChecked();
   });
 
   it("キャラ画像チェックボックスをクリックすると onShowCharactersChange が呼ばれる", async () => {
@@ -166,7 +166,7 @@ describe("TimelineControls - キャラ画像チェックボックス", () => {
         onShowCharactersChange={onShowCharactersChange}
       />,
     );
-    await user.click(screen.getByLabelText("キャラ画像を表示"));
+    await user.click(screen.getByLabelText("キャラ画像"));
     expect(onShowCharactersChange).toHaveBeenCalledWith(true);
     expect(onShowCharactersChange).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/components/TimelineControls.tsx
+++ b/frontend/src/components/TimelineControls.tsx
@@ -63,7 +63,7 @@ export function TimelineControls(props: TimelineControlsProps) {
         ))}
       </select>
       <CheckboxToggle
-        label="話者名"
+        label="キャラ名"
         checked={showSpeakerName}
         onChange={onShowSpeakerNameChange}
       />
@@ -79,7 +79,7 @@ export function TimelineControls(props: TimelineControlsProps) {
       />
       {charactersEnabled && onShowCharactersChange && (
         <CheckboxToggle
-          label="キャラ画像を表示"
+          label="キャラ画像"
           checked={showCharacters}
           onChange={onShowCharactersChange}
         />

--- a/frontend/src/components/TimelineItem.test.tsx
+++ b/frontend/src/components/TimelineItem.test.tsx
@@ -48,6 +48,23 @@ describe("TimelineItem - clip", () => {
     const item = screen.getByRole("listitem");
     expect(item).not.toHaveClass("bg-ctp-overlay");
   });
+
+  it("highlightPlaying=false のとき playing=true でもハイライトクラスが付かない", () => {
+    render(<TimelineItem {...defaultProps} playing={true} highlightPlaying={false} />);
+    const item = screen.getByRole("listitem");
+    expect(item).not.toHaveClass("bg-ctp-overlay");
+  });
+
+  it("highlightPlaying=false のとき playing=true でも再生アイコンが表示されない", () => {
+    render(<TimelineItem {...defaultProps} playing={true} highlightPlaying={false} />);
+    expect(screen.queryByText("▶")).not.toBeInTheDocument();
+  });
+
+  it("highlightPlaying=true（デフォルト）のとき playing=true でハイライトクラスが付く", () => {
+    render(<TimelineItem {...defaultProps} playing={true} />);
+    const item = screen.getByRole("listitem");
+    expect(item).toHaveClass("bg-ctp-overlay");
+  });
 });
 
 describe("TimelineItem - clip meta toggles", () => {

--- a/frontend/src/components/TimelineItem.tsx
+++ b/frontend/src/components/TimelineItem.tsx
@@ -7,6 +7,7 @@ interface TimelineItemProps {
   showSpeakerName: boolean;
   showStyleName: boolean;
   showTimestamp: boolean;
+  highlightPlaying?: boolean;
 }
 
 function formatTimestamp(ms: number): string {
@@ -26,6 +27,7 @@ export function TimelineItem({
   showSpeakerName,
   showStyleName,
   showTimestamp,
+  highlightPlaying = true,
 }: TimelineItemProps) {
   const ref = useRef<HTMLLIElement>(null);
   // 初期値は false 固定。マウント時点で playing=true のケース（SSE で
@@ -85,7 +87,7 @@ export function TimelineItem({
     );
   }
 
-  const playingCls = playing ? "bg-ctp-overlay font-bold" : "";
+  const playingCls = playing && highlightPlaying ? "bg-ctp-overlay font-bold" : "";
   return (
     <li
       ref={ref}
@@ -114,7 +116,7 @@ export function TimelineItem({
           aria-hidden
           className="inline-block w-[1em] flex-none text-ctp-blue"
         >
-          {playing ? "▶" : ""}
+          {playing && highlightPlaying ? "▶" : ""}
         </span>
         <span>{entry.text}</span>
       </div>

--- a/frontend/test/e2e/character.spec.ts
+++ b/frontend/test/e2e/character.spec.ts
@@ -13,7 +13,7 @@ test.describe("キャラ画像表示（配信タブ統合）", () => {
     ).not.toBeVisible();
   });
 
-  test("charactersEnabled=true のとき「キャラ画像を表示」チェックボックスが配信タブに表示される", async ({
+  test("charactersEnabled=true のとき「キャラ画像」チェックボックスが配信タブに表示される", async ({
     page,
     request,
   }) => {
@@ -31,11 +31,11 @@ test.describe("キャラ画像表示（配信タブ統合）", () => {
 
     await page.goto("/");
     await expect(
-      page.getByRole("checkbox", { name: "キャラ画像を表示" }),
+      page.getByRole("checkbox", { name: "キャラ画像" }),
     ).toBeVisible();
   });
 
-  test("charactersEnabled=false のとき「キャラ画像を表示」チェックボックスが非表示になる", async ({
+  test("charactersEnabled=false のとき「キャラ画像」チェックボックスが非表示になる", async ({
     page,
     request,
   }) => {
@@ -43,7 +43,7 @@ test.describe("キャラ画像表示（配信タブ統合）", () => {
 
     await page.goto("/");
     await expect(
-      page.getByRole("checkbox", { name: "キャラ画像を表示" }),
+      page.getByRole("checkbox", { name: "キャラ画像" }),
     ).not.toBeVisible();
   });
 });

--- a/frontend/test/e2e/persistence.spec.ts
+++ b/frontend/test/e2e/persistence.spec.ts
@@ -12,7 +12,7 @@ test.describe("各種設定の localStorage 永続化", () => {
     await page.goto("/");
 
     await page.getByLabel("履歴上限").selectOption("50");
-    await page.getByRole("checkbox", { name: "話者名" }).uncheck();
+    await page.getByRole("checkbox", { name: "キャラ名" }).uncheck();
     await page.getByRole("checkbox", { name: "スタイル" }).uncheck();
     await page.getByRole("checkbox", { name: "時刻" }).uncheck();
 
@@ -32,7 +32,7 @@ test.describe("各種設定の localStorage 永続化", () => {
     await page.reload();
     await expect(page.getByLabel("履歴上限")).toHaveValue("50");
     await expect(
-      page.getByRole("checkbox", { name: "話者名" }),
+      page.getByRole("checkbox", { name: "キャラ名" }),
     ).not.toBeChecked();
     await expect(
       page.getByRole("checkbox", { name: "スタイル" }),


### PR DESCRIPTION
## Summary

- **ラベル統一**: 配信タブの「話者名」→「キャラ名」、「キャラ画像を表示」→「キャラ画像」に変更
- **再生中セリフ表示**: キャラモード時のセリフ表示を「最新エントリ1件」から「`playingClipId` に対応するclipエントリ」に変更（口パクとセリフのズレを解消）
- **高さ固定**: キャラモード時のセリフ表示領域を `h-[7rem]` で固定し、キャラ画像の上下動を防止
- **ハイライト無効化**: キャラモード時は再生中ハイライト（背景色・太字・▶マーカー）を非表示
- **スクロール対応**: キャラ画像ON→OFF切替時に履歴Timelineを最新セリフまで自動スクロール

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `TimelineControls.tsx` | ラベル文言変更 |
| `TimelineItem.tsx` | `highlightPlaying` prop追加 |
| `Timeline.tsx` | `latestOnly` 廃止、`isCharacterMode` prop追加 |
| `StreamPanel.tsx` | `Timeline` の prop 更新 |
| 各 `*.test.tsx` / `e2e/*.spec.ts` | ラベル・挙動変更に追従 |

## Test plan

- [x] ユニットテスト全件 (141 tests) 通過確認済み
- [x] TypeScript型チェック通過確認済み
- [ ] 配信タブでチェックボックスラベルが「キャラ名」「キャラ画像」と表示されることを手動確認
- [ ] キャラ画像ON時、再生中クリップと表示セリフが一致することを手動確認（VOICEVOX接続環境が必要）
- [ ] キャラ画像ON→OFF切替時、Timelineが最新セリフまでスクロールされることを手動確認

Closes #399

---
🤖 Generated with [Claude Code](https://claude.ai/code)
