### PR TITLE
fix(viewer): /api/history がリロード時に最新履歴を返すよう修正

### DIFF
--- a/frontend/test/e2e/helpers.ts
+++ b/frontend/test/e2e/helpers.ts
@@ -68,6 +68,24 @@ export async function setApiCharacters(
   expect(resp.ok()).toBeTruthy();
 }
 
+export interface HistoryEntryPayload {
+  id: number;
+  text: string;
+  speakerName: string;
+  styleName: string;
+  timestamp: number;
+}
+
+export async function setApiHistory(
+  request: APIRequestContext,
+  entries: HistoryEntryPayload[],
+): Promise<void> {
+  const resp = await request.post(`${STUB_BASE_URL}/__stub/api-history`, {
+    data: { entries },
+  });
+  expect(resp.ok()).toBeTruthy();
+}
+
 export async function pushClip(
   request: APIRequestContext,
   payload: ClipPayload,

--- a/frontend/test/e2e/history.spec.ts
+++ b/frontend/test/e2e/history.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+import { resetStub, setApiHistory } from "./helpers";
+
+test.describe("配信タブ: 再生履歴", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test("ページ読み込み時に /api/history の履歴がタイムラインに表示される", async ({
+    page,
+    request,
+  }) => {
+    await setApiHistory(request, [
+      {
+        id: 1001,
+        text: "履歴テキスト1",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: Date.now(),
+      },
+      {
+        id: 1002,
+        text: "履歴テキスト2",
+        speakerName: "四国めたん",
+        styleName: "ノーマル",
+        timestamp: Date.now(),
+      },
+    ]);
+
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    await expect(page.locator('[data-clip-id="1001"]')).toBeVisible();
+    await expect(
+      page.locator('[data-clip-id="1001"]'),
+    ).toContainText("履歴テキスト1");
+    await expect(page.locator('[data-clip-id="1002"]')).toBeVisible();
+    await expect(
+      page.locator('[data-clip-id="1002"]'),
+    ).toContainText("履歴テキスト2");
+  });
+
+  test("履歴項目の表示後に audio の src が空のまま（音声再生が起きない）", async ({
+    page,
+    request,
+  }) => {
+    await setApiHistory(request, [
+      {
+        id: 2001,
+        text: "音声なし履歴",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: Date.now(),
+      },
+    ]);
+
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+    await expect(page.locator('[data-clip-id="2001"]')).toBeVisible();
+
+    // 履歴ロード後も audio.src が空 = 再生キューに積まれていない。
+    const audioSrc = await page.evaluate(
+      () => document.querySelector("audio")?.src ?? "",
+    );
+    expect(audioSrc).toBe("");
+  });
+
+  test("リロード後も最新の /api/history が表示される", async ({
+    page,
+    request,
+  }) => {
+    await setApiHistory(request, [
+      {
+        id: 3001,
+        text: "リロード前テキスト",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: Date.now(),
+      },
+    ]);
+
+    await page.goto("/");
+    await expect(page.locator('[data-clip-id="3001"]')).toBeVisible();
+
+    // リロード前後で新しいエントリを追加する。
+    await setApiHistory(request, [
+      {
+        id: 3001,
+        text: "リロード前テキスト",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: Date.now(),
+      },
+      {
+        id: 3002,
+        text: "リロード後追加テキスト",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: Date.now(),
+      },
+    ]);
+
+    await page.reload();
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    await expect(page.locator('[data-clip-id="3002"]')).toBeVisible();
+    await expect(
+      page.locator('[data-clip-id="3002"]'),
+    ).toContainText("リロード後追加テキスト");
+  });
+});

--- a/frontend/test/stub-server.mjs
+++ b/frontend/test/stub-server.mjs
@@ -1,6 +1,6 @@
 // Playwright E2E 用スタブサーバー。
 // バックエンド (internal/infra/http_stream_player.go) の /events, /api/status,
-// /api/characters, /test-clip, /clips/<id>.wav を Node 標準ライブラリだけでエミュレートする。
+// /api/characters, /api/history, /test-clip, /clips/<id>.wav を Node 標準ライブラリだけでエミュレートする。
 //
 // テスト側からの制御チャネルとして以下を追加で提供する:
 // - POST /__stub/clip             { id?, url?, text, speakerName?, styleName?, timestamp? } → SSE clip 配信
