### PR TITLE
refactor(cli): say の出力機能を script append サブコマンドに分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ export VOX_ACTOR_MONOLOGUE_MODE=file
 
 ## 📚 ドキュメント
 
-- [CLIリファレンス](./docs/reference/cli.md) — `say` / `act` / `watch` サブコマンドの詳細
+- [CLIリファレンス](./docs/reference/cli.md) — `say` / `script` / `act` / `watch` サブコマンドの詳細
 - [プラグイン／スキルリファレンス](./docs/reference/plugins.md) — 対応キャラクター、スキルごとの仕様、再生モード、音声デバイス利用不可環境のセットアップ
 - [開発者向け情報](./docs/development/contributing.md) — ビルド・テスト・Lint等のコマンド、レイヤー構成と責務ルール
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -28,6 +28,26 @@ func buildLoggerFromFlags(cmd *cobra.Command) *slog.Logger {
 	}))
 }
 
+// speakerDefaultFromEnv は VOX_SPEAKER 環境変数からデフォルトのスピーカーIDを解決する。
+func speakerDefaultFromEnv() int {
+	if v := os.Getenv("VOX_SPEAKER"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return 3
+}
+
+// registerVoiceParamFlags はキャラクター音声パラメータ（speaker/speed/pitch/intonation/verbose）を登録する。
+// VOICEVOX エンジン接続が不要なコマンドでも使える共通フラグ群。
+func registerVoiceParamFlags(cmd *cobra.Command) {
+	cmd.Flags().Int("speaker", speakerDefaultFromEnv(), "キャラクターID")
+	cmd.Flags().Float64("speed", 1.0, "話速")
+	cmd.Flags().Float64("pitch", 0.0, "音高")
+	cmd.Flags().Float64("intonation", 1.0, "抑揚")
+	cmd.Flags().Bool("verbose", false, "詳細ログを出力")
+}
+
 // registerBaseFlags は dry-run を除く共通フラグを登録する。viewer など dry-run を持たないコマンドで使う。
 func registerBaseFlags(cmd *cobra.Command) {
 	engineURLDefault := "http://localhost:50021"
@@ -36,18 +56,7 @@ func registerBaseFlags(cmd *cobra.Command) {
 	}
 	cmd.Flags().String("engine-url", engineURLDefault, "VOICEVOXエンジンのURL")
 
-	speakerDefault := 3
-	if v := os.Getenv("VOX_SPEAKER"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			speakerDefault = n
-		}
-	}
-	cmd.Flags().Int("speaker", speakerDefault, "キャラクターID")
-
-	cmd.Flags().Float64("speed", 1.0, "話速")
-	cmd.Flags().Float64("pitch", 0.0, "音高")
-	cmd.Flags().Float64("intonation", 1.0, "抑揚")
-	cmd.Flags().Bool("verbose", false, "詳細ログを出力")
+	registerVoiceParamFlags(cmd)
 }
 
 // registerCommonFlags は各サブコマンド共通のフラグを登録する。

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,13 +14,14 @@ var ErrUsage = errors.New("usage error")
 
 // Deps はルートコマンドの依存を保持する。
 type Deps struct {
-	Act        *ActDeps
-	Watch      *WatchDeps
-	Say        *SayDeps
-	AudioCheck *AudioCheckDeps
-	Viewer     *ViewerDeps
-	Assets     *AssetsDownloadDeps
-	Speakers   *SpeakersDeps
+	Act          *ActDeps
+	Watch        *WatchDeps
+	Say          *SayDeps
+	ScriptAppend *ScriptAppendDeps
+	AudioCheck   *AudioCheckDeps
+	Viewer       *ViewerDeps
+	Assets       *AssetsDownloadDeps
+	Speakers     *SpeakersDeps
 }
 
 func makeRootCmd(deps ...*Deps) *cobra.Command {
@@ -42,6 +43,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	var actDeps *ActDeps
 	var watchDeps *WatchDeps
 	var sayDeps *SayDeps
+	var scriptAppendDeps *ScriptAppendDeps
 	var audioCheckDeps *AudioCheckDeps
 	var assetsDeps *AssetsDownloadDeps
 	var speakersDeps *SpeakersDeps
@@ -49,6 +51,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 		actDeps = d.Act
 		watchDeps = d.Watch
 		sayDeps = d.Say
+		scriptAppendDeps = d.ScriptAppend
 		audioCheckDeps = d.AudioCheck
 		assetsDeps = d.Assets
 		speakersDeps = d.Speakers
@@ -60,6 +63,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	cmd.AddCommand(makeActCmd(actDeps))
 	cmd.AddCommand(makeWatchCmd(watchDeps))
 	cmd.AddCommand(makeSayCmd(sayDeps))
+	cmd.AddCommand(makeScriptCmd(scriptAppendDeps))
 	cmd.AddCommand(makeConfigCmd())
 	cmd.AddCommand(makeAudioCheckCmd(audioCheckDeps))
 	cmd.AddCommand(makeViewerCmd(viewerDeps))

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/canpok1/vox-actor/internal/app"
-	"github.com/canpok1/vox-actor/internal/domain/entity"
 	"github.com/spf13/cobra"
 )
 
