### PR TITLE
feat(viewer): viewer 起動中の say/act の音声を viewer 側で再生（API 連携）

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,8 @@ type ActDeps struct {
 	Player            app.AudioPlayer
 	Mover             app.FileMover
 	DirWatcherFactory func(logger *slog.Logger) app.DirWatcher
+	LockPathResolver  func() (string, error)
+	Logger            *slog.Logger
 }
 
 func makeActCmd(deps *ActDeps) *cobra.Command {
@@ -41,6 +44,13 @@ func makeActCmd(deps *ActDeps) *cobra.Command {
 	cmd.Flags().Bool("watch-delete", false, "ディレクトリ監視モード（処理済みファイルを削除）")
 
 	return cmd
+}
+
+func resolveActLockPath(deps *ActDeps) (string, error) {
+	if deps != nil {
+		return resolveViewerLockPathWith(deps.LockPathResolver)
+	}
+	return resolveViewerLockPathWith(nil)
 }
 
 func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
@@ -80,7 +90,12 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
-	logger := buildLoggerFromFlags(cmd)
+	var logger *slog.Logger
+	if deps.Logger != nil {
+		logger = deps.Logger
+	} else {
+		logger = buildLoggerFromFlags(cmd)
+	}
 
 	client := deps.ClientFactory(engineURL)
 	if client == nil {
@@ -105,6 +120,48 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 			Intonation: &intonation,
 			DryRun:     dryRun,
 		})
+	}
+
+	if !dryRun {
+		lockPath, lockErr := resolveActLockPath(deps)
+		if lockErr != nil {
+			logger.Debug("could not resolve viewer lock path, using local player", "error", lockErr)
+		} else if addr, ok := infra.DetectViewer(lockPath); ok {
+			logger.Info("viewer detected, sending audio via /api/play", "addr", addr)
+			scripts, err := deps.Reader.Read(args[0])
+			if err != nil {
+				return err
+			}
+			vc := infra.NewViewerAPIClient(addr)
+			for _, script := range scripts {
+				if script.IsEmpty {
+					continue
+				}
+				if ctx.Err() != nil {
+					return nil
+				}
+				effectiveSpeakerID := script.ResolveSpeakerID(speakerID)
+				effectiveSpeed := script.ResolveSpeed(&speed)
+				effectivePitch := script.ResolvePitch(&pitch)
+				effectiveIntonation := script.ResolveIntonation(&intonation)
+				resp, postErr := vc.Play(ctx, infra.ViewerPlayRequest{
+					Text:       script.Text,
+					SpeakerID:  effectiveSpeakerID,
+					Speed:      effectiveSpeed,
+					Pitch:      effectivePitch,
+					Intonation: effectiveIntonation,
+				})
+				if postErr != nil {
+					return fmt.Errorf("act via viewer: %w", postErr)
+				}
+				if resp.Silent {
+					logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
+				}
+			}
+			return nil
+		} else {
+			logger.Debug("viewer not running, using local player")
+		}
 	}
 
 	uc := app.NewActUsecase(deps.Reader, client, deps.Player, app.WithLogger(logger))

--- a/cmd/act_test.go
+++ b/cmd/act_test.go
@@ -2,15 +2,27 @@ package cmd
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
+	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
 	"github.com/spf13/cobra"
 )
 
 // act コマンド テストリスト（すべて実装済み）
+// #418 viewer 連携:
+// DONE: viewer 起動中は /api/play を行ごとに POST してローカル再生しない    → TestRunAct_ViewerRunning_POSTsPerLine
+// DONE: viewer 未起動はローカル再生にフォールバック                         → TestRunAct_ViewerNotRunning_UsesLocalPlayer
+// DONE: --dry-run 時は viewer へ POST しない                               → TestRunAct_DryRun_NoViewerPost
+// DONE: 途中行で POST 失敗した場合即座にエラー終了する                      → TestRunAct_ViewerRunning_PostFails_StopsEarly
 
 // グレースフルシャットダウン テストリスト
 // DONE: actコマンドのcontextにシグナルハンドリングが設定されていることを確認
@@ -311,3 +323,206 @@ func TestActCmd_EnvVarVOXSpeaker_InvalidValue(t *testing.T) {
 		t.Errorf("expected default speaker 3 when env var is invalid, got: %d", speaker)
 	}
 }
