### PR TITLE
feat(viewer): 再生履歴のファイル保存・起動時復元と viewer/ 配下へのレイアウト集約

### DIFF
--- a/cmd/viewer.go
+++ b/cmd/viewer.go
@@ -119,7 +119,7 @@ func resolveViewerLockPath(deps *ViewerDeps) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(ws, "run", "viewer.lock"), nil
+	return filepath.Join(ws, "viewer", "viewer.lock"), nil
 }
 
 func runViewer(cmd *cobra.Command, deps *ViewerDeps) error {

--- a/cmd/viewer_test.go
+++ b/cmd/viewer_test.go
@@ -427,9 +427,24 @@ func TestViewerCmd_EnvVarVOXSpeaker(t *testing.T) {
 	}
 }
 
+func TestResolveViewerLockPath_UsesViewerSubdir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", dir)
+
+	path, err := resolveViewerLockPath(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := filepath.Join(dir, "viewer", "viewer.lock")
+	if path != expected {
+		t.Errorf("expected path %q, got %q", expected, path)
+	}
+}
+
 func TestViewerCmd_AlreadyRunning_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
-	lockPath := filepath.Join(dir, "run", "viewer.lock")
+	lockPath := filepath.Join(dir, "viewer", "viewer.lock")
 
 	// 先に別インスタンスとしてロックを取得しておく
 	first, err := infra.AcquireViewerLock(lockPath)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { usePlaybackQueue } from "./hooks/usePlaybackQueue";
 import {
   isApiStatus,
   isApiCharacters,
+  isApiHistory,
   isClipEvent,
   isErrorEventPayload,
   type Speaker,
@@ -203,6 +204,37 @@ export function App() {
       cancelled = true;
     };
   }, [showTestError]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async (): Promise<void> => {
+      try {
+        const resp = await fetch("/api/history");
+        if (!resp.ok) throw new Error(`history ${resp.status}`);
+        const data: unknown = await resp.json();
+        if (!isApiHistory(data)) {
+          throw new Error("invalid api history payload");
+        }
+        if (cancelled) return;
+        const historyEntries: TimelineEntry[] = data.entries.map((e) => ({
+          kind: "clip" as const,
+          id: e.id,
+          url: "",
+          text: e.text,
+          speakerName: e.speakerName,
+          styleName: e.styleName,
+          timestamp: e.timestamp,
+        }));
+        setEntries(historyEntries);
+      } catch (err) {
+        console.error("failed to load api history", err);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -168,3 +168,38 @@ export function isApiCharacters(value: unknown): value is ApiCharacters {
     v.characters.every(isCharacterEntry)
   );
 }
+
+// HistoryEntry は /api/history の 1 エントリ（WAV URL なし）。
+export interface HistoryEntry {
+  id: number;
+  text: string;
+  speakerName: string;
+  styleName: string;
+  timestamp: number;
+}
+
+export interface ApiHistory {
+  entries: HistoryEntry[];
+}
+
+export function isHistoryEntry(value: unknown): value is HistoryEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === "number" &&
+    typeof v.text === "string" &&
+    typeof v.speakerName === "string" &&
+    typeof v.styleName === "string" &&
+    typeof v.timestamp === "number"
+  );
+}
+
+export function isApiHistory(value: unknown): value is ApiHistory {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return Array.isArray(v.entries) && v.entries.every(isHistoryEntry);
+}

--- a/internal/infra/git_workspace.go
+++ b/internal/infra/git_workspace.go
@@ -65,6 +65,15 @@ func ResolveQueuePath() (string, error) {
 	return filepath.Join(workspace, "queue"), nil
 }
 
+// ResolveViewerHistoryPath はワークスペース配下の viewer 履歴ディレクトリパスを返す。
+func ResolveViewerHistoryPath() (string, error) {
+	workspace, err := ResolveWorkspacePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(workspace, "viewer", "history"), nil
+}
+
 // ResolveHomeAssetsPath はホームスコープのアセットルートパス (~/.vox-actor/assets/) を返す。
 func ResolveHomeAssetsPath() (string, error) {
 	home, err := os.UserHomeDir()

--- a/internal/infra/git_workspace_test.go
+++ b/internal/infra/git_workspace_test.go
@@ -258,3 +258,17 @@ func TestResolveProjectAssetsPath_RespectsVoxActorWorkspaceEnv(t *testing.T) {
 		t.Errorf("ResolveProjectAssetsPath() = %q, want %q", got, want)
 	}
 }