@@ -8,6 +8,7 @@
 // - POST /__stub/disconnect       → 全 SSE 接続を一斉切断（再接続テスト用）
 // - POST /__stub/api-status       { silent, silentReason, speakers } → /api/status の応答を切替
 // - POST /__stub/api-characters   { enabled, characters } → /api/characters の応答を切替
+// - POST /__stub/api-history      { entries: [...] } → /api/history の応答を設定
 // - POST /__stub/reset            → 内部状態を初期化
 //
 // VOX_STUB_PORT で待受ポートを変えられる（既定: 8080）。
@@ -50,8 +51,11 @@ const DEFAULT_API_CHARACTERS = {
   characters: [],
 };
 
+const DEFAULT_API_HISTORY = { entries: [] };
+
 let apiStatus = structuredClone(DEFAULT_API_STATUS);
 let apiCharacters = structuredClone(DEFAULT_API_CHARACTERS);
+let apiHistory = structuredClone(DEFAULT_API_HISTORY);
 let nextClipId = 0;
 let nextErrorId = 0;
 const subscribers = new Set();
@@ -109,6 +113,10 @@ function handleApiStatus(_req, res) {
 
 function handleApiCharacters(_req, res) {
   writeJSON(res, 200, apiCharacters);
+}
+
+function handleApiHistory(_req, res) {
+  writeJSON(res, 200, apiHistory);
 }
 
 function handleTestClip(req, res) {
@@ -219,9 +227,18 @@ async function handleStubApiCharacters(req, res) {
   writeJSON(res, 200, { ok: true, apiCharacters });
 }
 
+async function handleStubApiHistory(req, res) {
+  const body = await readJSON(req);
+  apiHistory = {
+    entries: Array.isArray(body.entries) ? body.entries : [],
+  };
+  writeJSON(res, 200, { ok: true, apiHistory });
+}
+
 function handleStubReset(_req, res) {
   apiStatus = structuredClone(DEFAULT_API_STATUS);
   apiCharacters = structuredClone(DEFAULT_API_CHARACTERS);
+  apiHistory = structuredClone(DEFAULT_API_HISTORY);
   nextClipId = 0;
   nextErrorId = 0;
   for (const sub of subscribers) {
@@ -240,6 +257,8 @@ const server = http.createServer((req, res) => {
     return handleApiStatus(req, res);
   if (req.method === "GET" && path === "/api/characters")
     return handleApiCharacters(req, res);
+  if (req.method === "GET" && path === "/api/history")
+    return handleApiHistory(req, res);
   if (req.method === "GET" && path === "/test-clip")
     return handleTestClip(req, res);
   if (
@@ -261,6 +280,9 @@ const server = http.createServer((req, res) => {
   }
   if (req.method === "POST" && path === "/__stub/api-characters") {
     return handleStubApiCharacters(req, res);
+  }
+  if (req.method === "POST" && path === "/__stub/api-history") {
+    return handleStubApiHistory(req, res);
   }
   if (req.method === "POST" && path === "/__stub/reset")
     return handleStubReset(req, res);

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -63,8 +63,6 @@ type HTTPStreamPlayer struct {
 
 	// historyDir は再生履歴 JSONL ファイルの保存ディレクトリ。空文字の場合は履歴機能無効。
 	historyDir string
-	// apiHistoryJSON は Start 時に今日の履歴末尾 historyLoadSize 件からマーシャルしたレスポンス。
-	apiHistoryJSON []byte
 
 	// silentInterval は PlayText で使う固定待機時間（backpressure の暫定値）。
 	silentInterval time.Duration
@@ -297,9 +295,6 @@ func (p *HTTPStreamPlayer) Start(_ context.Context) error {
 		return err
 	}
 	p.pruneOldHistory()
-	if err := p.buildAPIHistoryJSON(); err != nil {
-		return err
-	}
 
 	lis, err := net.Listen("tcp", p.addr)
 	if err != nil {
@@ -862,23 +857,18 @@ func (p *HTTPStreamPlayer) handleAPICharacters(w http.ResponseWriter, _ *http.Re
 }
 
 func (p *HTTPStreamPlayer) handleAPIHistory(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	_, _ = w.Write(p.apiHistoryJSON)
-}
-
-// buildAPIHistoryJSON は今日の履歴ファイル末尾 historyLoadSize 件を読み込み、
-// /api/history のレスポンスとしてキャッシュする。historyDir が空なら空配列を返す。
-func (p *HTTPStreamPlayer) buildAPIHistoryJSON() error {
 	entries := p.loadHistory(historyLoadSize)
 	if entries == nil {
 		entries = []historyRecord{}
 	}
 	payload, err := json.Marshal(apiHistoryResponse{Entries: entries})
 	if err != nil {
-		return fmt.Errorf("failed to marshal api history: %w", err)
+		p.logger.Warn("failed to marshal api history", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
 	}
-	p.apiHistoryJSON = payload
-	return nil
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_, _ = w.Write(payload)
 }
 
 // loadHistory は今日の履歴ファイルから末尾 n 件を読み込む。

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -2564,3 +2564,125 @@ func TestHTTPStreamPlayer_APIHistory_EmptyWhenNoFile(t *testing.T) {
 		t.Errorf("expected 0 entries, got %d", len(result.Entries))
 	}
 }
+
+// TestHTTPStreamPlayer_APIHistory_ReturnsUpdatedHistory は Start() 後にファイルへ追記された
+// 履歴エントリが /api/history リクエスト時に反映されることを検証する。
+func TestHTTPStreamPlayer_APIHistory_ReturnsUpdatedHistory(t *testing.T) {
+	historyDir := t.TempDir()
+	fixedNow := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return fixedNow }),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	// Start() 後に履歴ファイルへエントリを追記する。
+	filePath := filepath.Join(historyDir, "2026-04-28.jsonl")
+	rec := historyRecord{
+		ID:          1,
+		Text:        "Start後に追記されたテキスト",
+		SpeakerName: "ずんだもん",
+		StyleName:   "ノーマル",
+		Timestamp:   fixedNow.UnixMilli(),
+	}
+	data, _ := json.Marshal(rec)
+	data = append(data, '\n')
+	if err := os.WriteFile(filePath, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/history")
+	if err != nil {
+		t.Fatalf("GET /api/history: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result apiHistoryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result.Entries))
+	}
+	if result.Entries[0].Text != "Start後に追記されたテキスト" {
+		t.Errorf("expected text %q, got %q", "Start後に追記されたテキスト", result.Entries[0].Text)
+	}
+}
+
+// TestHTTPStreamPlayer_APIHistory_CrossDayReturnsNewFile は日付を跨いだ後に
+// /api/history が新しい日付のファイルを読み込むことを検証する。
+func TestHTTPStreamPlayer_APIHistory_CrossDayReturnsNewFile(t *testing.T) {
+	historyDir := t.TempDir()
+	day1 := time.Date(2026, 4, 28, 23, 59, 0, 0, time.Local)
+	day2 := time.Date(2026, 4, 29, 0, 1, 0, 0, time.Local)
+	nowPtr := &day1
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return *nowPtr }),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	// Day1 のファイルを作成。
+	file1 := filepath.Join(historyDir, "2026-04-28.jsonl")
+	rec1 := historyRecord{ID: 1, Text: "day1エントリ", SpeakerName: "ずんだもん", StyleName: "ノーマル", Timestamp: day1.UnixMilli()}
+	data1, _ := json.Marshal(rec1)
+	data1 = append(data1, '\n')
+	if err := os.WriteFile(file1, data1, 0o644); err != nil {
+		t.Fatalf("WriteFile day1: %v", err)
+	}
+
+	// Day2 へ日付変更し、Day2 のファイルを作成。
+	*nowPtr = day2
+	file2 := filepath.Join(historyDir, "2026-04-29.jsonl")
+	rec2 := historyRecord{ID: 2, Text: "day2エントリ", SpeakerName: "ずんだもん", StyleName: "ノーマル", Timestamp: day2.UnixMilli()}
+	data2, _ := json.Marshal(rec2)
+	data2 = append(data2, '\n')
+	if err := os.WriteFile(file2, data2, 0o644); err != nil {
+		t.Fatalf("WriteFile day2: %v", err)
+	}
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/history")
+	if err != nil {
+		t.Fatalf("GET /api/history: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result apiHistoryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry from day2, got %d", len(result.Entries))
+	}
+	if result.Entries[0].Text != "day2エントリ" {
+		t.Errorf("expected day2 entry, got %q", result.Entries[0].Text)
+	}
+}

--- a/test/e2e/viewer_test.go
+++ b/test/e2e/viewer_test.go
@@ -275,3 +275,93 @@ func TestViewerE2E_WatchNonDirectory_ReturnsUsageError(t *testing.T) {
 		t.Fatalf("expected exit code 2 for non-directory --watch, got %d\nstderr:\n%s", exitCode, stderr)
 	}
 }
+
+// apiHistoryEntry は /api/history レスポンスの1エントリ。
+type apiHistoryEntry struct {
+	ID          uint64 `json:"id"`
+	Text        string `json:"text"`
+	SpeakerName string `json:"speakerName"`
+	StyleName   string `json:"styleName"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// apiHistoryResp は /api/history のレスポンス。
+type apiHistoryResp struct {
+	Entries []apiHistoryEntry `json:"entries"`
+}
+
+func TestViewerE2E_APIHistory_ReturnsUpdatedHistory(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	port := freePort(t)
+	historyDir := workspace + "/viewer/history"
+	if err := os.MkdirAll(historyDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll historyDir: %v", err)
+	}
+
+	vp := startViewer(t, map[string]string{"VOX_ACTOR_WORKSPACE": workspace}, "--port", fmt.Sprintf("%d", port))
+
+	line := vp.waitForStderr("stream server listening", 10*time.Second)
+	addr := extractAddrFromLog(line)
+	if addr == "" {
+		t.Fatalf("failed to extract addr from log line: %q", line)
+	}
+
+	// viewer 起動後に履歴ファイルへエントリを追記する。
+	today := time.Now().Format("2006-01-02")
+	filePath := historyDir + "/" + today + ".jsonl"
+	entry := apiHistoryEntry{
+		ID:          1,
+		Text:        "起動後追記テキスト",
+		SpeakerName: "ずんだもん",
+		StyleName:   "ノーマル",
+		Timestamp:   time.Now().UnixMilli(),
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("json.Marshal entry: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filePath, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	url := fmt.Sprintf("http://%s/api/history", addr)
+	var (
+		resp   *http.Response
+		getErr error
+	)
+	for i := 0; i < 20; i++ {
+		resp, getErr = http.Get(url) //nolint:noctx
+		if getErr == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if getErr != nil {
+		t.Fatalf("GET /api/history: %v", getErr)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	var result apiHistoryResp
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("failed to decode /api/history: %v\nbody: %s", err, body)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d\nbody: %s", len(result.Entries), body)
+	}
+	if result.Entries[0].Text != "起動後追記テキスト" {
+		t.Errorf("expected text %q, got %q", "起動後追記テキスト", result.Entries[0].Text)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}


### PR DESCRIPTION
## 概要

- `handleAPIHistory` の起動時キャッシュ方式を廃止し、リクエスト毎に `loadHistory()` を呼び直す方式に変更
- `apiHistoryJSON` フィールドと `buildAPIHistoryJSON()` 関数を削除
- ブラウザリロード時に直近 50 件の履歴が常に最新状態で表示される
- 日付跨ぎ後も前日キャッシュを返さず新しいファイルを読み込む

Closes #412

## テスト

### 追加したテスト

- `TestHTTPStreamPlayer_APIHistory_ReturnsUpdatedHistory`: Start() 後にファイルへ追記した履歴が `/api/history` に反映されることを検証
- `TestHTTPStreamPlayer_APIHistory_CrossDayReturnsNewFile`: 日付跨ぎ後に新しいファイルが読まれることを検証
- `TestViewerE2E_APIHistory_ReturnsUpdatedHistory`: バイナリを起動して同様のシナリオをe2e検証
- `frontend/test/e2e/history.spec.ts`: Playwright テスト3件（履歴表示・音声再生なし・リロード後最新表示）

### 手動確認が必要な項目

- viewer 起動後に `vox-actor say` でクリップを配信し、ブラウザリロードで配信タブに履歴が表示されること（VOICEVOX 接続環境が必要）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