+
+// --- viewer 連携テスト (#418) ---
+
+// stubScriptReaderForAct はテキストファイルを渡さずに固定スクリプトを返すスタブ。
+type stubScriptReaderForAct struct {
+	scripts []entity.Script
+}
+
+func (s stubScriptReaderForAct) Read(_ string) ([]entity.Script, error) {
+	return s.scripts, nil
+}
+
+func TestRunAct_ViewerRunning_POSTsPerLine(t *testing.T) {
+	var postCount int
+	var capturedTexts []string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if text, ok := req["text"].(string); ok {
+			capturedTexts = append(capturedTexts, text)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	scriptFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("line1\nline2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	deps := &ActDeps{
+		Reader:           stubScriptReaderForAct{scripts: []entity.Script{{Text: "line1"}, {Text: "line2"}}},
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	if postCount != 2 {
+		t.Errorf("expected 2 POSTs, got %d", postCount)
+	}
+	if len(capturedTexts) != 2 || capturedTexts[0] != "line1" || capturedTexts[1] != "line2" {
+		t.Errorf("expected texts [line1, line2], got %v", capturedTexts)
+	}
+}
+
+func TestRunAct_ViewerNotRunning_UsesLocalPlayer(t *testing.T) {
+	playCalled := 0
+	player := &trackingPlayer{playFn: func() { playCalled++ }}
+	client := &mockSayClient{}
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+
+	scriptFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	deps := &ActDeps{
+		Reader:           stubScriptReaderForAct{scripts: []entity.Script{{Text: "hello"}}},
+		ClientFactory:    func(_ string) app.VoicevoxClient { return client },
+		Player:           player,
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	if playCalled != 1 {
+		t.Errorf("expected local player called once, got %d", playCalled)
+	}
+}
+
+func TestRunAct_DryRun_NoViewerPost(t *testing.T) {
+	var postCount int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	scriptFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--dry-run"})
+
+	deps := &ActDeps{
+		Reader:           stubScriptReaderForAct{scripts: []entity.Script{{Text: "hello"}}},
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	if postCount != 0 {
+		t.Errorf("expected no POST in dry-run, got %d", postCount)
+	}
+}
+
+func TestRunAct_ViewerRunning_PostFails_StopsEarly(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	scriptFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("line1\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	deps := &ActDeps{
+		Reader:           stubScriptReaderForAct{scripts: []entity.Script{{Text: "line1"}}},
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	err := runAct(cmd, []string{scriptFile}, deps)
+	if err == nil {
+		t.Fatal("expected error when POST fails, got nil")
+	}
+}
+
+func TestRunAct_ViewerRunning_SilentMode_Warns(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"silent":        true,
+			"silent_reason": "VOICEVOX接続失敗",
+		})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	scriptFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	deps := &ActDeps{
+		Reader:           stubScriptReaderForAct{scripts: []entity.Script{{Text: "hello"}}},
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+		Logger:           logger,
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "WARN") {
+		t.Errorf("expected WARN log for silent mode, got: %s", output)
+	}
+}
+
+// mockActClient は act テスト用の VoicevoxClient スタブ（HealthCheck OK、合成成功）。
+type mockActClient struct{}
+
+func (c *mockActClient) HealthCheck(_ context.Context) error { return nil }
+func (c *mockActClient) CreateQuery(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	return &entity.AudioQuery{}, nil
+}
+func (c *mockActClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+	return []byte("RIFFx"), nil
+}
+func (c *mockActClient) GetSpeakers(_ context.Context) ([]entity.Speaker, error) { return nil, nil }

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -2,18 +2,22 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
 
 // SayDeps はsayコマンドの依存を保持する。
 type SayDeps struct {
-	ClientFactory func(engineURL string) app.VoicevoxClient
-	Player        app.AudioPlayer
+	ClientFactory    func(engineURL string) app.VoicevoxClient
+	Player           app.AudioPlayer
+	LockPathResolver func() (string, error)
+	Logger           *slog.Logger
 }
 
 func makeSayCmd(deps *SayDeps) *cobra.Command {
@@ -37,6 +41,13 @@ func makeSayCmd(deps *SayDeps) *cobra.Command {
 	return cmd
 }
 
+func resolveSayLockPath(deps *SayDeps) (string, error) {
+	if deps != nil {
+		return resolveViewerLockPathWith(deps.LockPathResolver)
+	}
+	return resolveViewerLockPathWith(nil)
+}
+
 func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 	if deps == nil || deps.ClientFactory == nil || deps.Player == nil {
 		return fmt.Errorf("say command dependencies are not initialized")
@@ -46,13 +57,45 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 	defer stop()
 
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
-	logger := buildLoggerFromFlags(cmd)
+
+	var logger *slog.Logger
+	if deps.Logger != nil {
+		logger = deps.Logger
+	} else {
+		logger = buildLoggerFromFlags(cmd)
+	}
 
 	engineURL, _ := cmd.Flags().GetString("engine-url")
 	speakerID, _ := cmd.Flags().GetInt("speaker")
 	speed, _ := cmd.Flags().GetFloat64("speed")
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
+
+	if !dryRun {
+		lockPath, lockErr := resolveSayLockPath(deps)
+		if lockErr != nil {
+			logger.Debug("could not resolve viewer lock path, using local player", "error", lockErr)
+		} else if addr, ok := infra.DetectViewer(lockPath); ok {
+			logger.Info("viewer detected, sending audio via /api/play", "addr", addr)
+			vc := infra.NewViewerAPIClient(addr)
+			resp, err := vc.Play(ctx, infra.ViewerPlayRequest{
+				Text:       args[0],
+				SpeakerID:  speakerID,
+				Speed:      &speed,
+				Pitch:      &pitch,
+				Intonation: &intonation,
+			})
+			if err != nil {
+				return err
+			}
+			if resp.Silent {
+				logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
+			}
+			return nil
+		} else {
+			logger.Debug("viewer not running, using local player")
+		}
+	}
 
 	params := app.SayParams{
 		Text:       args[0],

--- a/cmd/say_test.go
+++ b/cmd/say_test.go
@@ -3,7 +3,11 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
+	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -14,6 +18,11 @@ import (
 
 // say コマンド テストリスト
 // DONE: sayサブコマンドがrootに登録されている
+// #418 viewer 連携:
+// DONE: viewer 起動中は /api/play に POST してローカル再生をしない → TestRunSay_ViewerRunning_POSTsToViewer
+// DONE: viewer 無音モード応答で WARN ログを出す                   → TestRunSay_ViewerRunning_SilentMode_Warns
+// DONE: viewer 未起動はローカル再生にフォールバック               → TestRunSay_ViewerNotRunning_UsesLocalPlayer
+// DONE: --dry-run 時は viewer へ POST しない                      → TestRunSay_DryRun_NoViewerPost
 // DONE: 引数なしでErrUsageを返す
 // DONE: ヘルプ出力に全フラグが含まれる（--engine-url, --speaker, --speed, --pitch, --intonation, --verbose）
 // DONE: ヘルプ出力に--output/--watchフラグが含まれない
@@ -203,3 +212,166 @@ type noopPlayer struct{}
 func (n *noopPlayer) Play(_ context.Context, _ []byte, _ app.PlayMeta) error {
 	return errors.New("must not be called")
 }
+
+// --- viewer 連携テスト (#418) ---
+
+// newCmdWithContext は context.Background() を設定した cobra.Command を返すテストヘルパー。
+func newCmdWithContext(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+func TestRunSay_ViewerRunning_POSTsToViewer(t *testing.T) {
+	var postCount int
+	var capturedReq map[string]interface{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		_ = json.NewDecoder(r.Body).Decode(&capturedReq)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	deps := &SayDeps{
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runSay(cmd, []string{"こんにちは"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+	if postCount != 1 {
+		t.Errorf("expected 1 POST to /api/play, got %d", postCount)
+	}
+	if capturedReq["text"] != "こんにちは" {
+		t.Errorf("expected text=%q, got %v", "こんにちは", capturedReq["text"])
+	}
+}
+
+func TestRunSay_ViewerRunning_SilentMode_Warns(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"silent":        true,
+			"silent_reason": "VOICEVOX接続失敗",
+		})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	deps := &SayDeps{
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+		Logger:           logger,
+	}
+
+	if err := runSay(cmd, []string{"テスト"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "WARN") {
+		t.Errorf("expected WARN log for silent mode, got: %s", output)
+	}
+}
+
+func TestRunSay_ViewerNotRunning_UsesLocalPlayer(t *testing.T) {
+	playCalled := false
+
+	player := &trackingPlayer{playFn: func() { playCalled = true }}
+	client := &mockSayClient{}
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	deps := &SayDeps{
+		ClientFactory:    func(_ string) app.VoicevoxClient { return client },
+		Player:           player,
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runSay(cmd, []string{"ローカル再生テスト"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+	if !playCalled {
+		t.Error("expected local player to be called")
+	}
+}
+
+func TestRunSay_DryRun_NoViewerPost(t *testing.T) {
+	var postCount int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--dry-run"})
+
+	deps := &SayDeps{
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runSay(cmd, []string{"ドライラン"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+	if postCount != 0 {
+		t.Errorf("expected no POST in dry-run, got %d", postCount)
+	}
+}
+
+// trackingPlayer は Play が呼ばれたかを追跡するスタブ。
+type trackingPlayer struct {
+	playFn func()
+}
+
+func (p *trackingPlayer) Play(_ context.Context, _ []byte, _ app.PlayMeta) error {
+	if p.playFn != nil {
+		p.playFn()
+	}
+	return nil
+}
+
+// mockSayClient は say テスト用の最小限 VoicevoxClient スタブ。
+type mockSayClient struct{}
+
+func (c *mockSayClient) HealthCheck(_ context.Context) error { return nil }
+func (c *mockSayClient) CreateQuery(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	return &entity.AudioQuery{}, nil
+}
+func (c *mockSayClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+	return []byte("RIFFx"), nil
+}
+func (c *mockSayClient) GetSpeakers(_ context.Context) ([]entity.Speaker, error) { return nil, nil }

--- a/cmd/viewer.go
+++ b/cmd/viewer.go
@@ -111,15 +111,22 @@ func makeViewerCmd(deps *ViewerDeps) *cobra.Command {
 	return cmd
 }
 
-func resolveViewerLockPath(deps *ViewerDeps) (string, error) {
-	if deps != nil && deps.LockPathResolver != nil {
-		return deps.LockPathResolver()
+func resolveViewerLockPathWith(resolver func() (string, error)) (string, error) {
+	if resolver != nil {
+		return resolver()
 	}
 	ws, err := resolveWorkspaceWithFallback()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(ws, "viewer", "viewer.lock"), nil
+}
+
+func resolveViewerLockPath(deps *ViewerDeps) (string, error) {
+	if deps != nil {
+		return resolveViewerLockPathWith(deps.LockPathResolver)
+	}
+	return resolveViewerLockPathWith(nil)
 }
 
 func runViewer(cmd *cobra.Command, deps *ViewerDeps) error {
@@ -190,6 +197,10 @@ func runViewer(cmd *cobra.Command, deps *ViewerDeps) error {
 		}
 	}()
 	logger.Info("stream server listening", "addr", sp.Addr(), "silent", silent)
+
+	if err := viewerLock.WriteAddr(sp.Addr()); err != nil {
+		logger.Warn("failed to write addr to viewer.lock", "error", err)
+	}
 
 	if len(dirs) == 0 {
 		<-ctx.Done()

--- a/cmd/viewer_test.go
+++ b/cmd/viewer_test.go
@@ -63,6 +63,15 @@ func findViewerCmd(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
 	return nil
 }
 
+// tempLockResolver はテスト用に一時ディレクトリのロックパスを返す LockPathResolver を作る。
+// viewer が実際に起動中でも干渉しない隔離された lock path を使うため各テストで利用する。
+func tempLockResolver(t *testing.T) func() (string, error) {
+	t.Helper()
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+	return func() (string, error) { return lockPath, nil }
+}
+
 func TestViewerCmd_RegisteredAsSubcommand(t *testing.T) {
 	rootCmd := makeRootCmd()
 
@@ -171,6 +180,7 @@ func TestViewerCmd_PortOutOfRange_ReturnsUsageError(t *testing.T) {
 					StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 						return &stubStreamPlayer{}, nil
 					},
+					LockPathResolver: tempLockResolver(t),
 				},
 			}
 			rootCmd := makeRootCmd(deps)
@@ -203,6 +213,7 @@ func TestViewerCmd_WatchWithFile_ReturnsUsageError(t *testing.T) {
 			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return &stubStreamPlayer{}, nil
 			},
+			LockPathResolver: tempLockResolver(t),
 		},
 	}
 	rootCmd := makeRootCmd(deps)
@@ -227,6 +238,7 @@ func TestViewerCmd_WatchWithNonExistentPath_ReturnsUsageError(t *testing.T) {
 			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return &stubStreamPlayer{}, nil
 			},
+			LockPathResolver: tempLockResolver(t),
 		},
 	}
 	rootCmd := makeRootCmd(deps)
@@ -268,6 +280,7 @@ func TestViewerCmd_HealthCheckFailure_FallsBackToSilent(t *testing.T) {
 			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return sp, nil
 			},
+			LockPathResolver: tempLockResolver(t),
 		},
 	}
 
@@ -296,6 +309,7 @@ func TestViewerCmd_GetSpeakersFailure_FallsBackToSilent(t *testing.T) {
 			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return sp, nil
 			},
+			LockPathResolver: tempLockResolver(t),
 		},
 	}
 
@@ -328,6 +342,7 @@ func TestViewerCmd_EngineHealthy_DoesNotEnterSilent(t *testing.T) {
 			StreamPlayerFactory: func(_ string, _ *slog.Logger, _ map[int]entity.SpeakerStyleInfo, _ []int, _ app.VoicevoxClient) (app.StreamPlayer, error) {
 				return sp, nil
 			},
+			LockPathResolver: tempLockResolver(t),
 		},
 	}
 
@@ -362,6 +377,7 @@ func TestViewerCmd_WatchQueue_ResolvesAndCreatesQueueDir(t *testing.T) {
 				resolverCalled++
 				return queueDir, nil
 			},
+			LockPathResolver: tempLockResolver(t),
 		},
 	}
 
@@ -389,6 +405,7 @@ func TestViewerCmd_WatchQueue_ResolverReturnsNotInRepo_ReturnsError(t *testing.T
 			QueuePathResolver: func() (string, error) {
 				return "", infra.ErrNotInGitRepo
 			},
+			LockPathResolver: tempLockResolver(t),
 		},
 	}
 

--- a/cmd/viewer_test_helper_test.go
+++ b/cmd/viewer_test_helper_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/infra"
+)
+
+// setupFakeViewer sets up a fake viewer server with a lock file and returns the lock path.
+// Both say and act tests use this helper.
+func setupFakeViewer(t *testing.T, handler http.Handler) (lockPath string, srv *httptest.Server) {
+	t.Helper()
+	srv = httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	dir := t.TempDir()
+	lockPath = filepath.Join(dir, "viewer.lock")
+	vl, err := infra.AcquireViewerLock(lockPath)
+	if err != nil {
+		t.Fatalf("AcquireViewerLock: %v", err)
+	}
+	t.Cleanup(func() { _ = vl.Release() })
+
+	if err := vl.WriteAddr(srv.Listener.Addr().String()); err != nil {
+		t.Fatalf("WriteAddr: %v", err)
+	}
+	return lockPath, srv
+}

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -307,6 +307,7 @@ func (p *HTTPStreamPlayer) Start(_ context.Context) error {
 	mux.HandleFunc("/events", p.handleEvents)
 	mux.HandleFunc("/api/status", p.handleAPIStatus)
 	mux.HandleFunc("/api/history", p.handleAPIHistory)
+	mux.HandleFunc("/api/play", p.handleAPIPlay)
 	mux.HandleFunc("/api/characters", p.handleAPICharacters)
 	mux.HandleFunc("/assets/images/", p.handleCharacterImage)
 	mux.HandleFunc("/test-clip", p.handleTestClip)
@@ -863,6 +864,65 @@ func (p *HTTPStreamPlayer) handleAPIHistory(w http.ResponseWriter, _ *http.Reque
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_, _ = w.Write(payload)
+}
+
+func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if p.voicevoxClient == nil {
+		http.Error(w, "voicevox client is not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req ViewerPlayRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	p.mu.Lock()
+	silent := p.silent
+	silentReason := p.silentReason
+	p.mu.Unlock()
+
+	if silent {
+		resp := ViewerPlayResponse{Silent: true, SilentReason: silentReason}
+		payload, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = w.Write(payload)
+		return
+	}
+
+	ctx := r.Context()
+	query, err := p.voicevoxClient.CreateQuery(ctx, req.Text, req.SpeakerID)
+	if err != nil {
+		p.logger.Error("/api/play CreateQuery failed", "speakerID", req.SpeakerID, "error", err)
+		http.Error(w, "failed to create audio query", http.StatusBadGateway)
+		return
+	}
+
+	q := query.WithOverrides(req.Speed, req.Pitch, req.Intonation)
+	wav, err := p.voicevoxClient.Synthesize(ctx, &q, req.SpeakerID)
+	if err != nil {
+		p.logger.Error("/api/play Synthesize failed", "speakerID", req.SpeakerID, "error", err)
+		http.Error(w, "failed to synthesize", http.StatusBadGateway)
+		return
+	}
+
+	meta := app.PlayMeta{Text: req.Text, SpeakerID: req.SpeakerID}
+	if err := p.Play(ctx, wav, meta); err != nil {
+		p.logger.Error("/api/play Play failed", "speakerID", req.SpeakerID, "error", err)
+		http.Error(w, "failed to play", http.StatusInternalServerError)
+		return
+	}
+
+	resp := ViewerPlayResponse{Silent: false}
+	payload, _ := json.Marshal(resp)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_, _ = w.Write(payload)
 }

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -73,6 +73,14 @@ package infra
 // TODO: errorEvent.id はクリップIDと独立に 1 から単調増加する
 // TODO: BroadcastError は複数購読者にブロードキャストされる
 //
+// #418 /api/play エンドポイント:
+// DONE: GET /api/play は 405 を返す                               → TestHTTPStreamPlayer_APIPlay_MethodNotAllowed
+// DONE: voicevoxClient 未設定時は 503 を返す                      → TestHTTPStreamPlayer_APIPlay_NoClient
+// DONE: 不正 JSON ボディで 400 を返す                             → TestHTTPStreamPlayer_APIPlay_InvalidJSON
+// DONE: 正常リクエストで合成→Play して 200 {silent:false} を返す → TestHTTPStreamPlayer_APIPlay_Success
+// DONE: 無音モード時は合成せず 200 {silent:true,silent_reason} を返す → TestHTTPStreamPlayer_APIPlay_SilentMode
+// DONE: 合成失敗時に 502 を返す                                   → TestHTTPStreamPlayer_APIPlay_SynthesisFails
+//
 // #408 再生履歴ファイル保存・起動時復元:
 // TODO: Play() で clip が YYYY-MM-DD.jsonl に追記される          → TestHTTPStreamPlayer_History_WritesClipOnPlay
 // TODO: PlayText() で clip が YYYY-MM-DD.jsonl に追記される      → TestHTTPStreamPlayer_History_WritesClipOnPlayText
@@ -2738,5 +2746,121 @@ func TestHTTPStreamPlayer_APIHistory_CrossDayReturnsNewFile(t *testing.T) {
 	}
 	if result.Entries[0].Text != "day2エントリ" {
 		t.Errorf("expected day2 entry, got %q", result.Entries[0].Text)
+	}
+}
+
+// --- /api/play tests (#418) ---
+
+func TestHTTPStreamPlayer_APIPlay_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+	p := newStartedPlayer(t)
+	resp, err := http.Get("http://" + p.Addr() + "/api/play")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_NoClient(t *testing.T) {
+	t.Parallel()
+	p := newStartedPlayer(t)
+	body := bytes.NewBufferString(`{"text":"hello","speaker_id":2}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	body := bytes.NewBufferString(`not-json`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_Success(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	body := bytes.NewBufferString(`{"text":"こんにちは","speaker_id":2}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	var result ViewerPlayResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Silent {
+		t.Errorf("expected silent=false, got true")
+	}
+	if stub.capturedText != "こんにちは" {
+		t.Errorf("expected capturedText=%q, got %q", "こんにちは", stub.capturedText)
+	}
+	if stub.capturedSpeaker != 2 {
+		t.Errorf("expected capturedSpeaker=2, got %d", stub.capturedSpeaker)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_SilentMode(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	p.SetSilent("VOICEVOX接続失敗")
+	body := bytes.NewBufferString(`{"text":"こんにちは","speaker_id":2}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	var result ViewerPlayResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !result.Silent {
+		t.Errorf("expected silent=true")
+	}
+	if result.SilentReason == "" {
+		t.Errorf("expected non-empty silent_reason")
+	}
+	if stub.createQueryCall != 0 {
+		t.Errorf("expected no synthesis in silent mode, got createQueryCall=%d", stub.createQueryCall)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_SynthesisFails(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{createQueryErr: errors.New("synthesis error")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	body := bytes.NewBufferString(`{"text":"hello","speaker_id":2}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", resp.StatusCode)
 	}
 }

--- a/internal/infra/viewer_client.go
+++ b/internal/infra/viewer_client.go
@@ -1,0 +1,91 @@
+package infra
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const viewerDetectTimeout = 500 * time.Millisecond
+
+// DetectViewer checks if a viewer is running by reading the lock file and probing /api/status.
+// Returns (addr, true) if the viewer is reachable, ("", false) otherwise.
+func DetectViewer(lockPath string) (string, bool) {
+	info, err := ReadViewerLockInfo(lockPath)
+	if err != nil || info.Addr == "" {
+		return "", false
+	}
+
+	client := &http.Client{Timeout: viewerDetectTimeout}
+	resp, err := client.Get("http://" + info.Addr + "/api/status")
+	if err != nil {
+		return "", false
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+	return info.Addr, true
+}
+
+// ViewerPlayRequest is the request payload for POST /api/play.
+type ViewerPlayRequest struct {
+	Text       string   `json:"text"`
+	SpeakerID  int      `json:"speaker_id"`
+	Speed      *float64 `json:"speed,omitempty"`
+	Pitch      *float64 `json:"pitch,omitempty"`
+	Intonation *float64 `json:"intonation,omitempty"`
+}
+
+// ViewerPlayResponse is the response from POST /api/play.
+type ViewerPlayResponse struct {
+	Silent       bool   `json:"silent"`
+	SilentReason string `json:"silent_reason,omitempty"`
+}
+
+// ViewerAPIClient is a thin HTTP client for calling viewer's /api/play.
+type ViewerAPIClient struct {
+	addr   string
+	client *http.Client
+}
+
+// NewViewerAPIClient creates a client targeting the viewer at addr (host:port).
+func NewViewerAPIClient(addr string) *ViewerAPIClient {
+	return &ViewerAPIClient{
+		addr:   addr,
+		client: &http.Client{},
+	}
+}
+
+// Play sends a POST /api/play request to the viewer and returns the response.
+func (c *ViewerAPIClient) Play(ctx context.Context, req ViewerPlayRequest) (*ViewerPlayResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal play request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+c.addr+"/api/play", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("POST /api/play: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("POST /api/play returned %d", resp.StatusCode)
+	}
+
+	var result ViewerPlayResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode play response: %w", err)
+	}
+	return &result, nil
+}

--- a/internal/infra/viewer_client_test.go
+++ b/internal/infra/viewer_client_test.go
@@ -1,0 +1,183 @@
+package infra_test
+
+// テストリスト: viewer 検出 / ViewerAPIClient
+//
+// 受け入れ条件 vs テスト関数のマッピング:
+// - lock ファイルなし → DetectViewer が false を返す               → TestDetectViewer_NoLockFile
+// - lock に addr なし → DetectViewer が false を返す               → TestDetectViewer_NoAddr
+// - lock に addr あり HTTP 疎通 OK → DetectViewer が addr と true  → TestDetectViewer_Running
+// - lock に addr あり HTTP 疎通失敗 → DetectViewer が false を返す → TestDetectViewer_HTTPFails
+// - POST /api/play 成功 → ViewerAPIClient.Play が PlayResponse を返す      → TestViewerAPIClient_Play_Success
+// - POST /api/play 無音モード応答 → ViewerAPIClient.Play が silent=true    → TestViewerAPIClient_Play_Silent
+// - POST /api/play で非 200 応答 → ViewerAPIClient.Play がエラーを返す     → TestViewerAPIClient_Play_Error
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/infra"
+)
+
+func TestDetectViewer_NoLockFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+
+	_, ok := infra.DetectViewer(lockPath)
+	if ok {
+		t.Error("expected DetectViewer to return false when lock file is missing")
+	}
+}
+
+func TestDetectViewer_NoAddr(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+
+	vl, err := infra.AcquireViewerLock(lockPath)
+	if err != nil {
+		t.Fatalf("AcquireViewerLock: %v", err)
+	}
+	defer vl.Release() //nolint:errcheck
+
+	_, ok := infra.DetectViewer(lockPath)
+	if ok {
+		t.Error("expected DetectViewer to return false when addr is empty")
+	}
+}
+
+func TestDetectViewer_Running(t *testing.T) {
+	t.Parallel()
+	// Start a real HTTP test server that responds to /api/status
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/status" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+
+	vl, err := infra.AcquireViewerLock(lockPath)
+	if err != nil {
+		t.Fatalf("AcquireViewerLock: %v", err)
+	}
+	defer vl.Release() //nolint:errcheck
+
+	// srv.Listener.Addr().String() returns e.g. "127.0.0.1:XXXXX"
+	addr := srv.Listener.Addr().String()
+	if err := vl.WriteAddr(addr); err != nil {
+		t.Fatalf("WriteAddr: %v", err)
+	}
+
+	got, ok := infra.DetectViewer(lockPath)
+	if !ok {
+		t.Fatal("expected DetectViewer to return true when viewer is running")
+	}
+	if got != addr {
+		t.Errorf("expected addr=%s, got %s", addr, got)
+	}
+}
+
+func TestDetectViewer_HTTPFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+
+	vl, err := infra.AcquireViewerLock(lockPath)
+	if err != nil {
+		t.Fatalf("AcquireViewerLock: %v", err)
+	}
+	defer vl.Release() //nolint:errcheck
+
+	// Use an addr that is not listening
+	if err := vl.WriteAddr("127.0.0.1:1"); err != nil {
+		t.Fatalf("WriteAddr: %v", err)
+	}
+
+	_, ok := infra.DetectViewer(lockPath)
+	if ok {
+		t.Error("expected DetectViewer to return false when HTTP fails")
+	}
+}
+
+func TestViewerAPIClient_Play_Success(t *testing.T) {
+	t.Parallel()
+	var capturedReq infra.ViewerPlayRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedReq)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	}))
+	defer srv.Close()
+
+	speed := 1.2
+	pitch := 0.05
+	intonation := 1.3
+	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
+	req := infra.ViewerPlayRequest{Text: "こんにちは", SpeakerID: 2, Speed: &speed, Pitch: &pitch, Intonation: &intonation}
+	resp, err := client.Play(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+	if resp.Silent {
+		t.Errorf("expected silent=false, got true")
+	}
+	if capturedReq.Text != "こんにちは" {
+		t.Errorf("expected text=%q, got %q", "こんにちは", capturedReq.Text)
+	}
+	if capturedReq.SpeakerID != 2 {
+		t.Errorf("expected speaker_id=2, got %d", capturedReq.SpeakerID)
+	}
+	if capturedReq.Speed == nil || *capturedReq.Speed != speed {
+		t.Errorf("expected speed=%v, got %v", speed, capturedReq.Speed)
+	}
+	if capturedReq.Pitch == nil || *capturedReq.Pitch != pitch {
+		t.Errorf("expected pitch=%v, got %v", pitch, capturedReq.Pitch)
+	}
+	if capturedReq.Intonation == nil || *capturedReq.Intonation != intonation {
+		t.Errorf("expected intonation=%v, got %v", intonation, capturedReq.Intonation)
+	}
+}
+
+func TestViewerAPIClient_Play_Silent(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"silent":        true,
+			"silent_reason": "VOICEVOX接続失敗",
+		})
+	}))
+	defer srv.Close()
+
+	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
+	resp, err := client.Play(t.Context(), infra.ViewerPlayRequest{Text: "test", SpeakerID: 2})
+	if err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+	if !resp.Silent {
+		t.Errorf("expected silent=true")
+	}
+	if resp.SilentReason == "" {
+		t.Errorf("expected non-empty SilentReason")
+	}
+}
+
+func TestViewerAPIClient_Play_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "synthesis failed", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
+	_, err := client.Play(t.Context(), infra.ViewerPlayRequest{Text: "test", SpeakerID: 2})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/infra/viewer_lock.go
+++ b/internal/infra/viewer_lock.go
@@ -22,9 +22,19 @@ func (e *ViewerAlreadyRunningError) Error() string {
 		e.PID, e.StartedAt.Format(time.RFC3339))
 }
 