@@ -16,10 +14,6 @@ import (
 type SayDeps struct {
 	ClientFactory func(engineURL string) app.VoicevoxClient
 	Player        app.AudioPlayer
-	// WriterFactory は -o / --output 指定時のファイル書き出し用 ScriptWriter を生成する。
-	// runSay で構築したロガーを Writer に注入できるようファクトリ形式とする。
-	// nil の場合は -o オプション利用時にエラーを返す。
-	WriterFactory func(logger *slog.Logger) app.ScriptWriter
 }
 
 func makeSayCmd(deps *SayDeps) *cobra.Command {
@@ -39,13 +33,12 @@ func makeSayCmd(deps *SayDeps) *cobra.Command {
 	}
 
 	registerCommonFlags(cmd)
-	cmd.Flags().StringP("output", "o", "", "セリフをファイル出力する（既存ファイルには追記）（指定時はVOICEVOX接続・音声再生を行わない）")
 
 	return cmd
 }
 
 func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
-	if deps == nil {
+	if deps == nil || deps.ClientFactory == nil || deps.Player == nil {
 		return fmt.Errorf("say command dependencies are not initialized")
 	}
 
@@ -53,21 +46,7 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 	defer stop()
 
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	output, _ := cmd.Flags().GetString("output")
-
-	if output != "" && dryRun {
-		return fmt.Errorf("%w: --output and --dry-run cannot be specified together", ErrUsage)
-	}
-
 	logger := buildLoggerFromFlags(cmd)
-
-	if output != "" {
-		return runSayOutput(cmd, args[0], output, deps, logger)
-	}
-
-	if deps.ClientFactory == nil || deps.Player == nil {
-		return fmt.Errorf("say command dependencies are not initialized")
-	}
 
 	engineURL, _ := cmd.Flags().GetString("engine-url")
 	speakerID, _ := cmd.Flags().GetInt("speaker")
@@ -91,37 +70,4 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 
 	uc := app.NewSayUsecase(client, deps.Player, app.WithSayLogger(logger))
 	return uc.Run(ctx, params)
-}
-
-// runSayOutput は --output モードを実行する。VOICEVOX/再生は呼ばず ScriptWriter で書き出す。
-func runSayOutput(cmd *cobra.Command, text, output string, deps *SayDeps, logger *slog.Logger) error {
-	if deps.WriterFactory == nil {
-		return fmt.Errorf("ScriptWriter factory is not configured for --output")
-	}
-
-	script := entity.Script{Text: text, IsEmpty: text == ""}
-	if cmd.Flags().Changed("speaker") {
-		v, _ := cmd.Flags().GetInt("speaker")
-		script.SpeakerID = &v
-	}
-	if cmd.Flags().Changed("speed") {
-		v, _ := cmd.Flags().GetFloat64("speed")
-		script.SpeedScale = &v
-	}
-	if cmd.Flags().Changed("pitch") {
-		v, _ := cmd.Flags().GetFloat64("pitch")
-		script.PitchScale = &v
-	}
-	if cmd.Flags().Changed("intonation") {
-		v, _ := cmd.Flags().GetFloat64("intonation")
-		script.IntonationScale = &v
-	}
-
-	writer := deps.WriterFactory(logger)
-	written, err := writer.Write(output, script)
-	if err != nil {
-		return err
-	}
-	logger.Info("output completed", "path", written)
-	return nil
 }

--- a/cmd/say_test.go
+++ b/cmd/say_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"log/slog"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -17,16 +15,13 @@ import (
 // say コマンド テストリスト
 // DONE: sayサブコマンドがrootに登録されている
 // DONE: 引数なしでErrUsageを返す
-// DONE: ヘルプ出力に全フラグが含まれる（--engine-url, --speaker, --speed, --pitch, --intonation, --verbose, --output）
-// DONE: ヘルプ出力に--watchフラグが含まれない
+// DONE: ヘルプ出力に全フラグが含まれる（--engine-url, --speaker, --speed, --pitch, --intonation, --verbose）
+// DONE: ヘルプ出力に--output/--watchフラグが含まれない
 // DONE: デフォルトオプション値の確認（engine-url, speaker, speed, pitch, intonation）
 // DONE: 環境変数VOX_ENGINE_URLがデフォルト値に反映される
 // DONE: 環境変数VOX_SPEAKERがデフォルト値に反映される
 // DONE: VOX_SPEAKERに不正な値が設定されている場合デフォルト値が使われる
 // DONE: --verboseフラグのデフォルト値がfalse
-// DONE: --output と --dry-run の併用は ErrUsage
-// DONE: --output 指定時、Writer.Write が呼ばれる
-// DONE: --output 指定時、ClientFactory/Player は呼ばれない
 
 // findSayCmd はrootCmdからsayサブコマンドを検索して返すテストヘルパー。
 func findSayCmd(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
@@ -83,7 +78,7 @@ func TestSayCmd_HelpContainsFlags(t *testing.T) {
 	}
 
 	output := buf.String()
-	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run", "--output"}
+	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run"}
 	for _, flag := range flags {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected help output to contain '%s'", flag)
@@ -91,7 +86,7 @@ func TestSayCmd_HelpContainsFlags(t *testing.T) {
 	}
 }
 
-func TestSayCmd_HelpDoesNotContainWatchFlag(t *testing.T) {
+func TestSayCmd_HelpDoesNotContainRemovedFlags(t *testing.T) {
 	rootCmd := makeRootCmd()
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -103,8 +98,10 @@ func TestSayCmd_HelpDoesNotContainWatchFlag(t *testing.T) {
 	}
 
 	output := buf.String()
-	if strings.Contains(output, "--watch") {
-		t.Error("expected help output NOT to contain '--watch'")
+	for _, flag := range []string{"--watch", "--output"} {
+		if strings.Contains(output, flag) {
+			t.Errorf("expected help output NOT to contain '%s'", flag)
+		}
 	}
 }
 
@@ -187,100 +184,7 @@ func TestSayCmd_VerboseFlag_DefaultFalse(t *testing.T) {
 	}
 }
 
-// --- --output (-o) フラグ テスト ---
-
-type fakeScriptWriter struct {
-	calls []fakeWriterCall
-}
-
-type fakeWriterCall struct {
-	path string
-	text string
-}
-
-func (w *fakeScriptWriter) Write(path string, script entity.Script) (string, error) {
-	w.calls = append(w.calls, fakeWriterCall{path: path, text: script.Text})
-	return path, nil
-}
-
-func TestSayCmd_OutputFlag_HasShortAndLong(t *testing.T) {
-	rootCmd := makeRootCmd()
-	sayCmd := findSayCmd(t, rootCmd)
-
-	if f := sayCmd.Flags().Lookup("output"); f == nil {
-		t.Fatal("expected --output flag to be registered")
-	} else if f.Shorthand != "o" {
-		t.Errorf("expected --output shorthand to be 'o', got: %q", f.Shorthand)
-	}
-}
-
-func TestSayCmd_OutputAndDryRun_ReturnsUsageError(t *testing.T) {
-	writer := &fakeScriptWriter{}
-	deps := &Deps{
-		Say: &SayDeps{
-			ClientFactory: func(_ string) app.VoicevoxClient { return nil },
-			Player:        nil,
-			WriterFactory: func(_ *slog.Logger) app.ScriptWriter { return writer },
-		},
-	}
-	rootCmd := makeRootCmd(deps)
-
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"say", "--output", "/tmp/out.txt", "--dry-run", "hello"})
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for --output + --dry-run, got nil")
-	}
-	if !errors.Is(err, ErrUsage) {
-		t.Errorf("expected ErrUsage, got: %v", err)
-	}
-}
-
-func TestSayCmd_OutputFlag_CallsWriter_NotClient(t *testing.T) {
-	writer := &fakeScriptWriter{}
-	clientFactoryCalled := false
-
-	deps := &Deps{
-		Say: &SayDeps{
-			ClientFactory: func(_ string) app.VoicevoxClient {
-				clientFactoryCalled = true
-				return &noopClient{}
-			},
-			Player:        &noopPlayer{},
-			WriterFactory: func(_ *slog.Logger) app.ScriptWriter { return writer },
-		},
-	}
-	rootCmd := makeRootCmd(deps)
-
-	tmpDir := t.TempDir()
-	dest := filepath.Join(tmpDir, "out.txt")
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"say", "--output", dest, "hello"})
-
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(writer.calls) != 1 {
-		t.Fatalf("expected 1 Writer.Write call, got: %d", len(writer.calls))
-	}
-	if writer.calls[0].path != dest {
-		t.Errorf("expected path=%q, got %q", dest, writer.calls[0].path)
-	}
-	if writer.calls[0].text != "hello" {
-		t.Errorf("expected text=hello, got %q", writer.calls[0].text)
-	}
-	if clientFactoryCalled {
-		t.Error("expected ClientFactory NOT to be called when --output is set")
-	}
-}
-
-// noopClient / noopPlayer は --output 経路では呼ばれないことを保証するためのスタブ。
+// noopClient / noopPlayer は say コマンドのテスト用スタブ。
 type noopClient struct{}
 
 func (n *noopClient) HealthCheck(_ context.Context) error { return errors.New("must not be called") }

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -1,0 +1,18 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func makeScriptCmd(appendDeps *ScriptAppendDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "script",
+		Short: "セリフファイルを操作する",
+		Long:  "セリフファイルに対する操作を行うサブコマンド群。",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(makeScriptAppendCmd(appendDeps))
+
+	return cmd
+}