+
+func TestResolveViewerHistoryPath_ReturnsViewerHistoryDir_WhenEnvIsSet(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", dir)
+
+	got, err := ResolveViewerHistoryPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(dir, "viewer", "history")
+	if got != want {
+		t.Errorf("ResolveViewerHistoryPath() = %q, want %q", got, want)
+	}
+}

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -61,6 +61,11 @@ type HTTPStreamPlayer struct {
 	// nowFunc は clipEvent の timestamp 生成に使う時刻取得関数（テスト差し替え用）。
 	nowFunc func() time.Time
 
+	// historyDir は再生履歴 JSONL ファイルの保存ディレクトリ。空文字の場合は履歴機能無効。
+	historyDir string
+	// apiHistoryJSON は Start 時に今日の履歴末尾 historyLoadSize 件からマーシャルしたレスポンス。
+	apiHistoryJSON []byte
+
 	// silentInterval は PlayText で使う固定待機時間（backpressure の暫定値）。
 	silentInterval time.Duration
 
@@ -104,12 +109,31 @@ const (
 	defaultSilentInterval = 500 * time.Millisecond
 	// workspaceAssetsDir は workspacePath 配下のアセットディレクトリ名。
 	workspaceAssetsDir = "assets"
+	// historyLoadSize は起動時に読み込む履歴の最大件数。
+	historyLoadSize = 50
+	// historyRetentionDays は履歴ファイルの保持日数。
+	historyRetentionDays = 30
 )
 
 var (
 	// pathSegmentPattern はファイルパスのセグメント検証に使う正規表現。
 	pathSegmentPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 )
+
+// historyRecord は履歴ファイル（YYYY-MM-DD.jsonl）の 1 行スキーマ。
+// WAV URL は viewer 再起動で失効するため含めない。
+type historyRecord struct {
+	ID          uint64 `json:"id"`
+	Text        string `json:"text"`
+	SpeakerName string `json:"speakerName"`
+	StyleName   string `json:"styleName"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// apiHistoryResponse は GET /api/history のレスポンスペイロード。
+type apiHistoryResponse struct {
+	Entries []historyRecord `json:"entries"`
+}
 
 // clipEvent は SSE で配信する clip イベントのペイロード。
 type clipEvent struct {
@@ -210,6 +234,16 @@ func WithAssetsDirs(dirs []string) HTTPStreamOption {
 	}
 }
 
+// WithHistoryDir は再生履歴 JSONL ファイルの保存ディレクトリを設定するオプション。
+// 設定されない場合は履歴機能が無効になる。
+func WithHistoryDir(dir string) HTTPStreamOption {
+	return func(p *HTTPStreamPlayer) {
+		if dir != "" {
+			p.historyDir = dir
+		}
+	}
+}
+
 // withNowFunc は clipEvent の timestamp 取得に使う関数を設定する（テスト用）。
 func withNowFunc(now func() time.Time) HTTPStreamOption {
 	return func(p *HTTPStreamPlayer) {
@@ -262,6 +296,10 @@ func (p *HTTPStreamPlayer) Start(_ context.Context) error {
 	if err := p.buildAPICharactersJSON(); err != nil {
 		return err
 	}
+	p.pruneOldHistory()
+	if err := p.buildAPIHistoryJSON(); err != nil {
+		return err
+	}
 
 	lis, err := net.Listen("tcp", p.addr)
 	if err != nil {
@@ -275,6 +313,7 @@ func (p *HTTPStreamPlayer) Start(_ context.Context) error {
 	mux.Handle("/", withStaticCacheControl(fileServer))
 	mux.HandleFunc("/events", p.handleEvents)
 	mux.HandleFunc("/api/status", p.handleAPIStatus)
+	mux.HandleFunc("/api/history", p.handleAPIHistory)
 	mux.HandleFunc("/api/characters", p.handleAPICharacters)
 	mux.HandleFunc("/assets/images/", p.handleCharacterImage)
 	mux.HandleFunc("/test-clip", p.handleTestClip)
@@ -383,14 +422,15 @@ func (p *HTTPStreamPlayer) PlayText(ctx context.Context, meta app.PlayMeta) erro
 
 	id := p.nextClipID.Add(1)
 	speakerName, styleName := p.resolveSpeaker(meta.SpeakerID)
-	payload, err := json.Marshal(clipEvent{
+	ev := clipEvent{
 		ID:          id,
 		URL:         "",
 		Text:        meta.Text,
 		SpeakerName: speakerName,
 		StyleName:   styleName,
 		Timestamp:   p.nowFunc().UnixMilli(),
-	})
+	}
+	payload, err := json.Marshal(ev)
 	if err != nil {
 		return fmt.Errorf("failed to marshal clip payload: %w", err)
 	}
@@ -400,6 +440,7 @@ func (p *HTTPStreamPlayer) PlayText(ctx context.Context, meta app.PlayMeta) erro
 		p.logger.Warn("stream clip dropped for slow subscribers", "clipId", id, "dropped", dropped)
 	}
 	p.logger.Info("stream clip delivered (silent)", "clipId", id, "subscribers", n)
+	p.appendHistory(ev)
 
 	if p.silentInterval <= 0 {
 		return nil
@@ -443,14 +484,15 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 	p.clips.put(id, buf)
 
 	speakerName, styleName := p.resolveSpeaker(meta.SpeakerID)
-	payload, err := json.Marshal(clipEvent{
+	ev := clipEvent{
 		ID:          id,
 		URL:         clipPathPrefix + strconv.FormatUint(id, 10) + clipPathSuffix,
 		Text:        meta.Text,
 		SpeakerName: speakerName,
 		StyleName:   styleName,
 		Timestamp:   p.nowFunc().UnixMilli(),
-	})
+	}
+	payload, err := json.Marshal(ev)
 	if err != nil {
 		return fmt.Errorf("failed to marshal clip payload: %w", err)
 	}
@@ -460,6 +502,7 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 		p.logger.Warn("stream clip dropped for slow subscribers", "clipId", id, "dropped", dropped)
 	}
 	p.logger.Info("stream clip delivered", "clipId", id, "subscribers", n)
+	p.appendHistory(ev)
 
 	duration, err := estimateWAVDuration(wavData)
 	if err != nil {
@@ -816,6 +859,130 @@ func (p *HTTPStreamPlayer) handleAPIStatus(w http.ResponseWriter, _ *http.Reques
 func (p *HTTPStreamPlayer) handleAPICharacters(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_, _ = w.Write(p.apiCharactersJSON)
+}
+
+func (p *HTTPStreamPlayer) handleAPIHistory(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_, _ = w.Write(p.apiHistoryJSON)
+}
+
+// buildAPIHistoryJSON は今日の履歴ファイル末尾 historyLoadSize 件を読み込み、
+// /api/history のレスポンスとしてキャッシュする。historyDir が空なら空配列を返す。
+func (p *HTTPStreamPlayer) buildAPIHistoryJSON() error {
+	entries := p.loadHistory(historyLoadSize)
+	if entries == nil {
+		entries = []historyRecord{}
+	}
+	payload, err := json.Marshal(apiHistoryResponse{Entries: entries})
+	if err != nil {
+		return fmt.Errorf("failed to marshal api history: %w", err)
+	}
+	p.apiHistoryJSON = payload
+	return nil
+}
+
+// loadHistory は今日の履歴ファイルから末尾 n 件を読み込む。
+func (p *HTTPStreamPlayer) loadHistory(n int) []historyRecord {
+	if p.historyDir == "" {
+		return nil
+	}
+	filePath := p.historyFilePath(p.nowFunc())
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			p.logger.Warn("failed to read history file", "error", err)
+		}
+		return nil
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	start := 0
+	if len(lines) > n {
+		start = len(lines) - n
+	}
+	records := make([]historyRecord, 0, len(lines)-start)
+	for _, line := range lines[start:] {
+		if line == "" {
+			continue
+		}
+		var r historyRecord
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			p.logger.Warn("failed to parse history line", "error", err)
+			continue
+		}
+		records = append(records, r)
+	}
+	return records
+}
+
+// pruneOldHistory は historyDir 配下の 30日より古い *.jsonl を削除する（ベストエフォート）。
+func (p *HTTPStreamPlayer) pruneOldHistory() {
+	if p.historyDir == "" {
+		return
+	}
+	now := p.nowFunc()
+	cutoff := time.Date(now.Year(), now.Month(), now.Day()-historyRetentionDays, 0, 0, 0, 0, time.Local)
+
+	entries, err := os.ReadDir(p.historyDir)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			p.logger.Warn("failed to read history dir for pruning", "error", err)
+		}
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		nameWithoutExt := strings.TrimSuffix(entry.Name(), ".jsonl")
+		t, err := time.ParseInLocation("2006-01-02", nameWithoutExt, time.Local)
+		if err != nil {
+			continue
+		}
+		if t.Before(cutoff) {
+			path := filepath.Join(p.historyDir, entry.Name())
+			if err := os.Remove(path); err != nil {
+				p.logger.Warn("failed to delete old history file", "path", path, "error", err)
+			} else {
+				p.logger.Info("deleted old history file", "path", path)
+			}
+		}
+	}
+}
+
+// appendHistory は clip イベントを今日の履歴ファイルに追記する（ベストエフォート）。
+func (p *HTTPStreamPlayer) appendHistory(ev clipEvent) {
+	if p.historyDir == "" {
+		return
+	}
+	record := historyRecord{
+		ID:          ev.ID,
+		Text:        ev.Text,
+		SpeakerName: ev.SpeakerName,
+		StyleName:   ev.StyleName,
+		Timestamp:   ev.Timestamp,
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		p.logger.Warn("failed to marshal history record", "error", err)
+		return
+	}
+	filePath := p.historyFilePath(p.nowFunc())
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		p.logger.Warn("failed to create history directory", "error", err)
+		return
+	}
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		p.logger.Warn("failed to open history file", "error", err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "%s\n", data)
+}
+
+// historyFilePath は日付から履歴ファイルのパスを返す。
+func (p *HTTPStreamPlayer) historyFilePath(t time.Time) string {
+	return filepath.Join(p.historyDir, t.Format("2006-01-02")+".jsonl")
 }
 
 func (p *HTTPStreamPlayer) handleCharacterImage(w http.ResponseWriter, r *http.Request) {

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -72,6 +72,15 @@ package infra
 // TODO: connection カテゴリは message のみを含む
 // TODO: errorEvent.id はクリップIDと独立に 1 から単調増加する
 // TODO: BroadcastError は複数購読者にブロードキャストされる
+//
+// #408 再生履歴ファイル保存・起動時復元:
+// TODO: Play() で clip が YYYY-MM-DD.jsonl に追記される          → TestHTTPStreamPlayer_History_WritesClipOnPlay
+// TODO: PlayText() で clip が YYYY-MM-DD.jsonl に追記される      → TestHTTPStreamPlayer_History_WritesClipOnPlayText
+// TODO: 日付変更時に新ファイルへ切り替わる                       → TestHTTPStreamPlayer_History_RotatesOnDateChange
+// TODO: viewer 起動時に 30日より古い *.jsonl が削除される        → TestHTTPStreamPlayer_History_PrunesOldFiles
+// TODO: 当日ファイルなし時も正常起動                             → TestHTTPStreamPlayer_Start_NoHistoryFile
+// TODO: /api/history が当日末尾 50 件を返す                      → TestHTTPStreamPlayer_APIHistory_ReturnsTodaysEntries
+// TODO: /api/history がファイルなし時に空配列を返す              → TestHTTPStreamPlayer_APIHistory_EmptyWhenNoFile
 
 import (
 	"bufio"
@@ -2241,5 +2250,317 @@ func TestHTTPStreamPlayer_HandleCharacterImage_SearchesAcrossAssetsDirs(t *testi
 	body, _ := io.ReadAll(resp.Body)
 	if string(body) != string(imageBContent) {
 		t.Errorf("expected home image content %q, got %q", imageBContent, body)
+	}
+}
+
+func TestHTTPStreamPlayer_History_WritesClipOnPlay(t *testing.T) {
+	historyDir := t.TempDir()
+	fixedNow := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+	lookup := map[int]entity.SpeakerStyleInfo{
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return fixedNow }),
+		WithSpeakerLookup(lookup),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	if err := p.Play(context.Background(), []byte("RIFFwavdata"), app.PlayMeta{
+		Text: "テストセリフ", SpeakerID: 3,
+	}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	filePath := filepath.Join(historyDir, "2026-04-28.jsonl")
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("expected history file at %s: %v", filePath, err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line in history, got %d: %q", len(lines), data)
+	}
+	var rec historyRecord
+	if err := json.Unmarshal([]byte(lines[0]), &rec); err != nil {
+		t.Fatalf("failed to parse history line: %v", err)
+	}
+	if rec.ID != 1 {
+		t.Errorf("expected ID=1, got %d", rec.ID)
+	}
+	if rec.Text != "テストセリフ" {
+		t.Errorf("expected Text=%q, got %q", "テストセリフ", rec.Text)
+	}
+	if rec.SpeakerName != "ずんだもん" {
+		t.Errorf("expected SpeakerName=%q, got %q", "ずんだもん", rec.SpeakerName)
+	}
+	if rec.StyleName != "ノーマル" {
+		t.Errorf("expected StyleName=%q, got %q", "ノーマル", rec.StyleName)
+	}
+	if rec.Timestamp != fixedNow.UnixMilli() {
+		t.Errorf("expected Timestamp=%d, got %d", fixedNow.UnixMilli(), rec.Timestamp)
+	}
+}
+
+func TestHTTPStreamPlayer_History_WritesClipOnPlayText(t *testing.T) {
+	historyDir := t.TempDir()
+	fixedNow := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+	lookup := map[int]entity.SpeakerStyleInfo{
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return fixedNow }),
+		WithSpeakerLookup(lookup),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+	p.silentInterval = 1 * time.Millisecond
+
+	if err := p.PlayText(context.Background(), app.PlayMeta{
+		Text: "サイレントセリフ", SpeakerID: 3,
+	}); err != nil {
+		t.Fatalf("PlayText: %v", err)
+	}
+
+	filePath := filepath.Join(historyDir, "2026-04-28.jsonl")
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("expected history file at %s: %v", filePath, err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	var rec historyRecord
+	if err := json.Unmarshal([]byte(lines[0]), &rec); err != nil {
+		t.Fatalf("failed to parse history line: %v", err)
+	}
+	if rec.Text != "サイレントセリフ" {
+		t.Errorf("expected Text=%q, got %q", "サイレントセリフ", rec.Text)
+	}
+}
+
+func TestHTTPStreamPlayer_History_RotatesOnDateChange(t *testing.T) {
+	historyDir := t.TempDir()
+	day1 := time.Date(2026, 4, 28, 23, 59, 0, 0, time.Local)
+	day2 := time.Date(2026, 4, 29, 0, 1, 0, 0, time.Local)
+	currentTime := day1
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return currentTime }),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	if err := p.Play(context.Background(), []byte("RIFFwavdata"), app.PlayMeta{Text: "day1"}); err != nil {
+		t.Fatalf("Play day1: %v", err)
+	}
+	currentTime = day2
+	if err := p.Play(context.Background(), []byte("RIFFwavdata"), app.PlayMeta{Text: "day2"}); err != nil {
+		t.Fatalf("Play day2: %v", err)
+	}
+
+	file1 := filepath.Join(historyDir, "2026-04-28.jsonl")
+	data1, err := os.ReadFile(file1)
+	if err != nil {
+		t.Fatalf("expected history file at %s: %v", file1, err)
+	}
+	if lines := strings.Split(strings.TrimRight(string(data1), "\n"), "\n"); len(lines) != 1 {
+		t.Errorf("expected 1 line in day1 file, got %d", len(lines))
+	}
+
+	file2 := filepath.Join(historyDir, "2026-04-29.jsonl")
+	data2, err := os.ReadFile(file2)
+	if err != nil {
+		t.Fatalf("expected history file at %s: %v", file2, err)
+	}
+	if lines := strings.Split(strings.TrimRight(string(data2), "\n"), "\n"); len(lines) != 1 {
+		t.Errorf("expected 1 line in day2 file, got %d", len(lines))
+	}
+}
+
+func TestHTTPStreamPlayer_History_PrunesOldFiles(t *testing.T) {
+	historyDir := t.TempDir()
+	fixedNow := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+
+	oldDate := fixedNow.AddDate(0, 0, -31)
+	oldFile := filepath.Join(historyDir, oldDate.Format("2006-01-02")+".jsonl")
+	if err := os.WriteFile(oldFile, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	recentDate := fixedNow.AddDate(0, 0, -29)
+	recentFile := filepath.Join(historyDir, recentDate.Format("2006-01-02")+".jsonl")
+	if err := os.WriteFile(recentFile, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return fixedNow }),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Errorf("expected old file to be deleted: %s", oldFile)
+	}
+	if _, err := os.Stat(recentFile); err != nil {
+		t.Errorf("expected recent file to still exist: %s", recentFile)
+	}
+}
+
+func TestHTTPStreamPlayer_Start_NoHistoryFile(t *testing.T) {
+	historyDir := t.TempDir()
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start with no history file: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+}
+
+func TestHTTPStreamPlayer_APIHistory_ReturnsTodaysEntries(t *testing.T) {
+	historyDir := t.TempDir()
+	fixedNow := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+
+	filePath := filepath.Join(historyDir, "2026-04-28.jsonl")
+	var sb strings.Builder
+	for i := 1; i <= 60; i++ {
+		rec := historyRecord{
+			ID:          uint64(i),
+			Text:        fmt.Sprintf("text%d", i),
+			SpeakerName: "ずんだもん",
+			StyleName:   "ノーマル",
+			Timestamp:   fixedNow.UnixMilli(),
+		}
+		data, _ := json.Marshal(rec)
+		sb.Write(data)
+		sb.WriteByte('\n')
+	}
+	if err := os.WriteFile(filePath, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return fixedNow }),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/history")
+	if err != nil {
+		t.Fatalf("GET /api/history: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result apiHistoryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(result.Entries) != 50 {
+		t.Errorf("expected 50 entries, got %d", len(result.Entries))
+	}
+	if len(result.Entries) > 0 && result.Entries[0].ID != 11 {
+		t.Errorf("expected first entry ID=11, got %d", result.Entries[0].ID)
+	}
+	if len(result.Entries) > 0 && result.Entries[len(result.Entries)-1].ID != 60 {
+		t.Errorf("expected last entry ID=60, got %d", result.Entries[len(result.Entries)-1].ID)
+	}
+}
+
+func TestHTTPStreamPlayer_APIHistory_EmptyWhenNoFile(t *testing.T) {
+	historyDir := t.TempDir()
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/history")
+	if err != nil {
+		t.Fatalf("GET /api/history: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result apiHistoryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(result.Entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(result.Entries))
 	}
 }

--- a/internal/infra/viewer_lock_test.go
+++ b/internal/infra/viewer_lock_test.go
@@ -3,11 +3,11 @@ package infra_test
 // テストリスト: ViewerLock
 //
 // 受け入れ条件 vs テスト関数のマッピング:
-// - ロック取得成功時にPIDと起動時刻をファイルに書き込む      → TestAcquireViewerLock_WritesLockFile
-// - 2つ目のロック取得は ViewerAlreadyRunningError を返す     → TestAcquireViewerLock_AlreadyLocked
-// - ViewerAlreadyRunningError に先行PIDと起動時刻が含まれる  → TestAcquireViewerLock_AlreadyLocked_HasPIDAndTime
-// - ロック解放後に再取得できる（stale lock なし）             → TestAcquireViewerLock_ReacquireAfterRelease
-// - run/ ディレクトリが存在しなければ自動作成する             → TestAcquireViewerLock_CreatesRunDir
+// - ロック取得成功時にPIDと起動時刻をファイルに書き込む        → TestAcquireViewerLock_WritesLockFile
+// - 2つ目のロック取得は ViewerAlreadyRunningError を返す       → TestAcquireViewerLock_AlreadyLocked
+// - ViewerAlreadyRunningError に先行PIDと起動時刻が含まれる    → TestAcquireViewerLock_AlreadyLocked_HasPIDAndTime
+// - ロック解放後に再取得できる（stale lock なし）               → TestAcquireViewerLock_ReacquireAfterRelease
+// - viewer/ ディレクトリが存在しなければ自動作成する            → TestAcquireViewerLock_CreatesViewerDir
 
 import (
 	"errors"
@@ -51,7 +51,7 @@ func parseLockFile(t *testing.T, path string) (pid int, startedAt time.Time) {
 
 func TestAcquireViewerLock_WritesLockFile(t *testing.T) {
 	dir := t.TempDir()
-	lockPath := filepath.Join(dir, "run", "viewer.lock")
+	lockPath := filepath.Join(dir, "viewer", "viewer.lock")
 
 	vl, err := infra.AcquireViewerLock(lockPath)
 	if err != nil {
@@ -78,7 +78,7 @@ func TestAcquireViewerLock_WritesLockFile(t *testing.T) {
 
 func TestAcquireViewerLock_AlreadyLocked(t *testing.T) {
 	dir := t.TempDir()
-	lockPath := filepath.Join(dir, "run", "viewer.lock")
+	lockPath := filepath.Join(dir, "viewer", "viewer.lock")
 
 	first, err := infra.AcquireViewerLock(lockPath)
 	if err != nil {
@@ -99,7 +99,7 @@ func TestAcquireViewerLock_AlreadyLocked(t *testing.T) {
 
 func TestAcquireViewerLock_AlreadyLocked_HasPIDAndTime(t *testing.T) {
 	dir := t.TempDir()
-	lockPath := filepath.Join(dir, "run", "viewer.lock")
+	lockPath := filepath.Join(dir, "viewer", "viewer.lock")
 
 	before := time.Now().Truncate(time.Second)
 
@@ -129,7 +129,7 @@ func TestAcquireViewerLock_AlreadyLocked_HasPIDAndTime(t *testing.T) {
 
 func TestAcquireViewerLock_ReacquireAfterRelease(t *testing.T) {
 	dir := t.TempDir()
-	lockPath := filepath.Join(dir, "run", "viewer.lock")
+	lockPath := filepath.Join(dir, "viewer", "viewer.lock")
 
 	first, err := infra.AcquireViewerLock(lockPath)
 	if err != nil {
@@ -146,13 +146,13 @@ func TestAcquireViewerLock_ReacquireAfterRelease(t *testing.T) {
 	defer second.Release() //nolint:errcheck
 }
 
-func TestAcquireViewerLock_CreatesRunDir(t *testing.T) {
+func TestAcquireViewerLock_CreatesViewerDir(t *testing.T) {
 	dir := t.TempDir()
-	runDir := filepath.Join(dir, "run")
-	lockPath := filepath.Join(runDir, "viewer.lock")
+	viewerDir := filepath.Join(dir, "viewer")
+	lockPath := filepath.Join(viewerDir, "viewer.lock")
 
-	if _, err := os.Stat(runDir); !os.IsNotExist(err) {
-		t.Fatalf("expected run dir to not exist before test")
+	if _, err := os.Stat(viewerDir); !os.IsNotExist(err) {
+		t.Fatalf("expected viewer dir to not exist before test")
 	}
 
 	vl, err := infra.AcquireViewerLock(lockPath)
@@ -161,11 +161,11 @@ func TestAcquireViewerLock_CreatesRunDir(t *testing.T) {
 	}
 	defer vl.Release() //nolint:errcheck
 
-	info, err := os.Stat(runDir)
+	info, err := os.Stat(viewerDir)
 	if err != nil {
-		t.Fatalf("expected run dir to be created at %s: %v", runDir, err)
+		t.Fatalf("expected viewer dir to be created at %s: %v", viewerDir, err)
 	}
 	if !info.IsDir() {
-		t.Errorf("expected %s to be a directory", runDir)
+		t.Errorf("expected %s to be a directory", viewerDir)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -54,6 +54,9 @@ func main() {
 		if len(assetsDirs) > 0 {
 			opts = append(opts, infra.WithAssetsDirs(assetsDirs))
 		}
+		if historyDir, err := infra.ResolveViewerHistoryPath(); err == nil {
+			opts = append(opts, infra.WithHistoryDir(historyDir))
+		}
 		return infra.NewHTTPStreamPlayer(addr, staticFS, opts...)
 	}
 


### PR DESCRIPTION
## Summary

- `viewer.lock` パスを `~/.vox-actor/run/viewer.lock` から `~/.vox-actor/viewer/viewer.lock` へ移動し、viewer 関連ファイルを `viewer/` 配下に集約
- `HTTPStreamPlayer` に再生履歴のファイル保存機能を追加（clip 配信時に `~/.vox-actor/viewer/history/YYYY-MM-DD.jsonl` へ追記）
- viewer 起動時に 30日より古い `*.jsonl` を自動削除（ベストエフォート）
- `/api/history` エンドポイントを追加し、当日の履歴末尾50件を返す
- フロントエンドで viewer 起動時に `/api/history` を fetch して配信タブに初期表示（音声再生なし）

## Test plan

- [x] `go test ./...` 全テストパス
- [x] `npm run typecheck` 型チェックパス
- [x] `gofmt -l .` と `golangci-lint run` でリント問題なし
- [ ] `vox-actor viewer` 起動後、`vox-actor say` で発話するとブラウザ「配信」タブに表示される（VOICEVOX 接続要）
- [ ] viewer 再起動後、当日の履歴が「配信」タブに初期表示される（VOICEVOX 接続要）
- [ ] `~/.vox-actor/viewer/history/YYYY-MM-DD.jsonl` に clip が追記されることを確認

Closes #408

---
🤖 Generated with [Claude Code](https://claude.ai/code)