+// ViewerLockInfo holds the information read from a viewer lock file.
+type ViewerLockInfo struct {
+	PID       int
+	StartedAt time.Time
+	Addr      string
+}
+
 // ViewerLock holds an acquired exclusive viewer lock.
 type ViewerLock struct {
-	lock *flock.Flock
+	lock      *flock.Flock
+	path      string
+	pid       int
+	startedAt time.Time
 }
 
 // AcquireViewerLock creates the run directory, acquires an exclusive flock on
@@ -41,7 +51,7 @@ func AcquireViewerLock(lockPath string) (*ViewerLock, error) {
 		return nil, fmt.Errorf("failed to try lock: %w", err)
 	}
 	if !locked {
-		pid, startedAt, readErr := readLockFile(lockPath)
+		pid, startedAt, _, readErr := readLockFile(lockPath)
 		if readErr != nil {
 			return nil, fmt.Errorf("viewer は既に起動中です (lock file unreadable: %w)", readErr)
 		}
@@ -50,26 +60,45 @@ func AcquireViewerLock(lockPath string) (*ViewerLock, error) {
 
 	pid := os.Getpid()
 	startedAt := time.Now()
-	if writeErr := writeLockFile(lockPath, pid, startedAt); writeErr != nil {
+	if writeErr := writeLockFile(lockPath, pid, startedAt, ""); writeErr != nil {
 		_ = f.Unlock()
 		return nil, fmt.Errorf("failed to write lock file: %w", writeErr)
 	}
 
-	return &ViewerLock{lock: f}, nil
+	return &ViewerLock{lock: f, path: lockPath, pid: pid, startedAt: startedAt}, nil
 }
 
 func (vl *ViewerLock) Release() error {
 	return vl.lock.Unlock()
 }
 
-func readLockFile(path string) (int, time.Time, error) {
+// WriteAddr updates the lock file with the given addr.
+// Call this after the HTTP server starts and the bound address is known.
+func (vl *ViewerLock) WriteAddr(addr string) error {
+	if err := writeLockFile(vl.path, vl.pid, vl.startedAt, addr); err != nil {
+		return fmt.Errorf("failed to write addr to lock file: %w", err)
+	}
+	return nil
+}
+
+// ReadViewerLockInfo reads all fields from the lock file at path.
+func ReadViewerLockInfo(path string) (*ViewerLockInfo, error) {
+	pid, startedAt, addr, err := readLockFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return &ViewerLockInfo{PID: pid, StartedAt: startedAt, Addr: addr}, nil
+}
+
+func readLockFile(path string) (int, time.Time, string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return 0, time.Time{}, err
+		return 0, time.Time{}, "", err
 	}
 
 	var pid int
 	var startedAt time.Time
+	var addr string
 	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
 		k, v, ok := strings.Cut(line, "=")
 		if !ok {
@@ -79,19 +108,24 @@ func readLockFile(path string) (int, time.Time, error) {
 		case "pid":
 			pid, err = strconv.Atoi(v)
 			if err != nil {
-				return 0, time.Time{}, fmt.Errorf("invalid pid: %w", err)
+				return 0, time.Time{}, "", fmt.Errorf("invalid pid: %w", err)
 			}
 		case "started_at":
 			startedAt, err = time.Parse(time.RFC3339, v)
 			if err != nil {
-				return 0, time.Time{}, fmt.Errorf("invalid started_at: %w", err)
+				return 0, time.Time{}, "", fmt.Errorf("invalid started_at: %w", err)
 			}
+		case "addr":
+			addr = v
 		}
 	}
-	return pid, startedAt, nil
+	return pid, startedAt, addr, nil
 }
 
-func writeLockFile(path string, pid int, startedAt time.Time) error {
+func writeLockFile(path string, pid int, startedAt time.Time, addr string) error {
 	content := fmt.Sprintf("pid=%d\nstarted_at=%s\n", pid, startedAt.Format(time.RFC3339))
+	if addr != "" {
+		content += fmt.Sprintf("addr=%s\n", addr)
+	}
 	return os.WriteFile(path, []byte(content), 0o644)
 }

--- a/internal/infra/viewer_lock_test.go
+++ b/internal/infra/viewer_lock_test.go
@@ -8,6 +8,9 @@ package infra_test
 // - ViewerAlreadyRunningError に先行PIDと起動時刻が含まれる    → TestAcquireViewerLock_AlreadyLocked_HasPIDAndTime
 // - ロック解放後に再取得できる（stale lock なし）               → TestAcquireViewerLock_ReacquireAfterRelease
 // - viewer/ ディレクトリが存在しなければ自動作成する            → TestAcquireViewerLock_CreatesViewerDir
+// - WriteAddr でロックファイルに addr が書き込まれる            → TestViewerLock_WriteAddr_WritesAddrToFile
+// - ReadViewerLockInfo で全フィールドが読み込める               → TestReadViewerLockInfo_ReadsAllFields
+// - ReadViewerLockInfo で addr なしのファイルも読み込める       → TestReadViewerLockInfo_NoAddrField
 
 import (
 	"errors"
@@ -167,5 +170,79 @@ func TestAcquireViewerLock_CreatesViewerDir(t *testing.T) {
 	}
 	if !info.IsDir() {
 		t.Errorf("expected %s to be a directory", viewerDir)
+	}
+}
+
+func TestViewerLock_WriteAddr_WritesAddrToFile(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer", "viewer.lock")
+
+	vl, err := infra.AcquireViewerLock(lockPath)
+	if err != nil {
+		t.Fatalf("AcquireViewerLock: %v", err)
+	}
+	defer vl.Release() //nolint:errcheck
+
+	addr := "127.0.0.1:8080"
+	if err := vl.WriteAddr(addr); err != nil {
+		t.Fatalf("WriteAddr: %v", err)
+	}
+
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "addr="+addr) {
+		t.Errorf("expected lock file to contain addr=%s, got:\n%s", addr, content)
+	}
+}
+
+func TestReadViewerLockInfo_ReadsAllFields(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer", "viewer.lock")
+
+	vl, err := infra.AcquireViewerLock(lockPath)
+	if err != nil {
+		t.Fatalf("AcquireViewerLock: %v", err)
+	}
+	defer vl.Release() //nolint:errcheck
+
+	addr := "127.0.0.1:9090"
+	if err := vl.WriteAddr(addr); err != nil {
+		t.Fatalf("WriteAddr: %v", err)
+	}
+
+	info, err := infra.ReadViewerLockInfo(lockPath)
+	if err != nil {
+		t.Fatalf("ReadViewerLockInfo: %v", err)
+	}
+	if info.PID != os.Getpid() {
+		t.Errorf("expected PID=%d, got %d", os.Getpid(), info.PID)
+	}
+	if time.Since(info.StartedAt) > 5*time.Second {
+		t.Errorf("expected StartedAt to be recent, got %v", info.StartedAt)
+	}
+	if info.Addr != addr {
+		t.Errorf("expected Addr=%s, got %s", addr, info.Addr)
+	}
+}
+
+func TestReadViewerLockInfo_NoAddrField(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer", "viewer.lock")
+
+	vl, err := infra.AcquireViewerLock(lockPath)
+	if err != nil {
+		t.Fatalf("AcquireViewerLock: %v", err)
+	}
+	defer vl.Release() //nolint:errcheck
+
+	info, err := infra.ReadViewerLockInfo(lockPath)
+	if err != nil {
+		t.Fatalf("ReadViewerLockInfo: %v", err)
+	}
+	if info.Addr != "" {
+		t.Errorf("expected empty Addr, got %s", info.Addr)
 	}
 }


### PR DESCRIPTION
## Summary

- `viewer.lock` に `addr`（host:port）フィールドを追加し、say/act が viewer の HTTP アドレスを自動解決できるようにした
- `say`/`act` コマンドに viewer 検出ロジックを追加: lock ファイル存在 + `/api/status` HTTP 疎通の両方が成立したら viewer 経由で再生
- viewer が起動中の場合、`POST /api/play` でテキスト・話者ID・速度・ピッチ・抑揚を送信し、viewer 側で合成・SSE 配信する
- viewer が未起動の場合は従来どおり `BeepPlayer` でローカル再生にフォールバック
- viewer の無音モード時は WARN ログを出してフォールバックせず viewer に委ねる
- `--dry-run` 時は viewer への POST もローカル再生もスキップ
- 既存の `viewer_test.go` が live viewer プロセスと競合して失敗していた問題を `tempLockResolver` で修正

## Test plan

- [ ] `go test ./...` が全件 GREEN
- [ ] `golangci-lint run` が 0 issues
- [ ] viewer 起動中に `vox-actor say "テスト"` を実行 → viewer（ブラウザ）側で音声が再生される（要 VOICEVOX 接続・手動確認）
- [ ] viewer 未起動で `vox-actor say "テスト"` → ローカルスピーカーから再生される（要 VOICEVOX 接続・手動確認）
- [ ] viewer 無音モード起動中に say/act 実行 → WARN ログが出て処理完了する（要手動確認）

Closes #418

---
🤖 Generated with [Claude Code](https://claude.ai/code)
