### PR TITLE
fix(viewer): vox-actor 再起動後の clip id 衝突を timestamp 識別子化で解消

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,16 +54,16 @@ const parseBool = (raw: string): boolean | null =>
 
 const passthrough = (v: string): string => v;
 
-// 再生中のクリップ項目は削除しない（playingId と一致する clip に出会ったら停止）。
+// 再生中のクリップ項目は削除しない（playingTimestamp と一致する clip に出会ったら停止）。
 function trimTimeline(
   entries: TimelineEntry[],
   size: number,
-  playingId: number | null,
+  playingTimestamp: number | null,
 ): TimelineEntry[] {
   let next = entries;
   while (next.length > size) {
     const head = next[0];
-    if (head.kind === "clip" && head.id === playingId) break;
+    if (head.kind === "clip" && head.timestamp === playingTimestamp) break;
     next = next.slice(1);
   }
   return next;
@@ -131,7 +131,7 @@ export function App() {
   const [characters, setCharacters] = useState<CharacterEntry[]>([]);
   const testErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { playingClipId, enqueue } = usePlaybackQueue(
+  const { playingClipTimestamp, enqueue } = usePlaybackQueue(
     audioRef,
     activeTab === "stream",
   );
@@ -139,8 +139,8 @@ export function App() {
     audioRef,
     charactersEnabled && (showCharacters || activeTab === "test"),
   );
-  const playingClipIdRef = useRef<number | null>(null);
-  playingClipIdRef.current = playingClipId;
+  const playingClipTimestampRef = useRef<number | null>(null);
+  playingClipTimestampRef.current = playingClipTimestamp;
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -153,10 +153,10 @@ export function App() {
   }, [muted]);
 
   // 履歴上限の変更時のみトリム。再生状態の変化ではトリムしない
-  // （再生終了直後の playingClipId=null 経由で過去のハイライト対象が消えるのを防ぐ）。
+  // （再生終了直後の playingClipTimestamp=null 経由で過去のハイライト対象が消えるのを防ぐ）。
   useEffect(() => {
     setEntries((prev) =>
-      trimTimeline(prev, historySize, playingClipIdRef.current),
+      trimTimeline(prev, historySize, playingClipTimestampRef.current),
     );
   }, [historySize]);
 
@@ -218,7 +218,6 @@ export function App() {
         if (cancelled) return;
         const historyEntries: TimelineEntry[] = data.entries.map((e) => ({
           kind: "clip" as const,
-          id: e.id,
           url: "",
           text: e.text,
           speakerName: e.speakerName,
@@ -292,7 +291,7 @@ export function App() {
         trimTimeline(
           [...prev, { kind: "clip", ...clip }],
           historySize,
-          playingClipIdRef.current,
+          playingClipTimestampRef.current,
         ),
       );
       // clip.url が空の場合は無音モード配信なのでタイムラインには載せつつ再生キューには積まない。
@@ -320,7 +319,7 @@ export function App() {
         trimTimeline(
           [...prev, { kind: "error", ...parsed }],
           historySize,
-          playingClipIdRef.current,
+          playingClipTimestampRef.current,
         ),
       );
     },
@@ -367,7 +366,7 @@ export function App() {
         <StreamPanel
           hidden={activeTab !== "stream"}
           entries={entries}
-          playingClipId={playingClipId}
+          playingClipTimestamp={playingClipTimestamp}
           historySize={historySize}
           historySizeOptions={HISTORY_SIZE_OPTIONS}
           onHistorySizeChange={setHistorySize}

--- a/frontend/src/components/StreamPanel.test.tsx
+++ b/frontend/src/components/StreamPanel.test.tsx
@@ -6,7 +6,6 @@ import { StreamPanel } from "./StreamPanel";
 const mockEntries: TimelineEntry[] = [
   {
     kind: "clip",
-    id: 1,
     url: "http://example.com/audio.mp3",
     text: "クリップテキスト",
     speakerName: "話者A",
@@ -26,7 +25,7 @@ const mockCharacters: CharacterEntry[] = [
 
 const defaultProps = {
   entries: [],
-  playingClipId: null,
+  playingClipTimestamp: null,
   historySize: 50,
   historySizeOptions: [10, 50, 100] as const,
   onHistorySizeChange: vi.fn(),
@@ -84,13 +83,13 @@ describe("StreamPanel", () => {
     expect(screen.getByText("クリップテキスト")).toBeInTheDocument();
   });
 
-  it("Timeline に playingClipId が渡され再生中エントリが強調される", () => {
+  it("Timeline に playingClipTimestamp が渡され再生中エントリが強調される", () => {
     render(
       <StreamPanel
         {...defaultProps}
         hidden={false}
         entries={mockEntries}
-        playingClipId={1}
+        playingClipTimestamp={1700000000000}
       />,
     );
     expect(screen.getByText("▶")).toBeInTheDocument();
@@ -125,7 +124,6 @@ describe("StreamPanel", () => {
     const entries: TimelineEntry[] = [
       {
         kind: "clip",
-        id: 1,
         url: "http://example.com/1.mp3",
         text: "古いテキスト",
         speakerName: "話者A",
@@ -134,7 +132,6 @@ describe("StreamPanel", () => {
       },
       {
         kind: "clip",
-        id: 2,
         url: "http://example.com/2.mp3",
         text: "新しいテキスト",
         speakerName: "話者A",
@@ -158,7 +155,6 @@ describe("StreamPanel", () => {
     const entries: TimelineEntry[] = [
       {
         kind: "clip",
-        id: 1,
         url: "http://example.com/1.mp3",
         text: "古いテキスト",
         speakerName: "話者A",
@@ -167,7 +163,6 @@ describe("StreamPanel", () => {
       },
       {
         kind: "clip",
-        id: 2,
         url: "http://example.com/2.mp3",
         text: "新しいテキスト",
         speakerName: "話者A",
@@ -175,7 +170,7 @@ describe("StreamPanel", () => {
         timestamp: 1700000001000,
       },
     ];
-    // showCharacters=true かつ characters が存在し playingClipId が設定されていると
+    // showCharacters=true かつ characters が存在し playingClipTimestamp が設定されていると
     // useCharacterStage がスロットを返し、キャラモードになる
     render(
       <StreamPanel
@@ -185,18 +180,17 @@ describe("StreamPanel", () => {
         characters={mockCharacters}
         charactersEnabled={true}
         showCharacters={true}
-        playingClipId={2}
+        playingClipTimestamp={1700000001000}
       />,
     );
     expect(screen.queryByText("古いテキスト")).not.toBeInTheDocument();
     expect(screen.getByText("新しいテキスト")).toBeInTheDocument();
   });
 
-  it("キャラモード時は再生中でない最新エントリではなく playingClipId のエントリが表示される", () => {
+  it("キャラモード時は再生中でない最新エントリではなく playingClipTimestamp のエントリが表示される", () => {
     const entries: TimelineEntry[] = [
       {
         kind: "clip",
-        id: 1,
         url: "http://example.com/1.mp3",
         text: "古いテキスト",
         speakerName: "話者A",
@@ -205,7 +199,6 @@ describe("StreamPanel", () => {
       },
       {
         kind: "clip",
-        id: 2,
         url: "http://example.com/2.mp3",
         text: "新しいテキスト",
         speakerName: "話者A",
@@ -221,7 +214,7 @@ describe("StreamPanel", () => {
         characters={mockCharacters}
         charactersEnabled={true}
         showCharacters={true}
-        playingClipId={1}
+        playingClipTimestamp={1700000000000}
       />,
     );
     expect(screen.getByText("古いテキスト")).toBeInTheDocument();
@@ -237,13 +230,13 @@ describe("StreamPanel", () => {
         characters={mockCharacters}
         charactersEnabled={true}
         showCharacters={true}
-        playingClipId={1}
+        playingClipTimestamp={1700000000000}
       />,
     );
     expect(screen.queryByText("▶")).not.toBeInTheDocument();
   });
 
-  it("キャラモード時、再生終了後（playingClipId=null）もセリフが表示される", async () => {
+  it("キャラモード時、再生終了後（playingClipTimestamp=null）もセリフが表示される", async () => {
     const { rerender } = render(
       <StreamPanel
         {...defaultProps}
@@ -252,7 +245,7 @@ describe("StreamPanel", () => {
         characters={mockCharacters}
         charactersEnabled={true}
         showCharacters={true}
-        playingClipId={1}
+        playingClipTimestamp={1700000000000}
       />,
     );
     expect(screen.getByText("クリップテキスト")).toBeInTheDocument();
@@ -266,7 +259,7 @@ describe("StreamPanel", () => {
         characters={mockCharacters}
         charactersEnabled={true}
         showCharacters={true}
-        playingClipId={null}
+        playingClipTimestamp={null}
       />,
     );
 

--- a/frontend/src/components/StreamPanel.tsx
+++ b/frontend/src/components/StreamPanel.tsx
@@ -8,7 +8,7 @@ import { TimelineControls } from "./TimelineControls";
 interface StreamPanelProps {
   hidden: boolean;
   entries: TimelineEntry[];
-  playingClipId: number | null;
+  playingClipTimestamp: number | null;
   historySize: number;
   historySizeOptions: readonly number[];
   onHistorySizeChange: (value: number) => void;
@@ -53,7 +53,7 @@ export function StreamPanel(props: StreamPanelProps) {
   const {
     hidden,
     entries,
-    playingClipId,
+    playingClipTimestamp,
     historySize,
     historySizeOptions,
     onHistorySizeChange,
@@ -70,8 +70,8 @@ export function StreamPanel(props: StreamPanelProps) {
     volume,
   } = props;
 
-  const { slots, isMultiSlot, lastClipId } = useCharacterStage(
-    playingClipId,
+  const { slots, isMultiSlot, lastClipTimestamp } = useCharacterStage(
+    playingClipTimestamp,
     entries,
     characters,
   );
@@ -79,8 +79,10 @@ export function StreamPanel(props: StreamPanelProps) {
   const hasCharactersOnStage = slots.some((s) => s !== null);
   const isCharacterMode = showCharacters && hasCharactersOnStage;
 
-  const playingClipData = playingClipId
-    ? (entries.find((e) => e.kind === "clip" && e.id === playingClipId) ?? null)
+  const playingClipData = playingClipTimestamp
+    ? (entries.find(
+        (e) => e.kind === "clip" && e.timestamp === playingClipTimestamp,
+      ) ?? null)
     : null;
 
   function isPlayingCharacter(character: CharacterEntry): boolean {
@@ -208,8 +210,8 @@ export function StreamPanel(props: StreamPanelProps) {
       )}
       <Timeline
         entries={entries}
-        playingClipId={playingClipId}
-        lastPlayingClipId={lastClipId}
+        playingClipTimestamp={playingClipTimestamp}
+        lastPlayingClipTimestamp={lastClipTimestamp}
         showSpeakerName={showSpeakerName}
         showStyleName={showStyleName}
         showTimestamp={showTimestamp}

--- a/frontend/src/components/Timeline.test.tsx
+++ b/frontend/src/components/Timeline.test.tsx
@@ -4,20 +4,19 @@ import type { TimelineEntry } from "../types/api";
 import { Timeline } from "./Timeline";
 
 const defaultProps = {
-  playingClipId: null,
+  playingClipTimestamp: null,
   showSpeakerName: false,
   showStyleName: false,
   showTimestamp: false,
 };
 
-const clipEntry = (id: number, text: string): TimelineEntry => ({
+const clipEntry = (timestamp: number, text: string): TimelineEntry => ({
   kind: "clip",
-  id,
-  url: `http://example.com/${id}.mp3`,
+  url: `http://example.com/${timestamp}.mp3`,
   text,
   speakerName: "話者A",
   styleName: "ノーマル",
-  timestamp: 1700000000000,
+  timestamp,
 });
 
 describe("Timeline", () => {
@@ -29,9 +28,9 @@ describe("Timeline", () => {
 
   it("entries の数だけリストアイテムが描画される", () => {
     const entries: TimelineEntry[] = [
-      clipEntry(1, "テキスト1"),
-      clipEntry(2, "テキスト2"),
-      clipEntry(3, "テキスト3"),
+      clipEntry(1000, "テキスト1"),
+      clipEntry(2000, "テキスト2"),
+      clipEntry(3000, "テキスト3"),
     ];
     render(<Timeline {...defaultProps} entries={entries} />);
     const items = screen.getAllByRole("listitem");
@@ -40,31 +39,37 @@ describe("Timeline", () => {
 
   it("entries のテキストが描画される", () => {
     const entries: TimelineEntry[] = [
-      clipEntry(1, "最初のテキスト"),
-      clipEntry(2, "次のテキスト"),
+      clipEntry(1000, "最初のテキスト"),
+      clipEntry(2000, "次のテキスト"),
     ];
     render(<Timeline {...defaultProps} entries={entries} />);
     expect(screen.getByText("最初のテキスト")).toBeInTheDocument();
     expect(screen.getByText("次のテキスト")).toBeInTheDocument();
   });
 
-  it("playingClipId が一致するエントリにのみ再生中アイコンが表示される", () => {
+  it("playingClipTimestamp が一致するエントリにのみ再生中アイコンが表示される", () => {
     const entries: TimelineEntry[] = [
-      clipEntry(1, "テキスト1"),
-      clipEntry(2, "テキスト2"),
+      clipEntry(1000, "テキスト1"),
+      clipEntry(2000, "テキスト2"),
     ];
-    render(<Timeline {...defaultProps} entries={entries} playingClipId={1} />);
+    render(
+      <Timeline {...defaultProps} entries={entries} playingClipTimestamp={1000} />,
+    );
     const playIcons = screen.getAllByText("▶");
     expect(playIcons).toHaveLength(1);
   });
 
-  it("playingClipId が null のとき再生中アイコンが表示されない", () => {
+  it("playingClipTimestamp が null のとき再生中アイコンが表示されない", () => {
     const entries: TimelineEntry[] = [
-      clipEntry(1, "テキスト1"),
-      clipEntry(2, "テキスト2"),
+      clipEntry(1000, "テキスト1"),
+      clipEntry(2000, "テキスト2"),
     ];
     render(
-      <Timeline {...defaultProps} entries={entries} playingClipId={null} />,
+      <Timeline
+        {...defaultProps}
+        entries={entries}
+        playingClipTimestamp={null}
+      />,
     );
     expect(screen.queryByText("▶")).not.toBeInTheDocument();
   });
@@ -85,8 +90,8 @@ describe("Timeline", () => {
 
   describe("isCharacterMode", () => {
     const entries: TimelineEntry[] = [
-      clipEntry(1, "古いテキスト"),
-      clipEntry(2, "新しいテキスト"),
+      clipEntry(1000, "古いテキスト"),
+      clipEntry(2000, "新しいテキスト"),
     ];
 
     it("isCharacterMode=true のとき再生中クリップのみ描画される", () => {
@@ -94,7 +99,7 @@ describe("Timeline", () => {
         <Timeline
           {...defaultProps}
           entries={entries}
-          playingClipId={2}
+          playingClipTimestamp={2000}
           isCharacterMode={true}
         />,
       );
@@ -103,12 +108,12 @@ describe("Timeline", () => {
       expect(screen.getAllByRole("listitem")).toHaveLength(1);
     });
 
-    it("isCharacterMode=true かつ playingClipId が最新でないエントリでも、そのエントリが描画される", () => {
+    it("isCharacterMode=true かつ playingClipTimestamp が最新でないエントリでも、そのエントリが描画される", () => {
       render(
         <Timeline
           {...defaultProps}
           entries={entries}
-          playingClipId={1}
+          playingClipTimestamp={1000}
           isCharacterMode={true}
         />,
       );
@@ -116,25 +121,25 @@ describe("Timeline", () => {
       expect(screen.queryByText("新しいテキスト")).not.toBeInTheDocument();
     });
 
-    it("isCharacterMode=true かつ playingClipId=null のとき何も描画されない", () => {
+    it("isCharacterMode=true かつ playingClipTimestamp=null のとき何も描画されない", () => {
       render(
         <Timeline
           {...defaultProps}
           entries={entries}
-          playingClipId={null}
+          playingClipTimestamp={null}
           isCharacterMode={true}
         />,
       );
       expect(screen.getByRole("list")).toBeEmptyDOMElement();
     });
 
-    it("isCharacterMode=true かつ playingClipId=null でも lastPlayingClipId が設定されていれば最後のクリップが表示される", () => {
+    it("isCharacterMode=true かつ playingClipTimestamp=null でも lastPlayingClipTimestamp が設定されていれば最後のクリップが表示される", () => {
       render(
         <Timeline
           {...defaultProps}
           entries={entries}
-          playingClipId={null}
-          lastPlayingClipId={2}
+          playingClipTimestamp={null}
+          lastPlayingClipTimestamp={2000}
           isCharacterMode={true}
         />,
       );
@@ -142,13 +147,13 @@ describe("Timeline", () => {
       expect(screen.getByText("新しいテキスト")).toBeInTheDocument();
     });
 
-    it("isCharacterMode=true かつ playingClipId が設定されている場合は lastPlayingClipId より優先される", () => {
+    it("isCharacterMode=true かつ playingClipTimestamp が設定されている場合は lastPlayingClipTimestamp より優先される", () => {
       render(
         <Timeline
           {...defaultProps}
           entries={entries}
-          playingClipId={1}
-          lastPlayingClipId={2}
+          playingClipTimestamp={1000}
+          lastPlayingClipTimestamp={2000}
           isCharacterMode={true}
         />,
       );
@@ -179,7 +184,7 @@ describe("Timeline", () => {
         <Timeline
           {...defaultProps}
           entries={entries}
-          playingClipId={2}
+          playingClipTimestamp={2000}
           isCharacterMode={true}
         />,
       );
@@ -191,7 +196,7 @@ describe("Timeline", () => {
         <Timeline
           {...defaultProps}
           entries={entries}
-          playingClipId={1}
+          playingClipTimestamp={1000}
           showSpeakerName={false}
           isCharacterMode={true}
         />,

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -4,8 +4,8 @@ import { TimelineItem } from "./TimelineItem";
 
 interface TimelineProps {
   entries: TimelineEntry[];
-  playingClipId: number | null;
-  lastPlayingClipId?: number | null;
+  playingClipTimestamp: number | null;
+  lastPlayingClipTimestamp?: number | null;
   showSpeakerName: boolean;
   showStyleName: boolean;
   showTimestamp: boolean;
@@ -14,8 +14,8 @@ interface TimelineProps {
 
 export function Timeline({
   entries,
-  playingClipId,
-  lastPlayingClipId = null,
+  playingClipTimestamp,
+  lastPlayingClipTimestamp = null,
   showSpeakerName,
   showStyleName,
   showTimestamp,
@@ -46,10 +46,13 @@ export function Timeline({
     }
   }, [entries, scrollToBottom]);
 
-  const characterModeClipId = playingClipId ?? lastPlayingClipId;
+  const characterModeClipTimestamp =
+    playingClipTimestamp ?? lastPlayingClipTimestamp;
   const displayEntries = isCharacterMode
-    ? characterModeClipId !== null
-      ? entries.filter((e) => e.kind === "clip" && e.id === characterModeClipId)
+    ? characterModeClipTimestamp !== null
+      ? entries.filter(
+          (e) => e.kind === "clip" && e.timestamp === characterModeClipTimestamp,
+        )
       : []
     : entries;
 
@@ -62,9 +65,12 @@ export function Timeline({
       <ol ref={listRef} aria-live="polite" className={listCls}>
         {displayEntries.map((entry) => (
           <TimelineItem
-            key={`${entry.kind}-${entry.id}`}
+            key={`${entry.kind}-${entry.timestamp}`}
             entry={entry}
-            playing={entry.kind === "clip" && entry.id === playingClipId}
+            playing={
+              entry.kind === "clip" &&
+              entry.timestamp === playingClipTimestamp
+            }
             showSpeakerName={isCharacterMode ? true : showSpeakerName}
             showStyleName={isCharacterMode ? false : showStyleName}
             showTimestamp={isCharacterMode ? false : showTimestamp}

--- a/frontend/src/components/TimelineItem.test.tsx
+++ b/frontend/src/components/TimelineItem.test.tsx
@@ -5,7 +5,6 @@ import { TimelineItem } from "./TimelineItem";
 
 const clipEntry: TimelineEntry = {
   kind: "clip",
-  id: 1,
   url: "http://example.com/audio.mp3",
   text: "クリップテキスト",
   speakerName: "話者A",

--- a/frontend/src/components/TimelineItem.tsx
+++ b/frontend/src/components/TimelineItem.tsx
@@ -91,7 +91,7 @@ export function TimelineItem({
   return (
     <li
       ref={ref}
-      data-clip-id={entry.id}
+      data-clip-timestamp={entry.timestamp}
       className={`${base} ${playingCls} text-ctp-text`}
     >
       {showMeta && (

--- a/frontend/src/hooks/useCharacterStage.test.ts
+++ b/frontend/src/hooks/useCharacterStage.test.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck - renderHook type inference limitation with rerender and playingClipId
+// @ts-nocheck - renderHook type inference limitation with rerender and playingClipTimestamp
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CharacterEntry, TimelineEntry } from "../types/api";
@@ -14,18 +14,17 @@ function makeChar(speakerName: string, styleName = "ノーマル"): CharacterEnt
 }
 
 function makeClipEntry(
-  id: number,
+  n: number,
   speakerName: string,
   styleName = "ノーマル",
 ): TimelineEntry {
   return {
     kind: "clip",
-    id,
-    url: `http://example.com/${id}.wav`,
-    text: `text ${id}`,
+    url: `http://example.com/${n}.wav`,
+    text: `text ${n}`,
     speakerName,
     styleName,
-    timestamp: id * 1000,
+    timestamp: n * 1000,
   };
 }
 
@@ -51,17 +50,17 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
       {
         initialProps: {
-          playingClipId: null,
+          playingClipTimestamp: null,
           entries: [entry1],
           characters: [charA],
         },
@@ -70,7 +69,7 @@ describe("useCharacterStage", () => {
 
     await act(async () => {
       rerender({
-        playingClipId: 1,
+        playingClipTimestamp: 1000,
         entries: [entry1],
         characters: [charA],
       });
@@ -91,17 +90,17 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
       {
         initialProps: {
-          playingClipId: null,
+          playingClipTimestamp: null,
           entries: [entry1, entry2],
           characters: [charA, charB],
         },
@@ -111,7 +110,7 @@ describe("useCharacterStage", () => {
     // charA speaks
     await act(async () => {
       rerender({
-        playingClipId: 1,
+        playingClipTimestamp: 1000,
         entries: [entry1, entry2],
         characters: [charA, charB],
       });
@@ -121,7 +120,7 @@ describe("useCharacterStage", () => {
     // charB speaks
     await act(async () => {
       rerender({
-        playingClipId: 2,
+        playingClipTimestamp: 2000,
         entries: [entry1, entry2],
         characters: [charA, charB],
       });
@@ -138,20 +137,20 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
-      { initialProps: { playingClipId: null, entries, characters: chars } },
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
+      { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
     );
 
     for (let id = 1; id <= 4; id++) {
       await act(async () => {
-        rerender({ playingClipId: id, entries, characters: chars });
+        rerender({ playingClipTimestamp: id * 1000, entries, characters: chars });
       });
     }
 
@@ -173,25 +172,25 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
-      { initialProps: { playingClipId: null, entries, characters: chars } },
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
+      { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
     );
 
     await act(async () => {
-      rerender({ playingClipId: 1, entries, characters: chars });
+      rerender({ playingClipTimestamp: 1000, entries, characters: chars });
     });
     await act(async () => {
-      rerender({ playingClipId: 2, entries, characters: chars });
+      rerender({ playingClipTimestamp: 2000, entries, characters: chars });
     });
     await act(async () => {
-      rerender({ playingClipId: 3, entries, characters: chars });
+      rerender({ playingClipTimestamp: 3000, entries, characters: chars });
     }); // charA再発話
 
     // charA はinner-rightのまま
@@ -210,33 +209,33 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
-      { initialProps: { playingClipId: null, entries, characters: chars } },
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
+      { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
     );
 
     // charA speaks clip 1
     await act(async () => {
-      rerender({ playingClipId: 1, entries, characters: chars });
+      rerender({ playingClipTimestamp: 1000, entries, characters: chars });
     });
     // charB speaks clips 2-6
     // count: 2→3(完了=B, A.count=1), 3→4(A.count=2), 4→5(A.count=3), 5→6(A.count=4)
     for (let id = 2; id <= 6; id++) {
       await act(async () => {
-        rerender({ playingClipId: id, entries, characters: chars });
+        rerender({ playingClipTimestamp: id * 1000, entries, characters: chars });
       });
     }
     expect(result.current.slots[0]?.character.speakerName).toBe("キャラA"); // count=4 still there
 
     // charB speaks clip 7 (clip 6完了 = 5本目 → charA evicted)
     await act(async () => {
-      rerender({ playingClipId: 7, entries, characters: chars });
+      rerender({ playingClipTimestamp: 7000, entries, characters: chars });
     });
 
     expect(result.current.slots[0]).toBeNull(); // charA evicted
@@ -250,25 +249,25 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
-      { initialProps: { playingClipId: null, entries, characters: chars } },
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
+      { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
     );
 
     await act(async () => {
-      rerender({ playingClipId: 1, entries, characters: chars });
+      rerender({ playingClipTimestamp: 1000, entries, characters: chars });
     });
     expect(result.current.slots[0]?.character.speakerName).toBe("キャラA");
 
     // Queue becomes empty
     await act(async () => {
-      rerender({ playingClipId: null, entries, characters: chars });
+      rerender({ playingClipTimestamp: null, entries, characters: chars });
     });
     expect(result.current.slots[0]?.character.speakerName).toBe("キャラA"); // still there
 
@@ -291,22 +290,22 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
-      { initialProps: { playingClipId: null, entries, characters: chars } },
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
+      { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
     );
 
     await act(async () => {
-      rerender({ playingClipId: 1, entries, characters: chars });
+      rerender({ playingClipTimestamp: 1000, entries, characters: chars });
     });
     await act(async () => {
-      rerender({ playingClipId: null, entries, characters: chars });
+      rerender({ playingClipTimestamp: null, entries, characters: chars });
     }); // queue empty
 
     // 10 seconds pass (under 15s)
@@ -317,7 +316,7 @@ describe("useCharacterStage", () => {
 
     // New clip starts - timer should be cancelled
     await act(async () => {
-      rerender({ playingClipId: 2, entries, characters: chars });
+      rerender({ playingClipTimestamp: 2000, entries, characters: chars });
     });
 
     // 15 more seconds pass (total >15 from first pause, but timer was cancelled)
@@ -333,28 +332,28 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
-      { initialProps: { playingClipId: null, entries, characters: chars } },
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
+      { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
     );
 
     // A, B, C, D enter in order
     for (let id = 1; id <= 4; id++) {
       await act(async () => {
-        rerender({ playingClipId: id, entries, characters: chars });
+        rerender({ playingClipTimestamp: id * 1000, entries, characters: chars });
       });
     }
     expect(result.current.slots[0]?.character.speakerName).toBe("キャラA");
 
     // E enters - should evict A (oldest)
     await act(async () => {
-      rerender({ playingClipId: 5, entries, characters: chars });
+      rerender({ playingClipTimestamp: 5000, entries, characters: chars });
     });
 
     expect(result.current.slots[0]?.character.speakerName).toBe("キャラE"); // E took A's slot (innermost available = 0)
@@ -373,23 +372,23 @@ describe("useCharacterStage", () => {
     ];
 
     const { result, rerender } = renderHook(
-      ({ playingClipId }: { playingClipId: number | null }) =>
-        useCharacterStage(playingClipId, entries, [charA, charB]),
-      { initialProps: { playingClipId: null } },
+      ({ playingClipTimestamp }: { playingClipTimestamp: number | null }) =>
+        useCharacterStage(playingClipTimestamp, entries, [charA, charB]),
+      { initialProps: { playingClipTimestamp: null } },
     );
 
     await act(async () => {
-      rerender({ playingClipId: 1 });
+      rerender({ playingClipTimestamp: 1000 });
     }); // A enters
     await act(async () => {
-      rerender({ playingClipId: 2 });
+      rerender({ playingClipTimestamp: 2000 });
     }); // B enters → isMultiSlot=true
     expect(result.current.isMultiSlot).toBe(true);
 
     // A speaks 6 clips (clips 3-8 start → clips 3-7 complete = 5 completions → B exits)
     for (let id = 3; id <= 8; id++) {
       await act(async () => {
-        rerender({ playingClipId: id });
+        rerender({ playingClipTimestamp: id * 1000 });
       });
     }
 
@@ -409,25 +408,25 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
-      { initialProps: { playingClipId: null, entries, characters: chars } },
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
+      { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
     );
 
     await act(async () => {
-      rerender({ playingClipId: 1, entries, characters: chars });
+      rerender({ playingClipTimestamp: 1000, entries, characters: chars });
     });
     await act(async () => {
-      rerender({ playingClipId: 2, entries, characters: chars });
+      rerender({ playingClipTimestamp: 2000, entries, characters: chars });
     }); // isMultiSlot=true
     await act(async () => {
-      rerender({ playingClipId: null, entries, characters: chars });
+      rerender({ playingClipTimestamp: null, entries, characters: chars });
     }); // queue empty
 
     // 15s timer fires → all exit, isMultiSlot=false
@@ -438,7 +437,7 @@ describe("useCharacterStage", () => {
 
     // A enters again
     await act(async () => {
-      rerender({ playingClipId: 3, entries, characters: chars });
+      rerender({ playingClipTimestamp: 3000, entries, characters: chars });
     });
     expect(result.current.isMultiSlot).toBe(false); // center layout
     expect(result.current.slots[0]?.character.speakerName).toBe("キャラA");
@@ -459,25 +458,25 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
-      { initialProps: { playingClipId: null, entries, characters: chars } },
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
+      { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
     );
 
     await act(async () => {
-      rerender({ playingClipId: 1, entries, characters: chars });
+      rerender({ playingClipTimestamp: 1000, entries, characters: chars });
     });
     expect(result.current.slots[0]?.character).toEqual(charANormal);
     expect(result.current.isMultiSlot).toBe(false);
 
     await act(async () => {
-      rerender({ playingClipId: 2, entries, characters: chars });
+      rerender({ playingClipTimestamp: 2000, entries, characters: chars });
     });
 
     expect(result.current.slots[0]?.character).toEqual(charASweet);
@@ -495,19 +494,19 @@ describe("useCharacterStage", () => {
 
     const { result, rerender } = renderHook(
       ({
-        playingClipId,
+        playingClipTimestamp,
         entries,
         characters,
       }: {
-        playingClipId: number | null;
+        playingClipTimestamp: number | null;
         entries: TimelineEntry[];
         characters: CharacterEntry[];
-      }) => useCharacterStage(playingClipId, entries, characters),
-      { initialProps: { playingClipId: null, entries, characters: chars } },
+      }) => useCharacterStage(playingClipTimestamp, entries, characters),
+      { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
     );
 
     await act(async () => {
-      rerender({ playingClipId: 1, entries, characters: chars });
+      rerender({ playingClipTimestamp: 1000, entries, characters: chars });
     });
 
     expect(result.current.slots).toEqual([null, null, null, null]);
@@ -525,17 +524,17 @@ describe("useCharacterStage", () => {
 
       const { result, rerender } = renderHook(
         ({
-          playingClipId,
+          playingClipTimestamp,
           entries,
           characters,
         }: {
-          playingClipId: number | null;
+          playingClipTimestamp: number | null;
           entries: TimelineEntry[];
           characters: CharacterEntry[];
-        }) => useCharacterStage(playingClipId, entries, characters),
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
         {
           initialProps: {
-            playingClipId: null,
+            playingClipTimestamp: null,
             entries: [entry1],
             characters: [charA],
           },
@@ -543,7 +542,7 @@ describe("useCharacterStage", () => {
       );
 
       await act(async () => {
-        rerender({ playingClipId: 1, entries: [entry1], characters: [charA] });
+        rerender({ playingClipTimestamp: 1000, entries: [entry1], characters: [charA] });
       });
 
       expect(result.current.lastClipText).toBe("text 1");
@@ -555,17 +554,17 @@ describe("useCharacterStage", () => {
 
       const { result, rerender } = renderHook(
         ({
-          playingClipId,
+          playingClipTimestamp,
           entries,
           characters,
         }: {
-          playingClipId: number | null;
+          playingClipTimestamp: number | null;
           entries: TimelineEntry[];
           characters: CharacterEntry[];
-        }) => useCharacterStage(playingClipId, entries, characters),
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
         {
           initialProps: {
-            playingClipId: null,
+            playingClipTimestamp: null,
             entries: [entry1],
             characters: [charA],
           },
@@ -573,11 +572,11 @@ describe("useCharacterStage", () => {
       );
 
       await act(async () => {
-        rerender({ playingClipId: 1, entries: [entry1], characters: [charA] });
+        rerender({ playingClipTimestamp: 1000, entries: [entry1], characters: [charA] });
       });
       await act(async () => {
         rerender({
-          playingClipId: null,
+          playingClipTimestamp: null,
           entries: [entry1],
           characters: [charA],
         });
@@ -594,24 +593,24 @@ describe("useCharacterStage", () => {
 
       const { result, rerender } = renderHook(
         ({
-          playingClipId,
+          playingClipTimestamp,
           entries,
           characters,
         }: {
-          playingClipId: number | null;
+          playingClipTimestamp: number | null;
           entries: TimelineEntry[];
           characters: CharacterEntry[];
-        }) => useCharacterStage(playingClipId, entries, characters),
-        { initialProps: { playingClipId: null, entries, characters: chars } },
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
+        { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
       );
 
       await act(async () => {
-        rerender({ playingClipId: 1, entries, characters: chars });
+        rerender({ playingClipTimestamp: 1000, entries, characters: chars });
       });
       expect(result.current.lastClipText).toBe("text 1");
 
       await act(async () => {
-        rerender({ playingClipId: 2, entries, characters: chars });
+        rerender({ playingClipTimestamp: 2000, entries, characters: chars });
       });
       expect(result.current.lastClipText).toBe("text 2");
     });
@@ -623,17 +622,17 @@ describe("useCharacterStage", () => {
 
       const { result, rerender } = renderHook(
         ({
-          playingClipId,
+          playingClipTimestamp,
           entries,
           characters,
         }: {
-          playingClipId: number | null;
+          playingClipTimestamp: number | null;
           entries: TimelineEntry[];
           characters: CharacterEntry[];
-        }) => useCharacterStage(playingClipId, entries, characters),
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
         {
           initialProps: {
-            playingClipId: null,
+            playingClipTimestamp: null,
             entries: [entry1],
             characters: chars,
           },
@@ -641,10 +640,10 @@ describe("useCharacterStage", () => {
       );
 
       await act(async () => {
-        rerender({ playingClipId: 1, entries: [entry1], characters: chars });
+        rerender({ playingClipTimestamp: 1000, entries: [entry1], characters: chars });
       });
       await act(async () => {
-        rerender({ playingClipId: null, entries: [entry1], characters: chars });
+        rerender({ playingClipTimestamp: null, entries: [entry1], characters: chars });
       });
       expect(result.current.lastClipText).toBe("text 1");
 
@@ -666,24 +665,24 @@ describe("useCharacterStage", () => {
 
       const { result, rerender } = renderHook(
         ({
-          playingClipId,
+          playingClipTimestamp,
           entries,
           characters,
         }: {
-          playingClipId: number | null;
+          playingClipTimestamp: number | null;
           entries: TimelineEntry[];
           characters: CharacterEntry[];
-        }) => useCharacterStage(playingClipId, entries, characters),
-        { initialProps: { playingClipId: null, entries, characters: chars } },
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
+        { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
       );
 
       await act(async () => {
-        rerender({ playingClipId: 1, entries, characters: chars });
+        rerender({ playingClipTimestamp: 1000, entries, characters: chars });
       });
       // charB speaks clips 2-7 (charA gets evicted after 5 charB clips)
       for (let id = 2; id <= 7; id++) {
         await act(async () => {
-          rerender({ playingClipId: id, entries, characters: chars });
+          rerender({ playingClipTimestamp: id * 1000, entries, characters: chars });
         });
       }
 
@@ -693,29 +692,29 @@ describe("useCharacterStage", () => {
     });
   });
 
-  describe("lastClipId", () => {
-    it("初期状態ではlastClipIdがnull", () => {
+  describe("lastClipTimestamp", () => {
+    it("初期状態ではlastClipTimestampがnull", () => {
       const { result } = renderHook(() => useCharacterStage(null, [], []));
-      expect(result.current.lastClipId).toBeNull();
+      expect(result.current.lastClipTimestamp).toBeNull();
     });
 
-    it("クリップ再生開始でlastClipIdが更新される", async () => {
+    it("クリップ再生開始でlastClipTimestampが更新される", async () => {
       const charA = makeChar("キャラA");
       const entry1 = makeClipEntry(1, "キャラA");
 
       const { result, rerender } = renderHook(
         ({
-          playingClipId,
+          playingClipTimestamp,
           entries,
           characters,
         }: {
-          playingClipId: number | null;
+          playingClipTimestamp: number | null;
           entries: TimelineEntry[];
           characters: CharacterEntry[];
-        }) => useCharacterStage(playingClipId, entries, characters),
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
         {
           initialProps: {
-            playingClipId: null,
+            playingClipTimestamp: null,
             entries: [entry1],
             characters: [charA],
           },
@@ -723,29 +722,29 @@ describe("useCharacterStage", () => {
       );
 
       await act(async () => {
-        rerender({ playingClipId: 1, entries: [entry1], characters: [charA] });
+        rerender({ playingClipTimestamp: 1000, entries: [entry1], characters: [charA] });
       });
 
-      expect(result.current.lastClipId).toBe(1);
+      expect(result.current.lastClipTimestamp).toBe(1000);
     });
 
-    it("クリップ再生終了後もlastClipIdが保持される", async () => {
+    it("クリップ再生終了後もlastClipTimestampが保持される", async () => {
       const charA = makeChar("キャラA");
       const entry1 = makeClipEntry(1, "キャラA");
 
       const { result, rerender } = renderHook(
         ({
-          playingClipId,
+          playingClipTimestamp,
           entries,
           characters,
         }: {
-          playingClipId: number | null;
+          playingClipTimestamp: number | null;
           entries: TimelineEntry[];
           characters: CharacterEntry[];
-        }) => useCharacterStage(playingClipId, entries, characters),
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
         {
           initialProps: {
-            playingClipId: null,
+            playingClipTimestamp: null,
             entries: [entry1],
             characters: [charA],
           },
@@ -753,20 +752,20 @@ describe("useCharacterStage", () => {
       );
 
       await act(async () => {
-        rerender({ playingClipId: 1, entries: [entry1], characters: [charA] });
+        rerender({ playingClipTimestamp: 1000, entries: [entry1], characters: [charA] });
       });
       await act(async () => {
         rerender({
-          playingClipId: null,
+          playingClipTimestamp: null,
           entries: [entry1],
           characters: [charA],
         });
       });
 
-      expect(result.current.lastClipId).toBe(1);
+      expect(result.current.lastClipTimestamp).toBe(1000);
     });
 
-    it("次のクリップ再生開始でlastClipIdが切り替わる", async () => {
+    it("次のクリップ再生開始でlastClipTimestampが切り替わる", async () => {
       const charA = makeChar("キャラA");
       const charB = makeChar("キャラB");
       const entries = [makeClipEntry(1, "キャラA"), makeClipEntry(2, "キャラB")];
@@ -774,46 +773,46 @@ describe("useCharacterStage", () => {
 
       const { result, rerender } = renderHook(
         ({
-          playingClipId,
+          playingClipTimestamp,
           entries,
           characters,
         }: {
-          playingClipId: number | null;
+          playingClipTimestamp: number | null;
           entries: TimelineEntry[];
           characters: CharacterEntry[];
-        }) => useCharacterStage(playingClipId, entries, characters),
-        { initialProps: { playingClipId: null, entries, characters: chars } },
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
+        { initialProps: { playingClipTimestamp: null, entries, characters: chars } },
       );
 
       await act(async () => {
-        rerender({ playingClipId: 1, entries, characters: chars });
+        rerender({ playingClipTimestamp: 1000, entries, characters: chars });
       });
-      expect(result.current.lastClipId).toBe(1);
+      expect(result.current.lastClipTimestamp).toBe(1000);
 
       await act(async () => {
-        rerender({ playingClipId: 2, entries, characters: chars });
+        rerender({ playingClipTimestamp: 2000, entries, characters: chars });
       });
-      expect(result.current.lastClipId).toBe(2);
+      expect(result.current.lastClipTimestamp).toBe(2000);
     });
 
-    it("ALL_EXIT後にlastClipIdがnullになる", async () => {
+    it("ALL_EXIT後にlastClipTimestampがnullになる", async () => {
       const charA = makeChar("キャラA");
       const entry1 = makeClipEntry(1, "キャラA");
       const chars = [charA];
 
       const { result, rerender } = renderHook(
         ({
-          playingClipId,
+          playingClipTimestamp,
           entries,
           characters,
         }: {
-          playingClipId: number | null;
+          playingClipTimestamp: number | null;
           entries: TimelineEntry[];
           characters: CharacterEntry[];
-        }) => useCharacterStage(playingClipId, entries, characters),
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
         {
           initialProps: {
-            playingClipId: null,
+            playingClipTimestamp: null,
             entries: [entry1],
             characters: chars,
           },
@@ -821,17 +820,17 @@ describe("useCharacterStage", () => {
       );
 
       await act(async () => {
-        rerender({ playingClipId: 1, entries: [entry1], characters: chars });
+        rerender({ playingClipTimestamp: 1000, entries: [entry1], characters: chars });
       });
       await act(async () => {
-        rerender({ playingClipId: null, entries: [entry1], characters: chars });
+        rerender({ playingClipTimestamp: null, entries: [entry1], characters: chars });
       });
-      expect(result.current.lastClipId).toBe(1);
+      expect(result.current.lastClipTimestamp).toBe(1000);
 
       await act(async () => {
         vi.advanceTimersByTime(QUEUE_EMPTY_MS);
       });
-      expect(result.current.lastClipId).toBeNull();
+      expect(result.current.lastClipTimestamp).toBeNull();
     });
   });
 });

--- a/frontend/src/hooks/useCharacterStage.ts
+++ b/frontend/src/hooks/useCharacterStage.ts
@@ -14,7 +14,7 @@ interface StageState {
   chars: StageChar[];
   isMultiSlot: boolean;
   lastClipText: string | null;
-  lastClipId: number | null;
+  lastClipTimestamp: number | null;
 }
 
 type StageAction =
@@ -25,7 +25,7 @@ type StageAction =
       startedCharacter: CharacterEntry | null;
       startedEntryOrder: number;
       startedClipText: string | null;
-      startedClipId: number | null;
+      startedClipTimestamp: number | null;
     }
   | { type: "ALL_EXIT" };
 
@@ -99,13 +99,19 @@ function stageReducer(state: StageState, action: StageAction): StageState {
         chars.length === 0 ? false : state.isMultiSlot || chars.length >= 2;
 
       const lastClipText = action.startedClipText ?? state.lastClipText;
-      const lastClipId = action.startedClipId ?? state.lastClipId;
+      const lastClipTimestamp =
+        action.startedClipTimestamp ?? state.lastClipTimestamp;
 
-      return { chars, isMultiSlot, lastClipText, lastClipId };
+      return { chars, isMultiSlot, lastClipText, lastClipTimestamp };
     }
 
     case "ALL_EXIT":
-      return { chars: [], isMultiSlot: false, lastClipText: null, lastClipId: null };
+      return {
+        chars: [],
+        isMultiSlot: false,
+        lastClipText: null,
+        lastClipTimestamp: null,
+      };
 
     default:
       return state;
@@ -120,11 +126,11 @@ export interface CharacterStageResult {
   slots: (CharacterStageSlot | null)[];
   isMultiSlot: boolean;
   lastClipText: string | null;
-  lastClipId: number | null;
+  lastClipTimestamp: number | null;
 }
 
 export function useCharacterStage(
-  playingClipId: number | null,
+  playingClipTimestamp: number | null,
   entries: TimelineEntry[],
   characters: CharacterEntry[],
 ): CharacterStageResult {
@@ -132,17 +138,17 @@ export function useCharacterStage(
     chars: [],
     isMultiSlot: false,
     lastClipText: null,
-    lastClipId: null,
+    lastClipTimestamp: null,
   });
 
-  const prevPlayingClipIdRef = useRef<number | null>(null);
+  const prevPlayingClipTimestampRef = useRef<number | null>(null);
   const entryCounterRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    const prev = prevPlayingClipIdRef.current;
-    const curr = playingClipId;
-    prevPlayingClipIdRef.current = curr;
+    const prev = prevPlayingClipTimestampRef.current;
+    const curr = playingClipTimestamp;
+    prevPlayingClipTimestampRef.current = curr;
 
     if (prev === curr) return;
 
@@ -153,7 +159,9 @@ export function useCharacterStage(
 
     let completedCharKey: string | null = null;
     if (prev !== null) {
-      const e = entries.find((e) => e.kind === "clip" && e.id === prev);
+      const e = entries.find(
+        (e) => e.kind === "clip" && e.timestamp === prev,
+      );
       if (e?.kind === "clip") {
         completedCharKey = charKey(e.speakerName);
       }
@@ -165,7 +173,9 @@ export function useCharacterStage(
     const startedEntryOrder = entryCounterRef.current;
 
     if (curr !== null) {
-      const e = entries.find((e) => e.kind === "clip" && e.id === curr);
+      const e = entries.find(
+        (e) => e.kind === "clip" && e.timestamp === curr,
+      );
       if (e?.kind === "clip") {
         startedCharKey = charKey(e.speakerName);
         startedClipText = e.text;
@@ -187,7 +197,7 @@ export function useCharacterStage(
       startedCharacter,
       startedEntryOrder,
       startedClipText,
-      startedClipId: curr,
+      startedClipTimestamp: curr,
     });
 
     if (curr === null && prev !== null) {
@@ -196,7 +206,7 @@ export function useCharacterStage(
         timerRef.current = null;
       }, QUEUE_EMPTY_MS);
     }
-  }, [playingClipId, entries, characters]);
+  }, [playingClipTimestamp, entries, characters]);
 
   useEffect(() => {
     return () => {
@@ -215,6 +225,6 @@ export function useCharacterStage(
     slots,
     isMultiSlot: state.isMultiSlot,
     lastClipText: state.lastClipText,
-    lastClipId: state.lastClipId,
+    lastClipTimestamp: state.lastClipTimestamp,
   };
 }

--- a/frontend/src/hooks/usePlaybackQueue.test.ts
+++ b/frontend/src/hooks/usePlaybackQueue.test.ts
@@ -3,14 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClipEvent } from "../types/api";
 import { usePlaybackQueue } from "./usePlaybackQueue";
 
-function makeClip(id: number): ClipEvent {
+function makeClip(n: number): ClipEvent {
   return {
-    id,
-    url: `http://example.com/clip/${id}.wav`,
-    text: `clip ${id}`,
+    url: `http://example.com/clip/${n}.wav`,
+    text: `clip ${n}`,
     speakerName: "speaker",
     styleName: "normal",
-    timestamp: id * 1000,
+    timestamp: n * 1000,
   };
 }
 
@@ -36,14 +35,14 @@ describe("usePlaybackQueue", () => {
     vi.restoreAllMocks();
   });
 
-  it("enqueue で audio.play が呼ばれ playingClipId が更新される", async () => {
+  it("enqueue で audio.play が呼ばれ playingClipTimestamp が更新される", async () => {
     const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
-    expect(result.current.playingClipId).toBeNull();
+    expect(result.current.playingClipTimestamp).toBeNull();
     await act(async () => {
       result.current.enqueue(makeClip(1));
     });
     expect(mockPlay).toHaveBeenCalled();
-    expect(result.current.playingClipId).toBe(1);
+    expect(result.current.playingClipTimestamp).toBe(1000);
   });
 
   it("ended イベント発火で次クリップが再生されキューが空なら null", async () => {
@@ -52,18 +51,18 @@ describe("usePlaybackQueue", () => {
       result.current.enqueue(makeClip(1));
       result.current.enqueue(makeClip(2));
     });
-    expect(result.current.playingClipId).toBe(1);
+    expect(result.current.playingClipTimestamp).toBe(1000);
     await act(async () => {
       audio.dispatchEvent(new Event("ended"));
     });
-    expect(result.current.playingClipId).toBe(2);
+    expect(result.current.playingClipTimestamp).toBe(2000);
     await act(async () => {
       audio.dispatchEvent(new Event("ended"));
     });
-    expect(result.current.playingClipId).toBeNull();
+    expect(result.current.playingClipTimestamp).toBeNull();
   });
 
-  it("active=false への遷移で pause とキュー破棄と playingClipId=null になる", async () => {
+  it("active=false への遷移で pause とキュー破棄と playingClipTimestamp=null になる", async () => {
     const { result, rerender } = renderHook(
       ({ active }: { active: boolean }) => usePlaybackQueue(audioRef, active),
       { initialProps: { active: true } },
@@ -71,12 +70,12 @@ describe("usePlaybackQueue", () => {
     await act(async () => {
       result.current.enqueue(makeClip(1));
     });
-    expect(result.current.playingClipId).toBe(1);
+    expect(result.current.playingClipTimestamp).toBe(1000);
     await act(async () => {
       rerender({ active: false });
     });
     expect(mockPause).toHaveBeenCalled();
-    expect(result.current.playingClipId).toBeNull();
+    expect(result.current.playingClipTimestamp).toBeNull();
   });
 
   it("active=false の間に enqueue してもキューに積まれない", async () => {
@@ -85,10 +84,10 @@ describe("usePlaybackQueue", () => {
       result.current.enqueue(makeClip(1));
     });
     expect(mockPlay).not.toHaveBeenCalled();
-    expect(result.current.playingClipId).toBeNull();
+    expect(result.current.playingClipTimestamp).toBeNull();
   });
 
-  it("audio.play reject 時に playingClipId が null に戻り次の再生試行が走る", async () => {
+  it("audio.play reject 時に playingClipTimestamp が null に戻り次の再生試行が走る", async () => {
     mockPlay
       .mockRejectedValueOnce(new Error("play failed"))
       .mockResolvedValue(undefined);
@@ -98,7 +97,7 @@ describe("usePlaybackQueue", () => {
       result.current.enqueue(makeClip(1));
       result.current.enqueue(makeClip(2));
     });
-    expect(result.current.playingClipId).toBe(2);
+    expect(result.current.playingClipTimestamp).toBe(2000);
   });
 
   it("アンマウントで ended リスナーが解除される", () => {

--- a/frontend/src/hooks/usePlaybackQueue.ts
+++ b/frontend/src/hooks/usePlaybackQueue.ts
@@ -8,7 +8,7 @@ import {
 import type { ClipEvent } from "../types/api";
 
 interface PlaybackQueue {
-  playingClipId: number | null;
+  playingClipTimestamp: number | null;
   enqueue: (clip: ClipEvent) => void;
 }
 
@@ -18,26 +18,26 @@ export function usePlaybackQueue(
   active: boolean,
 ): PlaybackQueue {
   const queueRef = useRef<ClipEvent[]>([]);
-  const [playingClipId, setPlayingClipId] = useState<number | null>(null);
-  const playingClipIdRef = useRef<number | null>(null);
-  playingClipIdRef.current = playingClipId;
+  const [playingClipTimestamp, setPlayingClipTimestamp] = useState<number | null>(null);
+  const playingClipTimestampRef = useRef<number | null>(null);
+  playingClipTimestampRef.current = playingClipTimestamp;
   const activeRef = useRef(active);
   activeRef.current = active;
 
   const playNext = useCallback((): void => {
     if (!activeRef.current) return;
-    if (playingClipIdRef.current !== null) return;
+    if (playingClipTimestampRef.current !== null) return;
     const audio = audioRef.current;
     if (!audio) return;
     const next = queueRef.current.shift();
     if (!next) return;
-    playingClipIdRef.current = next.id;
-    setPlayingClipId(next.id);
+    playingClipTimestampRef.current = next.timestamp;
+    setPlayingClipTimestamp(next.timestamp);
     audio.src = next.url;
     audio.play().catch((err: unknown) => {
       console.error("play failed", err);
-      playingClipIdRef.current = null;
-      setPlayingClipId(null);
+      playingClipTimestampRef.current = null;
+      setPlayingClipTimestamp(null);
       playNext();
     });
   }, [audioRef]);
@@ -59,8 +59,8 @@ export function usePlaybackQueue(
       audio.load();
     }
     queueRef.current = [];
-    playingClipIdRef.current = null;
-    setPlayingClipId(null);
+    playingClipTimestampRef.current = null;
+    setPlayingClipTimestamp(null);
   }, [audioRef]);
 
   useEffect(() => {
@@ -73,8 +73,8 @@ export function usePlaybackQueue(
     const audio = audioRef.current;
     if (!audio) return;
     const onEnded = (): void => {
-      playingClipIdRef.current = null;
-      setPlayingClipId(null);
+      playingClipTimestampRef.current = null;
+      setPlayingClipTimestamp(null);
       playNext();
     };
     audio.addEventListener("ended", onEnded);
@@ -83,5 +83,5 @@ export function usePlaybackQueue(
     };
   }, [audioRef, playNext]);
 
-  return { playingClipId, enqueue };
+  return { playingClipTimestamp, enqueue };
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -16,7 +16,7 @@ export interface ClipEvent {
 export type ErrorCategory = "synthesis" | "file" | "connection";
 
 export interface ErrorEventPayload {
-  // clipEvent.id とは独立した連番。
+  // clip イベントの timestamp とは独立した連番。
   id: number;
   category: ErrorCategory;
   message: string;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -3,12 +3,11 @@
 // どちらか一方を変更した場合は両方を同時に修正する。
 
 export interface ClipEvent {
-  id: number;
   url: string;
   text: string;
   speakerName: string;
   styleName: string;
-  // Unix ms (UTC)
+  // Unix ms (UTC)。セッション跨ぎでも単調増加するため再起動後の衝突が発生しない。
   timestamp: number;
 }
 
@@ -52,7 +51,6 @@ export function isClipEvent(value: unknown): value is ClipEvent {
   }
   const v = value as Record<string, unknown>;
   return (
-    typeof v.id === "number" &&
     typeof v.url === "string" &&
     typeof v.text === "string" &&
     typeof v.speakerName === "string" &&
@@ -171,7 +169,6 @@ export function isApiCharacters(value: unknown): value is ApiCharacters {
 
 // HistoryEntry は /api/history の 1 エントリ（WAV URL なし）。
 export interface HistoryEntry {
-  id: number;
   text: string;
   speakerName: string;
   styleName: string;
@@ -188,7 +185,6 @@ export function isHistoryEntry(value: unknown): value is HistoryEntry {
   }
   const v = value as Record<string, unknown>;
   return (
-    typeof v.id === "number" &&
     typeof v.text === "string" &&
     typeof v.speakerName === "string" &&
     typeof v.styleName === "string" &&

--- a/frontend/test/e2e/helpers.ts
+++ b/frontend/test/e2e/helpers.ts
@@ -8,7 +8,6 @@ const STUB_BASE_URL =
   process.env.VOX_STUB_BASE_URL ?? `http://127.0.0.1:${STUB_PORT}`;
 
 export interface ClipPayload {
-  id?: number;
   url?: string;
   text: string;
   speakerName?: string;
@@ -69,7 +68,6 @@ export async function setApiCharacters(
 }
 
 export interface HistoryEntryPayload {
-  id: number;
   text: string;
   speakerName: string;
   styleName: string;

--- a/frontend/test/e2e/history.spec.ts
+++ b/frontend/test/e2e/history.spec.ts
@@ -10,33 +10,33 @@ test.describe("配信タブ: 再生履歴", () => {
     page,
     request,
   }) => {
+    const ts1 = 1700000001001;
+    const ts2 = 1700000001002;
     await setApiHistory(request, [
       {
-        id: 1001,
         text: "履歴テキスト1",
         speakerName: "ずんだもん",
         styleName: "ノーマル",
-        timestamp: Date.now(),
+        timestamp: ts1,
       },
       {
-        id: 1002,
         text: "履歴テキスト2",
         speakerName: "四国めたん",
         styleName: "ノーマル",
-        timestamp: Date.now(),
+        timestamp: ts2,
       },
     ]);
 
     await page.goto("/");
     await expect(page.getByText("● 接続中")).toBeVisible();
 
-    await expect(page.locator('[data-clip-id="1001"]')).toBeVisible();
+    await expect(page.locator(`[data-clip-timestamp="${ts1}"]`)).toBeVisible();
     await expect(
-      page.locator('[data-clip-id="1001"]'),
+      page.locator(`[data-clip-timestamp="${ts1}"]`),
     ).toContainText("履歴テキスト1");
-    await expect(page.locator('[data-clip-id="1002"]')).toBeVisible();
+    await expect(page.locator(`[data-clip-timestamp="${ts2}"]`)).toBeVisible();
     await expect(
-      page.locator('[data-clip-id="1002"]'),
+      page.locator(`[data-clip-timestamp="${ts2}"]`),
     ).toContainText("履歴テキスト2");
   });
 
@@ -44,19 +44,19 @@ test.describe("配信タブ: 再生履歴", () => {
     page,
     request,
   }) => {
+    const ts = 1700000002001;
     await setApiHistory(request, [
       {
-        id: 2001,
         text: "音声なし履歴",
         speakerName: "ずんだもん",
         styleName: "ノーマル",
-        timestamp: Date.now(),
+        timestamp: ts,
       },
     ]);
 
     await page.goto("/");
     await expect(page.getByText("● 接続中")).toBeVisible();
-    await expect(page.locator('[data-clip-id="2001"]')).toBeVisible();
+    await expect(page.locator(`[data-clip-timestamp="${ts}"]`)).toBeVisible();
 
     // 履歴ロード後も audio.src が空 = 再生キューに積まれていない。
     const audioSrc = await page.evaluate(
@@ -69,23 +69,25 @@ test.describe("配信タブ: 再生履歴", () => {
     page,
     request,
   }) => {
+    const baseTs = 1700000006000;
     const entries = Array.from({ length: 20 }, (_, i) => ({
-      id: 6000 + i,
       text: `スクロールテスト履歴${i + 1}`,
       speakerName: "ずんだもん",
       styleName: "ノーマル",
-      timestamp: Date.now() + i * 1000,
+      timestamp: baseTs + i * 1000,
     }));
     await setApiHistory(request, entries);
 
     await page.goto("/");
     await expect(page.getByText("● 接続中")).toBeVisible();
 
-    const lastEntry = page.locator(`[data-clip-id="${entries[entries.length - 1].id}"]`);
+    const lastTs = entries[entries.length - 1].timestamp;
+    const firstTs = entries[0].timestamp;
+    const lastEntry = page.locator(`[data-clip-timestamp="${lastTs}"]`);
     await expect(lastEntry).toBeVisible();
     await expect(lastEntry).toBeInViewport();
 
-    const firstEntry = page.locator(`[data-clip-id="${entries[0].id}"]`);
+    const firstEntry = page.locator(`[data-clip-timestamp="${firstTs}"]`);
     await expect(firstEntry).not.toBeInViewport();
   });
 
@@ -101,43 +103,42 @@ test.describe("配信タブ: 再生履歴", () => {
     page,
     request,
   }) => {
+    const ts1 = 1700000003001;
+    const ts2 = 1700000003002;
     await setApiHistory(request, [
       {
-        id: 3001,
         text: "リロード前テキスト",
         speakerName: "ずんだもん",
         styleName: "ノーマル",
-        timestamp: Date.now(),
+        timestamp: ts1,
       },
     ]);
 
     await page.goto("/");
-    await expect(page.locator('[data-clip-id="3001"]')).toBeVisible();
+    await expect(page.locator(`[data-clip-timestamp="${ts1}"]`)).toBeVisible();
 
     // リロード前後で新しいエントリを追加する。
     await setApiHistory(request, [
       {
-        id: 3001,
         text: "リロード前テキスト",
         speakerName: "ずんだもん",
         styleName: "ノーマル",
-        timestamp: Date.now(),
+        timestamp: ts1,
       },
       {
-        id: 3002,
         text: "リロード後追加テキスト",
         speakerName: "ずんだもん",
         styleName: "ノーマル",
-        timestamp: Date.now(),
+        timestamp: ts2,
       },
     ]);
 
     await page.reload();
     await expect(page.getByText("● 接続中")).toBeVisible();
 
-    await expect(page.locator('[data-clip-id="3002"]')).toBeVisible();
+    await expect(page.locator(`[data-clip-timestamp="${ts2}"]`)).toBeVisible();
     await expect(
-      page.locator('[data-clip-id="3002"]'),
+      page.locator(`[data-clip-timestamp="${ts2}"]`),
     ).toContainText("リロード後追加テキスト");
   });
 });

--- a/frontend/test/e2e/silent.spec.ts
+++ b/frontend/test/e2e/silent.spec.ts
@@ -29,15 +29,16 @@ test.describe("無音モード", () => {
     await page.goto("/");
     await expect(page.getByText("● 接続中")).toBeVisible();
 
+    const ts = 1700000000501;
     await pushClip(request, {
-      id: 501,
       url: "",
       text: "無音モードで配信されたテキスト",
       speakerName: "ずんだもん",
       styleName: "ノーマル",
+      timestamp: ts,
     });
 
-    const item = page.locator('[data-clip-id="501"]');
+    const item = page.locator(`[data-clip-timestamp="${ts}"]`);
     await expect(item).toBeVisible();
     await expect(item).toContainText("無音モードで配信されたテキスト");
   });

--- a/frontend/test/e2e/stream.spec.ts
+++ b/frontend/test/e2e/stream.spec.ts
@@ -13,15 +13,16 @@ test.describe("配信タブ: SSE と Timeline", () => {
     await page.goto("/");
     await expect(page.getByText("● 接続中")).toBeVisible();
 
+    const ts = 1700000000101;
     await pushClip(request, {
-      id: 101,
-      url: "/clips/101.wav",
+      url: `/clips/${ts}.wav`,
       text: "こんにちはなのだ",
       speakerName: "ずんだもん",
       styleName: "ノーマル",
+      timestamp: ts,
     });
 
-    const item = page.locator('[data-clip-id="101"]');
+    const item = page.locator(`[data-clip-timestamp="${ts}"]`);
     await expect(item).toBeVisible();
     await expect(item).toContainText("こんにちはなのだ");
     await expect(item).toContainText("ずんだもん");

--- a/frontend/test/stub-server.mjs
+++ b/frontend/test/stub-server.mjs
@@ -56,7 +56,6 @@ const DEFAULT_API_HISTORY = { entries: [] };
 let apiStatus = structuredClone(DEFAULT_API_STATUS);
 let apiCharacters = structuredClone(DEFAULT_API_CHARACTERS);
 let apiHistory = structuredClone(DEFAULT_API_HISTORY);
-let nextClipId = 0;
 let nextErrorId = 0;
 const subscribers = new Set();
 
@@ -155,15 +154,14 @@ function handleClipFile(_req, res) {
 
 async function handleStubClip(req, res) {
   const body = await readJSON(req);
-  nextClipId += 1;
+  const timestamp = typeof body.timestamp === "number" ? body.timestamp : Date.now();
   const payload = {
-    id: typeof body.id === "number" ? body.id : nextClipId,
-    url: typeof body.url === "string" ? body.url : `/clips/${nextClipId}.wav`,
+    url: typeof body.url === "string" ? body.url : `/clips/${timestamp}.wav`,
     text: typeof body.text === "string" ? body.text : "",
     speakerName:
       typeof body.speakerName === "string" ? body.speakerName : "ずんだもん",
     styleName: typeof body.styleName === "string" ? body.styleName : "ノーマル",
-    timestamp: typeof body.timestamp === "number" ? body.timestamp : Date.now(),
+    timestamp,
   };
   broadcast("clip", payload);
   writeJSON(res, 200, { ok: true, payload });
@@ -239,7 +237,6 @@ function handleStubReset(_req, res) {
   apiStatus = structuredClone(DEFAULT_API_STATUS);
   apiCharacters = structuredClone(DEFAULT_API_CHARACTERS);
   apiHistory = structuredClone(DEFAULT_API_HISTORY);
-  nextClipId = 0;
   nextErrorId = 0;
   for (const sub of subscribers) {
     sub.end();

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -138,7 +138,7 @@ type clipEvent struct {
 	SpeakerName string `json:"speakerName"`
 	StyleName   string `json:"styleName"`
 	// Timestamp は配信時刻の Unix ms（UTC）。ブラウザ側で HH:MM:SS に整形する。
-	// セッションをまたいでも単調増加するため再起動後の id 衝突が発生しない。
+	// セッション跨ぎで単調増加するため再起動後も timestamp が衝突しない。
 	Timestamp int64 `json:"timestamp"`
 }
 

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -80,7 +80,6 @@ type HTTPStreamPlayer struct {
 	mu          sync.Mutex
 	started     bool
 	shutdown    bool
-	nextClipID  atomic.Uint64
 	nextErrorID atomic.Uint64
 	clips       *clipRingBuffer
 	subscribers *subscriberRegistry
@@ -121,7 +120,6 @@ var (
 // historyRecord は履歴ファイル（YYYY-MM-DD.jsonl）の 1 行スキーマ。
 // WAV URL は viewer 再起動で失効するため含めない。
 type historyRecord struct {
-	ID          uint64 `json:"id"`
 	Text        string `json:"text"`
 	SpeakerName string `json:"speakerName"`
 	StyleName   string `json:"styleName"`
@@ -135,12 +133,12 @@ type apiHistoryResponse struct {
 
 // clipEvent は SSE で配信する clip イベントのペイロード。
 type clipEvent struct {
-	ID          uint64 `json:"id"`
 	URL         string `json:"url"`
 	Text        string `json:"text"`
 	SpeakerName string `json:"speakerName"`
 	StyleName   string `json:"styleName"`
 	// Timestamp は配信時刻の Unix ms（UTC）。ブラウザ側で HH:MM:SS に整形する。
+	// セッションをまたいでも単調増加するため再起動後の id 衝突が発生しない。
 	Timestamp int64 `json:"timestamp"`
 }
 
@@ -415,15 +413,14 @@ func (p *HTTPStreamPlayer) PlayText(ctx context.Context, meta app.PlayMeta) erro
 		return fmt.Errorf("HTTPStreamPlayer is not started")
 	}
 
-	id := p.nextClipID.Add(1)
+	ts := p.nowFunc().UnixMilli()
 	speakerName, styleName := p.resolveSpeaker(meta.SpeakerID)
 	ev := clipEvent{
-		ID:          id,
 		URL:         "",
 		Text:        meta.Text,
 		SpeakerName: speakerName,
 		StyleName:   styleName,
-		Timestamp:   p.nowFunc().UnixMilli(),
+		Timestamp:   ts,
 	}
 	payload, err := json.Marshal(ev)
 	if err != nil {
@@ -432,9 +429,9 @@ func (p *HTTPStreamPlayer) PlayText(ctx context.Context, meta app.PlayMeta) erro
 
 	n, dropped := p.subscribers.broadcast(sseEventClip, payload)
 	if dropped > 0 {
-		p.logger.Warn("stream clip dropped for slow subscribers", "clipId", id, "dropped", dropped)
+		p.logger.Warn("stream clip dropped for slow subscribers", "clipTimestamp", ts, "dropped", dropped)
 	}
-	p.logger.Info("stream clip delivered (silent)", "clipId", id, "subscribers", n)
+	p.logger.Info("stream clip delivered (silent)", "clipTimestamp", ts, "subscribers", n)
 	p.appendHistory(ev)
 
 	if p.silentInterval <= 0 {
@@ -472,20 +469,19 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 		return fmt.Errorf("HTTPStreamPlayer is not started")
 	}
 
-	id := p.nextClipID.Add(1)
+	ts := p.nowFunc().UnixMilli()
 	// 呼び出し元のバッファ再利用に備えてコピーを保持する。
 	buf := make([]byte, len(wavData))
 	copy(buf, wavData)
-	p.clips.put(id, buf)
+	p.clips.put(ts, buf)
 
 	speakerName, styleName := p.resolveSpeaker(meta.SpeakerID)
 	ev := clipEvent{
-		ID:          id,
-		URL:         clipPathPrefix + strconv.FormatUint(id, 10) + clipPathSuffix,
+		URL:         clipPathPrefix + strconv.FormatInt(ts, 10) + clipPathSuffix,
 		Text:        meta.Text,
 		SpeakerName: speakerName,
 		StyleName:   styleName,
-		Timestamp:   p.nowFunc().UnixMilli(),
+		Timestamp:   ts,
 	}
 	payload, err := json.Marshal(ev)
 	if err != nil {
@@ -494,14 +490,14 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 
 	n, dropped := p.subscribers.broadcast(sseEventClip, payload)
 	if dropped > 0 {
-		p.logger.Warn("stream clip dropped for slow subscribers", "clipId", id, "dropped", dropped)
+		p.logger.Warn("stream clip dropped for slow subscribers", "clipTimestamp", ts, "dropped", dropped)
 	}
-	p.logger.Info("stream clip delivered", "clipId", id, "subscribers", n)
+	p.logger.Info("stream clip delivered", "clipTimestamp", ts, "subscribers", n)
 	p.appendHistory(ev)
 
 	duration, err := estimateWAVDuration(wavData)
 	if err != nil {
-		p.logger.Warn("failed to estimate WAV duration, skipping playback backpressure", "clipId", id, "error", err)
+		p.logger.Warn("failed to estimate WAV duration, skipping playback backpressure", "clipTimestamp", ts, "error", err)
 		return nil
 	}
 	if duration <= 0 {
@@ -553,12 +549,12 @@ func (p *HTTPStreamPlayer) BroadcastError(e app.StreamError) {
 }
 
 func (p *HTTPStreamPlayer) handleClip(w http.ResponseWriter, r *http.Request) {
-	id, ok := parseClipID(r.URL.Path)
+	ts, ok := parseClipTimestamp(r.URL.Path)
 	if !ok {
 		http.NotFound(w, r)
 		return
 	}
-	data, ok := p.clips.get(id)
+	data, ok := p.clips.get(ts)
 	if !ok {
 		http.NotFound(w, r)
 		return
@@ -566,16 +562,16 @@ func (p *HTTPStreamPlayer) handleClip(w http.ResponseWriter, r *http.Request) {
 	writeWAV(w, data)
 }
 
-func parseClipID(path string) (uint64, bool) {
+func parseClipTimestamp(path string) (int64, bool) {
 	if !strings.HasPrefix(path, clipPathPrefix) || !strings.HasSuffix(path, clipPathSuffix) {
 		return 0, false
 	}
 	raw := strings.TrimSuffix(strings.TrimPrefix(path, clipPathPrefix), clipPathSuffix)
-	id, err := strconv.ParseUint(raw, 10, 64)
-	if err != nil {
+	ts, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || ts <= 0 {
 		return 0, false
 	}
-	return id, true
+	return ts, true
 }
 
 // speakerJSON は /api/status の speakers 配列要素のペイロード。
@@ -945,7 +941,6 @@ func (p *HTTPStreamPlayer) appendHistory(ev clipEvent) {
 		return
 	}
 	record := historyRecord{
-		ID:          ev.ID,
 		Text:        ev.Text,
 		SpeakerName: ev.SpeakerName,
 		StyleName:   ev.StyleName,
@@ -1097,8 +1092,8 @@ func (p *HTTPStreamPlayer) handleEvents(w http.ResponseWriter, r *http.Request) 
 // --- ring buffer ---
 
 type clipEntry struct {
-	id   uint64
-	data []byte
+	timestamp int64
+	data      []byte
 }
 
 type clipRingBuffer struct {
@@ -1111,7 +1106,7 @@ func newClipRingBuffer(capacity int) *clipRingBuffer {
 	return &clipRingBuffer{cap: capacity, entries: make([]clipEntry, 0, capacity)}
 }
 
-func (b *clipRingBuffer) put(id uint64, data []byte) {
+func (b *clipRingBuffer) put(timestamp int64, data []byte) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if len(b.entries) >= b.cap {
@@ -1119,14 +1114,14 @@ func (b *clipRingBuffer) put(id uint64, data []byte) {
 		b.entries[0] = clipEntry{}
 		b.entries = b.entries[1:]
 	}
-	b.entries = append(b.entries, clipEntry{id: id, data: data})
+	b.entries = append(b.entries, clipEntry{timestamp: timestamp, data: data})
 }
 
-func (b *clipRingBuffer) get(id uint64) ([]byte, bool) {
+func (b *clipRingBuffer) get(timestamp int64) ([]byte, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, e := range b.entries {
-		if e.id == id {
+		if e.timestamp == timestamp {
 			return e.data, true
 		}
 	}

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -17,11 +17,11 @@ package infra
 // DONE: GET / が index.html を返す
 // DONE: GET /app.js が JS を返す
 // DONE: GET /app.css が CSS を返す
-// DONE: 未登録の /clips/{id}.wav は 404
+// DONE: 未登録の /clips/{timestamp}.wav は 404
 //
 // Play / キュー / SSE:
-// DONE: Play() で WAV がキューに登録され GET /clips/{id}.wav で配信される
-// DONE: クリップID は 1 から単調増加
+// DONE: Play() で WAV がキューに登録され GET /clips/{timestamp}.wav で配信される
+// DONE: clipEvent の timestamp は一意かつ非ゼロ
 // DONE: 容量を超えて Play() すると古いクリップが破棄されて 404 になる
 // DONE: SSE 購読者に clip イベントがブロードキャストされる
 // DONE: 複数 SSE 購読者に同じイベントが届く
@@ -456,24 +456,30 @@ func TestHTTPStreamPlayer_Play_DeliversSSEAndWAV(t *testing.T) {
 		t.Fatalf("Play: %v", err)
 	}
 
+	var clipURL string
 	select {
 	case data, ok := <-events:
 		if !ok {
 			t.Fatal("events channel closed before clip delivered")
 		}
-		if !strings.Contains(data, "\"id\":1") {
-			t.Errorf("expected clip id=1, got: %s", data)
+		var ev clipEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			t.Fatalf("unmarshal clipEvent: %v, data=%s", err, data)
 		}
-		if !strings.Contains(data, "\"url\":\"/clips/1.wav\"") {
-			t.Errorf("expected url=/clips/1.wav, got: %s", data)
+		if ev.Timestamp == 0 {
+			t.Errorf("expected non-zero timestamp, got: %s", data)
 		}
+		if !strings.HasPrefix(ev.URL, clipPathPrefix) || !strings.HasSuffix(ev.URL, clipPathSuffix) {
+			t.Errorf("expected url like /clips/<timestamp>.wav, got: %s", ev.URL)
+		}
+		clipURL = ev.URL
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for clip event")
 	}
 
-	resp, err := http.Get(baseURL + "/clips/1.wav")
+	resp, err := http.Get(baseURL + clipURL)
 	if err != nil {
-		t.Fatalf("GET /clips/1.wav: %v", err)
+		t.Fatalf("GET %s: %v", clipURL, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
@@ -484,9 +490,27 @@ func TestHTTPStreamPlayer_Play_DeliversSSEAndWAV(t *testing.T) {
 	}
 }
 
-func TestHTTPStreamPlayer_ClipIDMonotonicallyIncreasing(t *testing.T) {
+func TestHTTPStreamPlayer_ClipTimestampIsNonZeroAndNoIDField(t *testing.T) {
 	t.Parallel()
-	p := newStartedPlayer(t)
+	fixedBase := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+	callCount := 0
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		withNowFunc(func() time.Time {
+			callCount++
+			return fixedBase.Add(time.Duration(callCount) * time.Millisecond)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
 	baseURL := "http://" + p.Addr()
 
 	events := subscribeSSE(t, baseURL)
@@ -498,15 +522,27 @@ func TestHTTPStreamPlayer_ClipIDMonotonicallyIncreasing(t *testing.T) {
 		}
 	}
 
-	for expected := 1; expected <= 3; expected++ {
+	seen := make(map[int64]bool)
+	for i := range 3 {
 		select {
 		case data := <-events:
-			needle := fmt.Sprintf("\"id\":%d", expected)
-			if !strings.Contains(data, needle) {
-				t.Errorf("expected %s in %s", needle, data)
+			var ev clipEvent
+			if err := json.Unmarshal([]byte(data), &ev); err != nil {
+				t.Fatalf("event #%d unmarshal: %v, data=%s", i+1, err, data)
+			}
+			if ev.Timestamp == 0 {
+				t.Errorf("event #%d: expected non-zero timestamp, got %s", i+1, data)
+			}
+			if seen[ev.Timestamp] {
+				t.Errorf("event #%d: duplicate timestamp %d", i+1, ev.Timestamp)
+			}
+			seen[ev.Timestamp] = true
+			// id フィールドが JSON に含まれないことを確認する
+			if strings.Contains(data, `"id":`) {
+				t.Errorf("event #%d: unexpected id field in clip payload: %s", i+1, data)
 			}
 		case <-time.After(2 * time.Second):
-			t.Fatalf("timeout waiting for event #%d", expected)
+			t.Fatalf("timeout waiting for event #%d", i+1)
 		}
 	}
 }
@@ -530,8 +566,8 @@ func TestHTTPStreamPlayer_MultipleSubscribers(t *testing.T) {
 	for i, ch := range channels {
 		select {
 		case data := <-ch:
-			if !strings.Contains(data, "\"id\":1") {
-				t.Errorf("subscriber %d got %s", i, data)
+			if !strings.Contains(data, `"timestamp":`) {
+				t.Errorf("subscriber %d: expected timestamp field, got %s", i, data)
 			}
 		case <-time.After(2 * time.Second):
 			t.Errorf("subscriber %d timeout", i)
@@ -848,18 +884,42 @@ func findLogLine(logs, needle string) string {
 
 func TestHTTPStreamPlayer_RingBuffer_FixedSize(t *testing.T) {
 	t.Parallel()
-	p := newStartedPlayer(t)
+	fixedBase := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+	callCount := 0
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		withNowFunc(func() time.Time {
+			callCount++
+			return fixedBase.Add(time.Duration(callCount) * time.Millisecond)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
 	baseURL := "http://" + p.Addr()
 
-	// 21件積むと1件目だけが押し出される（容量20）
+	// 21件積むと1件目だけが押し出される（容量20）。
+	// nowFunc は Play 毎に 1ms 増加するため、URL は /clips/<base+N>.wav で予測可能。
 	const total = 21
 	for range total {
 		if err := p.Play(context.Background(), []byte("RIFFx"), app.PlayMeta{}); err != nil {
 			t.Fatalf("Play: %v", err)
 		}
 	}
+	baseMs := fixedBase.UnixMilli()
+	clipURL := func(n int) string {
+		return fmt.Sprintf("/clips/%d.wav", baseMs+int64(n))
+	}
 
-	resp1, err := http.Get(baseURL + "/clips/1.wav")
+	// 1件目は押し出されて 404
+	resp1, err := http.Get(baseURL + clipURL(1))
 	if err != nil {
 		t.Fatalf("GET clip1: %v", err)
 	}
@@ -869,7 +929,7 @@ func TestHTTPStreamPlayer_RingBuffer_FixedSize(t *testing.T) {
 	}
 
 	// 2件目（最古の生存クリップ）と21件目（最新）は取得できる
-	resp2, err := http.Get(baseURL + "/clips/2.wav")
+	resp2, err := http.Get(baseURL + clipURL(2))
 	if err != nil {
 		t.Fatalf("GET clip2: %v", err)
 	}
@@ -878,7 +938,7 @@ func TestHTTPStreamPlayer_RingBuffer_FixedSize(t *testing.T) {
 		t.Errorf("expected 200 for clip 2 (oldest surviving), got %d", resp2.StatusCode)
 	}
 
-	resp21, err := http.Get(baseURL + "/clips/21.wav")
+	resp21, err := http.Get(baseURL + clipURL(total))
 	if err != nil {
 		t.Fatalf("GET clip21: %v", err)
 	}
@@ -1566,7 +1626,7 @@ func TestHTTPStreamPlayer_BroadcastError_IDMonotonicAndIndependentFromClip(t *te
 	errorEvents := subscribeSSEByEvent(t, baseURL, "error")
 	time.Sleep(80 * time.Millisecond)
 
-	// clip を 2 回、error を 3 回交互に配信して、それぞれが独立に 1 始まりで連番になること
+	// clip を 2 回、error を 3 回交互に配信して、error は独立に 1 始まりで連番になること
 	if err := p.Play(context.Background(), []byte("RIFFa"), app.PlayMeta{}); err != nil {
 		t.Fatalf("Play: %v", err)
 	}
@@ -1577,15 +1637,14 @@ func TestHTTPStreamPlayer_BroadcastError_IDMonotonicAndIndependentFromClip(t *te
 	}
 	p.BroadcastError(app.StreamError{Category: app.StreamErrorCategoryFile, Message: "e3"})
 
-	for i := 1; i <= 2; i++ {
+	for i := range 2 {
 		select {
 		case data := <-clipEvents:
-			needle := fmt.Sprintf(`"id":%d`, i)
-			if !strings.Contains(data, needle) {
-				t.Errorf("clip event #%d: expected %s, got %s", i, needle, data)
+			if !strings.Contains(data, `"timestamp":`) {
+				t.Errorf("clip event #%d: expected timestamp field, got %s", i+1, data)
 			}
 		case <-time.After(2 * time.Second):
-			t.Fatalf("timeout waiting for clip #%d", i)
+			t.Fatalf("timeout waiting for clip #%d", i+1)
 		}
 	}
 	for i := 1; i <= 3; i++ {
@@ -2295,9 +2354,6 @@ func TestHTTPStreamPlayer_History_WritesClipOnPlay(t *testing.T) {
 	if err := json.Unmarshal([]byte(lines[0]), &rec); err != nil {
 		t.Fatalf("failed to parse history line: %v", err)
 	}
-	if rec.ID != 1 {
-		t.Errorf("expected ID=1, got %d", rec.ID)
-	}
 	if rec.Text != "テストセリフ" {
 		t.Errorf("expected Text=%q, got %q", "テストセリフ", rec.Text)
 	}
@@ -2475,11 +2531,10 @@ func TestHTTPStreamPlayer_APIHistory_ReturnsTodaysEntries(t *testing.T) {
 	var sb strings.Builder
 	for i := 1; i <= 60; i++ {
 		rec := historyRecord{
-			ID:          uint64(i),
 			Text:        fmt.Sprintf("text%d", i),
 			SpeakerName: "ずんだもん",
 			StyleName:   "ノーマル",
-			Timestamp:   fixedNow.UnixMilli(),
+			Timestamp:   fixedNow.UnixMilli() + int64(i),
 		}
 		data, _ := json.Marshal(rec)
 		sb.Write(data)
@@ -2521,11 +2576,11 @@ func TestHTTPStreamPlayer_APIHistory_ReturnsTodaysEntries(t *testing.T) {
 	if len(result.Entries) != 50 {
 		t.Errorf("expected 50 entries, got %d", len(result.Entries))
 	}
-	if len(result.Entries) > 0 && result.Entries[0].ID != 11 {
-		t.Errorf("expected first entry ID=11, got %d", result.Entries[0].ID)
+	if len(result.Entries) > 0 && result.Entries[0].Text != "text11" {
+		t.Errorf("expected first entry text=text11, got %q", result.Entries[0].Text)
 	}
-	if len(result.Entries) > 0 && result.Entries[len(result.Entries)-1].ID != 60 {
-		t.Errorf("expected last entry ID=60, got %d", result.Entries[len(result.Entries)-1].ID)
+	if len(result.Entries) > 0 && result.Entries[len(result.Entries)-1].Text != "text60" {
+		t.Errorf("expected last entry text=text60, got %q", result.Entries[len(result.Entries)-1].Text)
 	}
 }
 
@@ -2590,7 +2645,6 @@ func TestHTTPStreamPlayer_APIHistory_ReturnsUpdatedHistory(t *testing.T) {
 	// Start() 後に履歴ファイルへエントリを追記する。
 	filePath := filepath.Join(historyDir, "2026-04-28.jsonl")
 	rec := historyRecord{
-		ID:          1,
 		Text:        "Start後に追記されたテキスト",
 		SpeakerName: "ずんだもん",
 		StyleName:   "ノーマル",
@@ -2649,7 +2703,7 @@ func TestHTTPStreamPlayer_APIHistory_CrossDayReturnsNewFile(t *testing.T) {
 
 	// Day1 のファイルを作成。
 	file1 := filepath.Join(historyDir, "2026-04-28.jsonl")
-	rec1 := historyRecord{ID: 1, Text: "day1エントリ", SpeakerName: "ずんだもん", StyleName: "ノーマル", Timestamp: day1.UnixMilli()}
+	rec1 := historyRecord{Text: "day1エントリ", SpeakerName: "ずんだもん", StyleName: "ノーマル", Timestamp: day1.UnixMilli()}
 	data1, _ := json.Marshal(rec1)
 	data1 = append(data1, '\n')
 	if err := os.WriteFile(file1, data1, 0o644); err != nil {
@@ -2659,7 +2713,7 @@ func TestHTTPStreamPlayer_APIHistory_CrossDayReturnsNewFile(t *testing.T) {
 	// Day2 へ日付変更し、Day2 のファイルを作成。
 	*nowPtr = day2
 	file2 := filepath.Join(historyDir, "2026-04-29.jsonl")
-	rec2 := historyRecord{ID: 2, Text: "day2エントリ", SpeakerName: "ずんだもん", StyleName: "ノーマル", Timestamp: day2.UnixMilli()}
+	rec2 := historyRecord{Text: "day2エントリ", SpeakerName: "ずんだもん", StyleName: "ノーマル", Timestamp: day2.UnixMilli()}
 	data2, _ := json.Marshal(rec2)
 	data2 = append(data2, '\n')
 	if err := os.WriteFile(file2, data2, 0o644); err != nil {


### PR DESCRIPTION
## Summary

- `clipEvent` / `historyRecord` から `id` フィールドを廃止し、`timestamp` (Unix ms) を唯一の識別子として採用した
- `vox-actor` 再起動ごとに `nextClipID` が 0 リセットされる問題を根本解消し、React の重複 key 警告とタイムライン表示崩れを修正した
- バックエンド (Go) / フロントエンド (TypeScript) / E2E テスト / スタブサーバーをすべて一貫して変更した

### 変更の詳細

**バックエンド (Go)**
- `clipEvent.ID`, `historyRecord.ID` を削除
- `HTTPStreamPlayer.nextClipID (atomic.Uint64)` を撤去
- `clipRingBuffer` のキーを `uint64 id` → `int64 timestamp` に変更
- `/clips/{id}.wav` → `/clips/{timestamp}.wav` へ URL 形式を変更
- `parseClipID` → `parseClipTimestamp` へリネーム

**フロントエンド (TypeScript)**
- `ClipEvent.id`, `HistoryEntry.id` を削除・型ガードを更新
- `playingClipId` → `playingClipTimestamp` にリネーム（App / StreamPanel / Timeline / usePlaybackQueue）
- `lastClipId` → `lastClipTimestamp` にリネーム（StreamPanel / useCharacterStage）
- React key を `${kind}-${id}` → `${kind}-${timestamp}` に変更
- `TimelineItem` の `data-clip-id` → `data-clip-timestamp` に変更

**E2E / スタブサーバー**
- `stub-server.mjs` の `nextClipId` を削除、clip payload の id を除去
- `helpers.ts` の `ClipPayload.id?` / `HistoryEntryPayload.id` を削除
- 各 spec の `data-clip-id` セレクタを `data-clip-timestamp` に変更

## Test plan

- [x] Go ユニットテスト: `go test ./internal/infra/` 全パス
- [x] フロントエンドユニットテスト: `npm run test:unit` 149/149 パス
- [x] TypeScript 型チェック: `npm run typecheck` エラーなし
- [x] Go lint: `golangci-lint run` 0 issues
- [ ] E2E テスト: CI で Playwright が実行されること
- [ ] 手動確認: `vox-actor watch --stream` を再起動し、リロード後もタイムラインが正常表示されること（VOICEVOX 必要のため CI 外手動確認）

Closes #416

---
🤖 Generated with [Claude Code](https://claude.ai/code)
