### PR TITLE
feat(viewer): lockfile/history の出力先をユーザースコープへ変更する

### DIFF
--- a/cmd/viewer.go
+++ b/cmd/viewer.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -115,11 +114,7 @@ func resolveViewerLockPathWith(resolver func() (string, error)) (string, error) 
 	if resolver != nil {
 		return resolver()
 	}
-	ws, err := resolveWorkspaceWithFallback()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(ws, "viewer", "viewer.lock"), nil
+	return infra.ResolveHomeViewerLockPath()
 }
 
 func resolveViewerLockPath(deps *ViewerDeps) (string, error) {

--- a/cmd/viewer_test.go
+++ b/cmd/viewer_test.go
@@ -444,7 +444,20 @@ func TestViewerCmd_EnvVarVOXSpeaker(t *testing.T) {
 	}
 }
 
-func TestResolveViewerLockPath_UsesViewerSubdir(t *testing.T) {
+func TestResolveViewerLockPath_UsesHomeDir(t *testing.T) {
+	path, err := resolveViewerLockPath(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	expected := filepath.Join(home, ".vox-actor", "viewer", "viewer.lock")
+	if path != expected {
+		t.Errorf("expected path %q, got %q", expected, path)
+	}
+}
+
+func TestResolveViewerLockPath_IgnoresVoxActorWorkspaceEnv(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("VOX_ACTOR_WORKSPACE", dir)
 
@@ -453,9 +466,8 @@ func TestResolveViewerLockPath_UsesViewerSubdir(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := filepath.Join(dir, "viewer", "viewer.lock")
-	if path != expected {
-		t.Errorf("expected path %q, got %q", expected, path)
+	if strings.Contains(path, dir) {
+		t.Errorf("resolveViewerLockPath() = %q, should not contain VOX_ACTOR_WORKSPACE dir %q", path, dir)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -230,6 +230,18 @@ vox-actor viewer --watch /extra/dir --watch-queue
 vox-actor viewer --host 0.0.0.0 --port 8080
 ```
 
+### ロックファイルと再生履歴
+
+viewer は端末内で `127.0.0.1:8080` にバインドする前提のため、排他粒度は**ユーザー（端末）スコープ**です。
+
+| 項目 | パス | 説明 |
+|---|---|---|
+| ロックファイル | `~/.vox-actor/viewer/viewer.lock` | 起動中に保持。同一ユーザーで 2 つ目の viewer 起動はエラーになる |
+| 再生履歴 | `~/.vox-actor/viewer/history/YYYY-MM-DD.jsonl` | `GET /api/history` で返す履歴の読み書き先 |
+
+- `VOX_ACTOR_WORKSPACE` はロック / 履歴の出力先に影響しません。
+- **破壊的変更**: `v0.x` 以前の `<repoRoot>/.vox-actor/viewer/history/` 配下のファイルは読み込まれません。必要な場合は `~/.vox-actor/viewer/history/` へ手動でコピーしてください。
+
 ### エラー条件
 
 | 状況 | 終了コード | エラー出力 |
@@ -238,6 +250,7 @@ vox-actor viewer --host 0.0.0.0 --port 8080
 | `--watch-queue` 指定時に git管理外かつ `VOX_ACTOR_WORKSPACE` 未設定 | 2 (`ErrUsage`) | `Error: gitコマンドが見つかりません` 等 |
 | `--port` が 1〜65535 範囲外 | 2 (`ErrUsage`) | `Error: invalid port: <n>` |
 | HTTPサーバー起動失敗（ポート占有等） | 1 | `Error: failed to start stream server: ...` |
+| 同一ユーザーで viewer が既に起動中 | 1 | `Error: viewer は既に起動中です...` |
 
 ブラウザUI・SSE・`/api/status`・無音モードの挙動は[ストリーム配信モード](#ストリーム配信モード)と同一です。
 

--- a/internal/infra/git_workspace.go
+++ b/internal/infra/git_workspace.go
@@ -65,13 +65,30 @@ func ResolveQueuePath() (string, error) {
 	return filepath.Join(workspace, "queue"), nil
 }
 
-// ResolveViewerHistoryPath はワークスペース配下の viewer 履歴ディレクトリパスを返す。
-func ResolveViewerHistoryPath() (string, error) {
-	workspace, err := ResolveWorkspacePath()
+func resolveHomeViewerDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".vox-actor", "viewer"), nil
+}
+
+// ResolveHomeViewerHistoryPath はホームスコープの viewer 履歴ディレクトリパス (~/.vox-actor/viewer/history/) を返す。
+func ResolveHomeViewerHistoryPath() (string, error) {
+	base, err := resolveHomeViewerDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(workspace, "viewer", "history"), nil
+	return filepath.Join(base, "history"), nil
+}
+
+// ResolveHomeViewerLockPath はホームスコープの viewer ロックファイルパス (~/.vox-actor/viewer/viewer.lock) を返す。
+func ResolveHomeViewerLockPath() (string, error) {
+	base, err := resolveHomeViewerDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "viewer.lock"), nil
 }
 
 // ResolveHomeAssetsPath はホームスコープのアセットルートパス (~/.vox-actor/assets/) を返す。

--- a/internal/infra/git_workspace_test.go
+++ b/internal/infra/git_workspace_test.go
@@ -259,16 +259,62 @@ func TestResolveProjectAssetsPath_RespectsVoxActorWorkspaceEnv(t *testing.T) {
 	}
 }
 
-func TestResolveViewerHistoryPath_ReturnsViewerHistoryDir_WhenEnvIsSet(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("VOX_ACTOR_WORKSPACE", dir)
-
-	got, err := ResolveViewerHistoryPath()
+func TestResolveHomeViewerHistoryPath_ReturnsDotVoxActorViewerHistoryUnderHome(t *testing.T) {
+	got, err := ResolveHomeViewerHistoryPath()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := filepath.Join(dir, "viewer", "history")
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".vox-actor", "viewer", "history")
 	if got != want {
-		t.Errorf("ResolveViewerHistoryPath() = %q, want %q", got, want)
+		t.Errorf("ResolveHomeViewerHistoryPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHomeViewerHistoryPath_IgnoresVoxActorWorkspaceEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", dir)
+
+	got, err := ResolveHomeViewerHistoryPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".vox-actor", "viewer", "history")
+	if got != want {
+		t.Errorf("ResolveHomeViewerHistoryPath() = %q, want %q (VOX_ACTOR_WORKSPACE should not affect home-scoped path)", got, want)
+	}
+	if strings.Contains(got, dir) {
+		t.Errorf("ResolveHomeViewerHistoryPath() = %q, should not contain workspace dir %q", got, dir)
+	}
+}
+
+func TestResolveHomeViewerLockPath_ReturnsDotVoxActorViewerLockUnderHome(t *testing.T) {
+	got, err := ResolveHomeViewerLockPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".vox-actor", "viewer", "viewer.lock")
+	if got != want {
+		t.Errorf("ResolveHomeViewerLockPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHomeViewerLockPath_IgnoresVoxActorWorkspaceEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", dir)
+
+	got, err := ResolveHomeViewerLockPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".vox-actor", "viewer", "viewer.lock")
+	if got != want {
+		t.Errorf("ResolveHomeViewerLockPath() = %q, want %q (VOX_ACTOR_WORKSPACE should not affect home-scoped path)", got, want)
+	}
+	if strings.Contains(got, dir) {
+		t.Errorf("ResolveHomeViewerLockPath() = %q, should not contain workspace dir %q", got, dir)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 		if len(assetsDirs) > 0 {
 			opts = append(opts, infra.WithAssetsDirs(assetsDirs))
 		}
-		if historyDir, err := infra.ResolveViewerHistoryPath(); err == nil {
+		if historyDir, err := infra.ResolveHomeViewerHistoryPath(); err == nil {
 			opts = append(opts, infra.WithHistoryDir(historyDir))
 		}
 		return infra.NewHTTPStreamPlayer(addr, staticFS, opts...)

--- a/test/e2e/helper_test.go
+++ b/test/e2e/helper_test.go
@@ -38,11 +38,7 @@ func runCLIInDir(t *testing.T, dir string, env map[string]string, args ...string
 		cmd.Dir = dir
 	}
 	if len(env) > 0 {
-		base := os.Environ()
-		for k, v := range env {
-			base = append(base, k+"="+v)
-		}
-		cmd.Env = base
+		cmd.Env = mergeEnv(os.Environ(), env)
 	}
 
 	var stdoutBuf, stderrBuf bytes.Buffer
@@ -83,6 +79,26 @@ func writeTempFile(t *testing.T, dir, name, content string) string {
 		t.Fatalf("failed to write %s: %v", path, err)
 	}
 	return path
+}
+
+// mergeEnv は base の env スライスに overrides を上書きマージして返す。
+// overrides に含まれるキーは base から除去してから末尾に追加するため、確実に上書きされる。
+func mergeEnv(base []string, overrides map[string]string) []string {
+	keys := make(map[string]bool, len(overrides))
+	for k := range overrides {
+		keys[k] = true
+	}
+	filtered := make([]string, 0, len(base))
+	for _, e := range base {
+		key, _, _ := strings.Cut(e, "=")
+		if !keys[key] {
+			filtered = append(filtered, e)
+		}
+	}
+	for k, v := range overrides {
+		filtered = append(filtered, k+"="+v)
+	}
+	return filtered
 }
 
 // countNonEmptyLines は s の空行を除いた行数を返す。

--- a/test/e2e/viewer_test.go
+++ b/test/e2e/viewer_test.go
@@ -35,13 +35,7 @@ func startViewer(t *testing.T, env map[string]string, args ...string) *viewerPro
 	ctx, cancel := context.WithCancel(context.Background())
 	fullArgs := append([]string{"viewer"}, args...)
 	cmd := exec.CommandContext(ctx, binaryPath, fullArgs...)
-	if len(env) > 0 {
-		base := os.Environ()
-		for k, v := range env {
-			base = append(base, k+"="+v)
-		}
-		cmd.Env = base
-	}
+	cmd.Env = mergeEnv(os.Environ(), env)
 
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
@@ -152,8 +146,9 @@ func TestViewerE2E_StatusEndpoint(t *testing.T) {
 	t.Parallel()
 
 	port := freePort(t)
+	homeDir := t.TempDir()
 	workspace := t.TempDir()
-	vp := startViewer(t, map[string]string{"VOX_ACTOR_WORKSPACE": workspace}, "--port", fmt.Sprintf("%d", port))
+	vp := startViewer(t, map[string]string{"HOME": homeDir, "VOX_ACTOR_WORKSPACE": workspace}, "--port", fmt.Sprintf("%d", port))
 
 	line := vp.waitForStderr("stream server listening", 10*time.Second)
 	addr := extractAddrFromLog(line)
@@ -200,9 +195,10 @@ func TestViewerE2E_WithWatchDir_WatchesDirectory(t *testing.T) {
 
 	dir := t.TempDir()
 	port := freePort(t)
+	homeDir := t.TempDir()
 	workspace := t.TempDir()
 
-	vp := startViewer(t, map[string]string{"VOX_ACTOR_WORKSPACE": workspace},
+	vp := startViewer(t, map[string]string{"HOME": homeDir, "VOX_ACTOR_WORKSPACE": workspace},
 		"--port", fmt.Sprintf("%d", port),
 		"--watch", dir,
 	)
@@ -214,11 +210,12 @@ func TestViewerE2E_WithWatchDir_WatchesDirectory(t *testing.T) {
 func TestViewerE2E_WatchQueue_StartsWatching(t *testing.T) {
 	t.Parallel()
 
+	homeDir := t.TempDir()
 	workspace := t.TempDir()
 	port := freePort(t)
 
 	vp := startViewer(t,
-		map[string]string{"VOX_ACTOR_WORKSPACE": workspace},
+		map[string]string{"HOME": homeDir, "VOX_ACTOR_WORKSPACE": workspace},
 		"--port", fmt.Sprintf("%d", port),
 		"--watch-queue",
 	)
@@ -250,8 +247,9 @@ func TestViewerE2E_InvalidPort_ReturnsUsageError(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			homeDir := t.TempDir()
 			workspace := t.TempDir()
-			_, stderr, exitCode := runCLI(t, map[string]string{"VOX_ACTOR_WORKSPACE": workspace}, "viewer", "--port", tc.port)
+			_, stderr, exitCode := runCLI(t, map[string]string{"HOME": homeDir, "VOX_ACTOR_WORKSPACE": workspace}, "viewer", "--port", tc.port)
 			if exitCode != 2 {
 				t.Fatalf("expected exit code 2 (usage error) for port %s, got %d\nstderr:\n%s",
 					tc.port, exitCode, stderr)
@@ -268,9 +266,10 @@ func TestViewerE2E_WatchNonDirectory_ReturnsUsageError(t *testing.T) {
 
 	dir := t.TempDir()
 	file := writeTempFile(t, dir, "notadir.txt", "hello")
+	homeDir := t.TempDir()
 	workspace := t.TempDir()
 
-	_, stderr, exitCode := runCLI(t, map[string]string{"VOX_ACTOR_WORKSPACE": workspace}, "viewer", "--watch", file)
+	_, stderr, exitCode := runCLI(t, map[string]string{"HOME": homeDir, "VOX_ACTOR_WORKSPACE": workspace}, "viewer", "--watch", file)
 	if exitCode != 2 {
 		t.Fatalf("expected exit code 2 for non-directory --watch, got %d\nstderr:\n%s", exitCode, stderr)
 	}
@@ -293,14 +292,15 @@ type apiHistoryResp struct {
 func TestViewerE2E_APIHistory_ReturnsUpdatedHistory(t *testing.T) {
 	t.Parallel()
 
+	homeDir := t.TempDir()
 	workspace := t.TempDir()
 	port := freePort(t)
-	historyDir := workspace + "/viewer/history"
+	historyDir := homeDir + "/.vox-actor/viewer/history"
 	if err := os.MkdirAll(historyDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll historyDir: %v", err)
 	}
 
-	vp := startViewer(t, map[string]string{"VOX_ACTOR_WORKSPACE": workspace}, "--port", fmt.Sprintf("%d", port))
+	vp := startViewer(t, map[string]string{"HOME": homeDir, "VOX_ACTOR_WORKSPACE": workspace}, "--port", fmt.Sprintf("%d", port))
 
 	line := vp.waitForStderr("stream server listening", 10*time.Second)
 	addr := extractAddrFromLog(line)


### PR DESCRIPTION
## Summary

- `ResolveHomeViewerLockPath()` / `ResolveHomeViewerHistoryPath()` を `internal/infra` に追加し、ロックファイルと再生履歴の出力先を `~/.vox-actor/viewer/` に変更した
- 旧 `ResolveViewerHistoryPath()` を削除（呼び出し元なし）
- `cmd/viewer.go` の `resolveViewerLockPathWith` を `infra.ResolveHomeViewerLockPath()` 呼び出しに変更
- `main.go` の historyDir 解決を `ResolveHomeViewerHistoryPath()` に変更
- e2e テストの env 上書きバグを修正（`mergeEnv` ヘルパーに統一し `HOME` 変数のオーバーライドを確実に）
- 全 viewer e2e テストに `HOME: homeDir` 隔離を追加（並列実行時のロック競合を排除）
- `docs/reference/cli.md` にロック / 履歴パスと排他粒度を記載

## Breaking Change

`<repoRoot>/.vox-actor/viewer/history/` 配下の既存履歴ファイルは読み込まれません。
必要な場合は手動で `~/.vox-actor/viewer/history/` 配下にコピーしてください。

## Test plan

- [ ] `go test ./...` がすべて緑（自動）
- [ ] viewer 起動時に `~/.vox-actor/viewer/viewer.lock` が作成されることを確認（手動）
- [ ] 別プロジェクトディレクトリから 2 つ目の viewer を起動すると「viewer は既に起動中です」エラーになることを確認（手動）
- [ ] viewer の再生履歴が `~/.vox-actor/viewer/history/YYYY-MM-DD.jsonl` に書き込まれることを確認（手動・VOICEVOX 接続必須）
- [ ] `VOX_ACTOR_WORKSPACE` を設定してもロック / 履歴の出力先が変わらないことを確認（手動）

Closes #420

---
🤖 Generated with [Claude Code](https://claude.ai/code)
