### PR TITLE
feat(viewer): 初期表示時に最新の履歴にスクロールする

### DIFF
--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { TimelineEntry } from "../types/api";
 import { TimelineItem } from "./TimelineItem";
 
@@ -25,25 +25,26 @@ export function Timeline({
   const prevIsCharacterMode = useRef(isCharacterMode);
   const hasInitialScrolled = useRef(false);
 
+  const scrollToBottom = useCallback(() => {
+    const list = listRef.current;
+    if (list) {
+      list.scrollTop = list.scrollHeight;
+    }
+  }, []);
+
   useEffect(() => {
     if (!isCharacterMode && prevIsCharacterMode.current) {
-      const list = listRef.current;
-      if (list) {
-        list.scrollTop = list.scrollHeight;
-      }
+      scrollToBottom();
     }
     prevIsCharacterMode.current = isCharacterMode;
-  }, [isCharacterMode]);
+  }, [isCharacterMode, scrollToBottom]);
 
   useEffect(() => {
     if (!hasInitialScrolled.current && entries.length > 0) {
-      const list = listRef.current;
-      if (list) {
-        list.scrollTop = list.scrollHeight;
-      }
+      scrollToBottom();
       hasInitialScrolled.current = true;
     }
-  }, [entries]);
+  }, [entries, scrollToBottom]);
 
   const characterModeClipId = playingClipId ?? lastPlayingClipId;
   const displayEntries = isCharacterMode

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -23,6 +23,7 @@ export function Timeline({
 }: TimelineProps) {
   const listRef = useRef<HTMLOListElement>(null);
   const prevIsCharacterMode = useRef(isCharacterMode);
+  const hasInitialScrolled = useRef(false);
 
   useEffect(() => {
     if (!isCharacterMode && prevIsCharacterMode.current) {
@@ -33,6 +34,16 @@ export function Timeline({
     }
     prevIsCharacterMode.current = isCharacterMode;
   }, [isCharacterMode]);
+
+  useEffect(() => {
+    if (!hasInitialScrolled.current && entries.length > 0) {
+      const list = listRef.current;
+      if (list) {
+        list.scrollTop = list.scrollHeight;
+      }
+      hasInitialScrolled.current = true;
+    }
+  }, [entries]);
 
   const characterModeClipId = playingClipId ?? lastPlayingClipId;
   const displayEntries = isCharacterMode

--- a/frontend/test/e2e/history.spec.ts
+++ b/frontend/test/e2e/history.spec.ts
@@ -81,12 +81,10 @@ test.describe("配信タブ: 再生履歴", () => {
     await page.goto("/");
     await expect(page.getByText("● 接続中")).toBeVisible();
 
-    // 最新（末尾）エントリが表示範囲内に存在する
     const lastEntry = page.locator(`[data-clip-id="${entries[entries.length - 1].id}"]`);
     await expect(lastEntry).toBeVisible();
     await expect(lastEntry).toBeInViewport();
 
-    // 最古（先頭）エントリはスクロールにより表示範囲外
     const firstEntry = page.locator(`[data-clip-id="${entries[0].id}"]`);
     await expect(firstEntry).not.toBeInViewport();
   });

--- a/frontend/test/e2e/history.spec.ts
+++ b/frontend/test/e2e/history.spec.ts
@@ -65,6 +65,40 @@ test.describe("配信タブ: 再生履歴", () => {
     expect(audioSrc).toBe("");
   });
 
+  test("viewer 起動直後に履歴リストが末尾（最新エントリ）にスクロールされる", async ({
+    page,
+    request,
+  }) => {
+    const entries = Array.from({ length: 20 }, (_, i) => ({
+      id: 6000 + i,
+      text: `スクロールテスト履歴${i + 1}`,
+      speakerName: "ずんだもん",
+      styleName: "ノーマル",
+      timestamp: Date.now() + i * 1000,
+    }));
+    await setApiHistory(request, entries);
+
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    // 最新（末尾）エントリが表示範囲内に存在する
+    const lastEntry = page.locator(`[data-clip-id="${entries[entries.length - 1].id}"]`);
+    await expect(lastEntry).toBeVisible();
+    await expect(lastEntry).toBeInViewport();
+
+    // 最古（先頭）エントリはスクロールにより表示範囲外
+    const firstEntry = page.locator(`[data-clip-id="${entries[0].id}"]`);
+    await expect(firstEntry).not.toBeInViewport();
+  });
+
+  test("履歴が空のとき従来どおりリストは空のまま", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    const list = page.getByRole("list");
+    await expect(list).toBeEmpty();
+  });
+
   test("リロード後も最新の /api/history が表示される", async ({
     page,
     request,


### PR DESCRIPTION
## Summary

- `Timeline.tsx` に `hasInitialScrolled` ref と `entries` 依存の `useEffect` を追加し、初回 entries 反映後に `list.scrollTop = list.scrollHeight` を実行して末尾へスクロールする
- 既存の `isCharacterMode` 切替時スクロールと共通の `scrollToBottom` ヘルパー（`useCallback`）に集約し、重複を解消
- 履歴が空の場合は `entries.length > 0` ガードにより従来挙動を維持

## Test plan

- [x] ユニットテスト（`npm run test:unit`）: 149件すべてパス
- [x] 型チェック（`npm run typecheck`）: エラーなし
- [x] e2e テスト（`npm run test:e2e`）: 20件すべてパス（新規テスト含む）
  - `viewer 起動直後に履歴リストが末尾（最新エントリ）にスクロールされる`
  - `履歴が空のとき従来どおりリストは空のまま`

Closes #414

---
🤖 Generated with [Claude Code](https://claude.ai/code)