--- a/cmd/script_append.go
+++ b/cmd/script_append.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/spf13/cobra"
+)
+
+// ScriptAppendDeps は script append コマンドの依存を保持する。
+type ScriptAppendDeps struct {
+	WriterFactory func(logger *slog.Logger) app.ScriptWriter
+}
+
+func makeScriptAppendCmd(deps *ScriptAppendDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "append <file> <text>",
+		Short: "セリフをファイルへ追記する",
+		Long:  "指定したセリフファイルにテキストを追記する。既存ファイルには追記、存在しない場合は新規作成する。VOICEVOX接続・音声再生は行わない。",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(2)(cmd, args); err != nil {
+				return fmt.Errorf("%w: %s", ErrUsage, err)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runScriptAppend(cmd, args, deps)
+		},
+	}
+
+	registerVoiceParamFlags(cmd)
+
+	return cmd
+}
+
+func runScriptAppend(cmd *cobra.Command, args []string, deps *ScriptAppendDeps) error {
+	if deps == nil || deps.WriterFactory == nil {
+		return fmt.Errorf("ScriptWriter factory is not configured for script append")
+	}
+
+	file := args[0]
+	text := args[1]
+
+	script := entity.Script{Text: text, IsEmpty: text == ""}
+	if cmd.Flags().Changed("speaker") {
+		v, _ := cmd.Flags().GetInt("speaker")
+		script.SpeakerID = &v
+	}
+	if cmd.Flags().Changed("speed") {
+		v, _ := cmd.Flags().GetFloat64("speed")
+		script.SpeedScale = &v
+	}
+	if cmd.Flags().Changed("pitch") {
+		v, _ := cmd.Flags().GetFloat64("pitch")
+		script.PitchScale = &v
+	}
+	if cmd.Flags().Changed("intonation") {
+		v, _ := cmd.Flags().GetFloat64("intonation")
+		script.IntonationScale = &v
+	}
+
+	logger := buildLoggerFromFlags(cmd)
+	writer := deps.WriterFactory(logger)
+	written, err := writer.Write(file, script)
+	if err != nil {
+		return err
+	}
+	logger.Info("output completed", "path", written)
+	return nil
+}

