### PR TITLE
fix(viewer): キャラ画像ON時に再生終了後もセリフを保持する

### DIFF
--- a/frontend/src/components/StreamPanel.test.tsx
+++ b/frontend/src/components/StreamPanel.test.tsx
@@ -242,4 +242,35 @@ describe("StreamPanel", () => {
     );
     expect(screen.queryByText("▶")).not.toBeInTheDocument();
   });
+
+  it("キャラモード時、再生終了後（playingClipId=null）もセリフが表示される", async () => {
+    const { rerender } = render(
+      <StreamPanel
+        {...defaultProps}
+        hidden={false}
+        entries={mockEntries}
+        characters={mockCharacters}
+        charactersEnabled={true}
+        showCharacters={true}
+        playingClipId={1}
+      />,
+    );
+    expect(screen.getByText("クリップテキスト")).toBeInTheDocument();
+
+    // 再生終了
+    rerender(
+      <StreamPanel
+        {...defaultProps}
+        hidden={false}
+        entries={mockEntries}
+        characters={mockCharacters}
+        charactersEnabled={true}
+        showCharacters={true}
+        playingClipId={null}
+      />,
+    );
+
+    // キャラ画像はまだステージに残るのでセリフも残るべき
+    expect(screen.getByText("クリップテキスト")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/StreamPanel.tsx
+++ b/frontend/src/components/StreamPanel.tsx
@@ -70,7 +70,7 @@ export function StreamPanel(props: StreamPanelProps) {
     volume,
   } = props;
 
-  const { slots, isMultiSlot } = useCharacterStage(
+  const { slots, isMultiSlot, lastClipId } = useCharacterStage(
     playingClipId,
     entries,
     characters,
@@ -209,6 +209,7 @@ export function StreamPanel(props: StreamPanelProps) {
       <Timeline
         entries={entries}
         playingClipId={playingClipId}
+        lastPlayingClipId={lastClipId}
         showSpeakerName={showSpeakerName}
         showStyleName={showStyleName}
         showTimestamp={showTimestamp}

--- a/frontend/src/components/Timeline.test.tsx
+++ b/frontend/src/components/Timeline.test.tsx
@@ -128,6 +128,34 @@ describe("Timeline", () => {
       expect(screen.getByRole("list")).toBeEmptyDOMElement();
     });
 
+    it("isCharacterMode=true かつ playingClipId=null でも lastPlayingClipId が設定されていれば最後のクリップが表示される", () => {
+      render(
+        <Timeline
+          {...defaultProps}
+          entries={entries}
+          playingClipId={null}
+          lastPlayingClipId={2}
+          isCharacterMode={true}
+        />,
+      );
+      expect(screen.queryByText("古いテキスト")).not.toBeInTheDocument();
+      expect(screen.getByText("新しいテキスト")).toBeInTheDocument();
+    });
+
+    it("isCharacterMode=true かつ playingClipId が設定されている場合は lastPlayingClipId より優先される", () => {
+      render(
+        <Timeline
+          {...defaultProps}
+          entries={entries}
+          playingClipId={1}
+          lastPlayingClipId={2}
+          isCharacterMode={true}
+        />,
+      );
+      expect(screen.getByText("古いテキスト")).toBeInTheDocument();
+      expect(screen.queryByText("新しいテキスト")).not.toBeInTheDocument();
+    });
+
     it("isCharacterMode=false のとき全件描画される", () => {
       render(
         <Timeline

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -5,6 +5,7 @@ import { TimelineItem } from "./TimelineItem";
 interface TimelineProps {
   entries: TimelineEntry[];
   playingClipId: number | null;
+  lastPlayingClipId?: number | null;
   showSpeakerName: boolean;
   showStyleName: boolean;
   showTimestamp: boolean;
@@ -14,6 +15,7 @@ interface TimelineProps {
 export function Timeline({
   entries,
   playingClipId,
+  lastPlayingClipId = null,
   showSpeakerName,
   showStyleName,
   showTimestamp,
@@ -32,9 +34,10 @@ export function Timeline({
     prevIsCharacterMode.current = isCharacterMode;
   }, [isCharacterMode]);
 
+  const characterModeClipId = playingClipId ?? lastPlayingClipId;
   const displayEntries = isCharacterMode
-    ? playingClipId !== null
-      ? entries.filter((e) => e.kind === "clip" && e.id === playingClipId)
+    ? characterModeClipId !== null
+      ? entries.filter((e) => e.kind === "clip" && e.id === characterModeClipId)
       : []
     : entries;
 

--- a/frontend/src/hooks/useCharacterStage.test.ts
+++ b/frontend/src/hooks/useCharacterStage.test.ts
@@ -692,4 +692,146 @@ describe("useCharacterStage", () => {
       expect(result.current.lastClipText).toBe("text 7"); // last played clip
     });
   });
+
+  describe("lastClipId", () => {
+    it("初期状態ではlastClipIdがnull", () => {
+      const { result } = renderHook(() => useCharacterStage(null, [], []));
+      expect(result.current.lastClipId).toBeNull();
+    });
+
+    it("クリップ再生開始でlastClipIdが更新される", async () => {
+      const charA = makeChar("キャラA");
+      const entry1 = makeClipEntry(1, "キャラA");
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipId,
+          entries,
+          characters,
+        }: {
+          playingClipId: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipId, entries, characters),
+        {
+          initialProps: {
+            playingClipId: null,
+            entries: [entry1],
+            characters: [charA],
+          },
+        },
+      );
+
+      await act(async () => {
+        rerender({ playingClipId: 1, entries: [entry1], characters: [charA] });
+      });
+
+      expect(result.current.lastClipId).toBe(1);
+    });
+
+    it("クリップ再生終了後もlastClipIdが保持される", async () => {
+      const charA = makeChar("キャラA");
+      const entry1 = makeClipEntry(1, "キャラA");
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipId,
+          entries,
+          characters,
+        }: {
+          playingClipId: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipId, entries, characters),
+        {
+          initialProps: {
+            playingClipId: null,
+            entries: [entry1],
+            characters: [charA],
+          },
+        },
+      );
+
+      await act(async () => {
+        rerender({ playingClipId: 1, entries: [entry1], characters: [charA] });
+      });
+      await act(async () => {
+        rerender({
+          playingClipId: null,
+          entries: [entry1],
+          characters: [charA],
+        });
+      });
+
+      expect(result.current.lastClipId).toBe(1);
+    });
+
+    it("次のクリップ再生開始でlastClipIdが切り替わる", async () => {
+      const charA = makeChar("キャラA");
+      const charB = makeChar("キャラB");
+      const entries = [makeClipEntry(1, "キャラA"), makeClipEntry(2, "キャラB")];
+      const chars = [charA, charB];
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipId,
+          entries,
+          characters,
+        }: {
+          playingClipId: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipId, entries, characters),
+        { initialProps: { playingClipId: null, entries, characters: chars } },
+      );
+
+      await act(async () => {
+        rerender({ playingClipId: 1, entries, characters: chars });
+      });
+      expect(result.current.lastClipId).toBe(1);
+
+      await act(async () => {
+        rerender({ playingClipId: 2, entries, characters: chars });
+      });
+      expect(result.current.lastClipId).toBe(2);
+    });
+
+    it("ALL_EXIT後にlastClipIdがnullになる", async () => {
+      const charA = makeChar("キャラA");
+      const entry1 = makeClipEntry(1, "キャラA");
+      const chars = [charA];
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipId,
+          entries,
+          characters,
+        }: {
+          playingClipId: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipId, entries, characters),
+        {
+          initialProps: {
+            playingClipId: null,
+            entries: [entry1],
+            characters: chars,
+          },
+        },
+      );
+
+      await act(async () => {
+        rerender({ playingClipId: 1, entries: [entry1], characters: chars });
+      });
+      await act(async () => {
+        rerender({ playingClipId: null, entries: [entry1], characters: chars });
+      });
+      expect(result.current.lastClipId).toBe(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(QUEUE_EMPTY_MS);
+      });
+      expect(result.current.lastClipId).toBeNull();
+    });
+  });
 });

