### PR TITLE
fix(viewer): assetsディレクトリ不在時のwarnログをinfoに変更する

### DIFF
--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -645,6 +645,11 @@ func (p *HTTPStreamPlayer) loadMergedCharacterSettings() []characterEntry {
 	var result []characterEntry
 
 	for _, assetsDir := range p.assetsDirs {
+		if _, err := os.Stat(assetsDir); errors.Is(err, fs.ErrNotExist) {
+			p.logger.Info("assets directory not found, skipping load",
+				"assetsDir", assetsDir)
+			continue
+		}
 		fsys := os.DirFS(assetsDir)
 		loadedEntries, loadErr := loadCharacterSettingsFromSpeakerJSON(fsys, assetsDir, ".", p.logger)
 		if loadErr != nil {

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -1924,7 +1924,11 @@ func TestBuildAPICharactersJSON_LogsWarnOnLoadError(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	workspaceDir := t.TempDir() // no assets/ subdir
+	// assets/ dir exists but is empty (no valid entries) → WARN "failed to load character settings"
+	workspaceDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "assets"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 
 	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
 		WithHTTPStreamLogger(logger),
@@ -1972,6 +1976,36 @@ func TestBuildAPICharactersJSON_LogsInfoOnSuccess(t *testing.T) {
 	}
 	if !strings.Contains(logOutput, "character settings loaded") {
 		t.Errorf("expected 'character settings loaded' in log, got: %s", logOutput)
+	}
+}
+
+func TestBuildAPICharactersJSON_LogsInfoOnDirNotFound(t *testing.T) {
+	t.Parallel()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	workspaceDir := t.TempDir() // no assets/ subdir → dir not found
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHTTPStreamLogger(logger),
+		WithWorkspacePath(workspaceDir),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.buildAPICharactersJSON(); err != nil {
+		t.Fatalf("buildAPICharactersJSON: %v", err)
+	}
+
+	logOutput := logBuf.String()
+	if !strings.Contains(logOutput, "INFO") {
+		t.Errorf("expected INFO log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "assets directory not found, skipping load") {
+		t.Errorf("expected info message in log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, workspaceDir) {
+		t.Errorf("expected workspaceDir in log, got: %s", logOutput)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `loadMergedCharacterSettings` に `os.Stat` による事前チェックを追加
- assetsディレクトリが存在しない場合は Info ログ (`assets directory not found, skipping load`) を出力してスキップ
- 権限エラー・JSON破損など他のエラーは既存の Warn ログ経路を維持

## Test plan

- [ ] `TestBuildAPICharactersJSON_LogsInfoOnDirNotFound`: ディレクトリ不在時にInfo ログが出ることを検証（新規追加）
- [ ] `TestBuildAPICharactersJSON_LogsWarnOnLoadError`: ディレクトリ存在・有効エントリなし時にWarn ログが出ることを検証（シナリオ更新）
- [ ] `go test ./internal/infra/...` 全テスト通過を確認済み

Closes #406

---
🤖 Generated with [Claude Code](https://claude.ai/code)