--- a/cmd/script_append_test.go
+++ b/cmd/script_append_test.go
@@ -1,0 +1,290 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/spf13/cobra"
+)
+
+// script append コマンド テストリスト
+// DONE: scriptサブコマンドがrootに登録されている
+// DONE: script appendサブコマンドがscriptに登録されている
+// DONE: 引数なし（fileのみ）でErrUsageを返す
+// DONE: 引数なし（fileもtextもなし）でErrUsageを返す
+// DONE: ヘルプ出力に--speaker/--speed/--pitch/--intonationが含まれる
+// DONE: ヘルプ出力に--engine-url/--dry-runが含まれない
+// DONE: デフォルトオプション値の確認（speaker, speed, pitch, intonation）
+// DONE: 環境変数VOX_SPEAKERがデフォルト値に反映される
+// DONE: WriterFactoryがnilのときエラーになる
+// DONE: Writer.Writeが呼ばれる
+// DONE: --speaker/--speed/--pitch/--intonation が ScriptWriter に伝わる
+
+func findScriptCmd(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
+	t.Helper()
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "script" {
+			return c
+		}
+	}
+	t.Fatal("script subcommand not found")
+	return nil
+}
+
+func findScriptAppendCmd(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
+	t.Helper()
+	scriptCmd := findScriptCmd(t, rootCmd)
+	for _, c := range scriptCmd.Commands() {
+		if c.Name() == "append" {
+			return c
+		}
+	}
+	t.Fatal("script append subcommand not found")
+	return nil
+}
+
+func TestScriptCmd_RegisteredAsSubcommand(t *testing.T) {
+	rootCmd := makeRootCmd()
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "script" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'script' subcommand to be registered")
+	}
+}
+
+func TestScriptAppendCmd_RegisteredUnderScript(t *testing.T) {
+	rootCmd := makeRootCmd()
+	scriptCmd := findScriptCmd(t, rootCmd)
+	found := false
+	for _, c := range scriptCmd.Commands() {
+		if c.Name() == "append" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'append' subcommand under 'script'")
+	}
+}
+
+func TestScriptAppendCmd_NoArgs_ReturnsUsageError(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"script", "append"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no args provided, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func TestScriptAppendCmd_OneArg_ReturnsUsageError(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"script", "append", "file.jsonl"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when only one arg provided, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func TestScriptAppendCmd_HelpContainsFlags(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"script", "append", "--help"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error for --help, got: %v", err)
+	}
+
+	output := buf.String()
+	flags := []string{"--speaker", "--speed", "--pitch", "--intonation", "--verbose"}
+	for _, flag := range flags {
+		if !strings.Contains(output, flag) {
+			t.Errorf("expected help output to contain '%s'", flag)
+		}
+	}
+}
+
+func TestScriptAppendCmd_HelpDoesNotContainEngineURLOrDryRun(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"script", "append", "--help"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error for --help, got: %v", err)
+	}
+
+	output := buf.String()
+	for _, flag := range []string{"--engine-url", "--dry-run"} {
+		if strings.Contains(output, flag) {
+			t.Errorf("expected help output NOT to contain '%s'", flag)
+		}
+	}
+}
+
+func TestScriptAppendCmd_DefaultOptionValues(t *testing.T) {
+	rootCmd := makeRootCmd()
+	appendCmd := findScriptAppendCmd(t, rootCmd)
+
+	speaker, _ := appendCmd.Flags().GetInt("speaker")
+	if speaker != 3 {
+		t.Errorf("expected default speaker 3, got: %d", speaker)
+	}
+	speed, _ := appendCmd.Flags().GetFloat64("speed")
+	if speed != 1.0 {
+		t.Errorf("expected default speed 1.0, got: %f", speed)
+	}
+	pitch, _ := appendCmd.Flags().GetFloat64("pitch")
+	if pitch != 0.0 {
+		t.Errorf("expected default pitch 0.0, got: %f", pitch)
+	}
+	intonation, _ := appendCmd.Flags().GetFloat64("intonation")
+	if intonation != 1.0 {
+		t.Errorf("expected default intonation 1.0, got: %f", intonation)
+	}
+}
+
+func TestScriptAppendCmd_EnvVarVOXSpeaker(t *testing.T) {
+	t.Setenv("VOX_SPEAKER", "42")
+	rootCmd := makeRootCmd()
+	appendCmd := findScriptAppendCmd(t, rootCmd)
+
+	speaker, _ := appendCmd.Flags().GetInt("speaker")
+	if speaker != 42 {
+		t.Errorf("expected speaker 42, got: %d", speaker)
+	}
+}
+
+func TestScriptAppendCmd_NilWriterFactory_ReturnsError(t *testing.T) {
+	deps := &Deps{
+		ScriptAppend: &ScriptAppendDeps{
+			WriterFactory: nil,
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	tmpDir := t.TempDir()
+	rootCmd.SetArgs([]string{"script", "append", filepath.Join(tmpDir, "out.jsonl"), "hello"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when WriterFactory is nil, got nil")
+	}
+}
+
+type captureScriptWriter struct {
+	calls []captureWriterCall
+}
+
+type captureWriterCall struct {
+	path   string
+	script entity.Script
+}
+
+func (w *captureScriptWriter) Write(path string, script entity.Script) (string, error) {
+	w.calls = append(w.calls, captureWriterCall{path: path, script: script})
+	return path, nil
+}
+
+func TestScriptAppendCmd_CallsWriter(t *testing.T) {
+	writer := &captureScriptWriter{}
+	deps := &Deps{
+		ScriptAppend: &ScriptAppendDeps{
+			WriterFactory: func(_ *slog.Logger) app.ScriptWriter { return writer },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "out.jsonl")
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"script", "append", dest, "hello"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(writer.calls) != 1 {
+		t.Fatalf("expected 1 Write call, got: %d", len(writer.calls))
+	}
+	if writer.calls[0].path != dest {
+		t.Errorf("expected path=%q, got %q", dest, writer.calls[0].path)
+	}
+	if writer.calls[0].script.Text != "hello" {
+		t.Errorf("expected text=hello, got %q", writer.calls[0].script.Text)
+	}
+}
+
+func TestScriptAppendCmd_FlagsPassedToWriter(t *testing.T) {
+	writer := &captureScriptWriter{}
+	deps := &Deps{
+		ScriptAppend: &ScriptAppendDeps{
+			WriterFactory: func(_ *slog.Logger) app.ScriptWriter { return writer },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "out.jsonl")
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{
+		"script", "append",
+		"--speaker", "5",
+		"--speed", "1.2",
+		"--pitch", "0.05",
+		"--intonation", "1.5",
+		dest, "hello",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(writer.calls) != 1 {
+		t.Fatalf("expected 1 Write call, got: %d", len(writer.calls))
+	}
+	s := writer.calls[0].script
+	if s.SpeakerID == nil || *s.SpeakerID != 5 {
+		t.Errorf("expected SpeakerID=5, got: %v", s.SpeakerID)
+	}
+	if s.SpeedScale == nil || *s.SpeedScale != 1.2 {
+		t.Errorf("expected SpeedScale=1.2, got: %v", s.SpeedScale)
+	}
+	if s.PitchScale == nil || *s.PitchScale != 0.05 {
+		t.Errorf("expected PitchScale=0.05, got: %v", s.PitchScale)
+	}
+	if s.IntonationScale == nil || *s.IntonationScale != 1.5 {
+		t.Errorf("expected IntonationScale=1.5, got: %v", s.IntonationScale)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -82,33 +82,46 @@ vox-actor say <text>
 | `--speed` | — | `1.0` | 話速 |
 | `--pitch` | — | `0.0` | 音高 |
 | `--intonation` | — | `1.0` | 抑揚 |
-| `-o`, `--output` | — | （未指定） | 指定時、音声再生せずセリフをファイル出力（[詳細](#--outputモード)） |
 | `--verbose` | — | `false` | 詳細ログを出力 |
 | `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#dry-runモード)） |
 
-### --outputモード
+## `script` サブコマンド
 
-`-o <パス>` または `--output <パス>` を指定すると、**音声合成・音声再生を行わず**にセリフをファイルへ書き出します。`vox-actor watch --queue` と組み合わせ、別プロセスで再生させたいユースケースに利用できます。
+セリフファイルを操作するサブコマンド群。
 
-- `-o` 指定時は **VOICEVOX エンジンへ接続しません**（`HealthCheck` / `CreateQuery` / `Synthesize` を呼ばない）。エンジンが起動していなくても成功します。
-- 出力ファイルの拡張子で書き出し形式を自動判定します。
+### `script append` サブコマンド
+
+```
+vox-actor script append <file> <text>
+```
+
+指定したセリフファイルにテキストを追記する。VOICEVOX接続・音声再生は行わない。`vox-actor watch --queue` と組み合わせ、別プロセスで再生させたいユースケースに利用できる。
+
+| オプション | 環境変数 | デフォルト値 | 説明 |
+|---|---|---|---|
+| `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
+| `--speed` | — | `1.0` | 話速 |
+| `--pitch` | — | `0.0` | 音高 |
+| `--intonation` | — | `1.0` | 抑揚 |
+| `--verbose` | — | `false` | 詳細ログを出力 |
+
+- 出力先ファイルの拡張子で書き出し形式を自動判定します。
   - `.json` → 1ファイル1スクリプトのJSON。`text` に加え、明示指定された `--speaker` / `--speed` / `--pitch` / `--intonation` を `speaker` / `speedScale` / `pitchScale` / `intonationScale` として保存
   - `.jsonl` → 1行JSON（フィールドは `.json` と同じ）
   - `.txt` および **未知の拡張子** → 本文のみのテキストファイル（拡張子はそのまま）
     - このとき `--speaker` / `--speed` / `--pitch` / `--intonation` がコマンドラインで明示指定されていたら、これらは保存できない旨を WARN ログで通知します（処理は継続）
 - **既存ファイルとの衝突回避**: 出力先に同名ファイルが存在する場合は、`<name>_<UnixNano><ext>` の形式で連番を付与してユニーク化します。
 - **親ディレクトリの扱い**: 親ディレクトリが存在しない場合はエラーになります（任意の深さを自動作成しません）。
-- **`--dry-run` との併用は禁止**です（起動時に `ErrUsage` で終了）。
 
 ```bash
 # ホスト側 / 別ターミナル: queue を監視
 vox-actor watch --queue
 
 # claude code 等から: queue にテキストを書き出すと watch が拾って読み上げる
-vox-actor say -o "$(vox-actor config path.queue)/01.txt" "こんにちは"
+vox-actor script append "$(vox-actor config path.queue)/01.txt" "こんにちは"
 
 # パラメータを保持したい場合は .json / .jsonl で書き出す
-vox-actor say -o "$(vox-actor config path.queue)/01.json" --speaker 5 --speed 1.2 "こんにちは"
+vox-actor script append "$(vox-actor config path.queue)/01.json" --speaker 5 --speed 1.2 "こんにちは"
 ```
 
 ## `act` サブコマンド

--- a/main.go
+++ b/main.go
@@ -85,6 +85,8 @@ func main() {
 		Say: &cmd.SayDeps{
 			ClientFactory: clientFactory,
 			Player:        player,
+		},
+		ScriptAppend: &cmd.ScriptAppendDeps{
 			WriterFactory: func(logger *slog.Logger) app.ScriptWriter {
 				return infra.NewFileWriter(infra.WithFileWriterLogger(logger))
 			},

--- a/plugins/vox-actor-plugin/skills/talk/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/talk/SKILL.md
@@ -20,7 +20,7 @@ allowed-tools: Bash(vox-actor *) Bash(scripts/play-script.sh *)
 - 使用可能なキャラクター一覧: `vox-actor speakers list`
 - キャラクター設定の確認方法: `vox-actor speakers profile --id {profile_id}`
     - `profile_id` は `vox-actor speakers list` の結果から選ぶ
-- セリフファイルへのセリフ追記方法: `vox-actor say -o {セリフファイルパス} {オプション} "{セリフ}"`
+- セリフファイルへのセリフ追記方法: `vox-actor script append {セリフファイルパス} {オプション} "{セリフ}"`
     - 話者指定オプション（省略化）: `--speaker {speaker_id}`
         - `speaker_id` は `vox-actor speakers profile` の結果の `speakers` フィールドから選ぶ
     - 抑揚変更オプション（省略化）: `--intonation {0.0〜1.5}`


### PR DESCRIPTION
## Summary

- `vox-actor script append <file> <text>` コマンドを新設し、`say -o` の機能を移管
- `say` コマンドから `-o/--output` フラグと関連ロジック（`runSayOutput`、`SayDeps.WriterFactory`）を削除
- `flags.go` に `speakerDefaultFromEnv()` と `registerVoiceParamFlags()` を共通ヘルパーとして抽出し重複を解消
- `talk` スキルの `vox-actor say -o` 記述を `vox-actor script append` に更新
- `docs/reference/cli.md` に `script append` サブコマンドの仕様を追記

## Test plan

- [x] `go test ./...` 全テスト通過
- [x] `golangci-lint run` 0 issues
- [ ] `vox-actor script append` でセリフファイルへの追記が動作する（手動確認）
- [ ] `vox-actor say -o` を実行するとエラーになる（手動確認）
- [ ] talk スキル経由でセリフファイル生成・再生が動作する（手動確認）

Closes #405

---
🤖 Generated with [Claude Code](https://claude.ai/code)