--- a/frontend/src/hooks/useCharacterStage.ts
+++ b/frontend/src/hooks/useCharacterStage.ts
@@ -14,6 +14,7 @@ interface StageState {
   chars: StageChar[];
   isMultiSlot: boolean;
   lastClipText: string | null;
+  lastClipId: number | null;
 }
 
 type StageAction =
@@ -24,6 +25,7 @@ type StageAction =
       startedCharacter: CharacterEntry | null;
       startedEntryOrder: number;
       startedClipText: string | null;
+      startedClipId: number | null;
     }
   | { type: "ALL_EXIT" };
 
@@ -97,12 +99,13 @@ function stageReducer(state: StageState, action: StageAction): StageState {
         chars.length === 0 ? false : state.isMultiSlot || chars.length >= 2;
 
       const lastClipText = action.startedClipText ?? state.lastClipText;
+      const lastClipId = action.startedClipId ?? state.lastClipId;
 
-      return { chars, isMultiSlot, lastClipText };
+      return { chars, isMultiSlot, lastClipText, lastClipId };
     }
 
     case "ALL_EXIT":
-      return { chars: [], isMultiSlot: false, lastClipText: null };
+      return { chars: [], isMultiSlot: false, lastClipText: null, lastClipId: null };
 
     default:
       return state;
@@ -117,6 +120,7 @@ export interface CharacterStageResult {
   slots: (CharacterStageSlot | null)[];
   isMultiSlot: boolean;
   lastClipText: string | null;
+  lastClipId: number | null;
 }
 
 export function useCharacterStage(
@@ -128,6 +132,7 @@ export function useCharacterStage(
     chars: [],
     isMultiSlot: false,
     lastClipText: null,
+    lastClipId: null,
   });
 
   const prevPlayingClipIdRef = useRef<number | null>(null);
@@ -182,6 +187,7 @@ export function useCharacterStage(
       startedCharacter,
       startedEntryOrder,
       startedClipText,
+      startedClipId: curr,
     });
 
     if (curr === null && prev !== null) {
@@ -209,5 +215,6 @@ export function useCharacterStage(
     slots,
     isMultiSlot: state.isMultiSlot,
     lastClipText: state.lastClipText,
+    lastClipId: state.lastClipId,
   };
 }


### PR DESCRIPTION
## Summary

- `useCharacterStage` フックに `lastClipId: number | null` を追加（`lastClipText` と同じライフサイクル: 再生開始で更新、再生終了後も保持、`ALL_EXIT`（15秒後）で `null` クリア）
- `Timeline` コンポーネントに `lastPlayingClipId` prop を追加し、キャラモードで `playingClipId=null` のとき `lastPlayingClipId` を fallback として使用することでセリフを保持
- `StreamPanel` が `lastClipId` を `Timeline` の `lastPlayingClipId` に渡すよう接続

## Test plan

- [x] `useCharacterStage` の `lastClipId` ライフサイクルが `lastClipText` と一致していることをユニットテストで確認
- [x] `Timeline` が `playingClipId=null` かつ `lastPlayingClipId` 設定時に最後のクリップを表示することをユニットテストで確認
- [x] `StreamPanel` で再生終了後もセリフが表示されることをユニットテストで確認
- [ ] 実機確認（VOICEVOX接続が必要なため手動検証）
  - キャラ画像 ON で 1 クリップ再生後、再生終了直後もセリフが残ること
  - 次クリップ再生開始時にセリフが切り替わること
  - 最後の再生から 15 秒後にキャラ画像とセリフが同時に消えること
  - キャラ画像 OFF 時の履歴一覧表示に影響がないこと

Closes #401

---
🤖 Generated with [Claude Code](https://claude.ai/code)
