### PR TITLE
refactor(act): act --watch / --watch-delete を廃止し watch コマンドに一本化する

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -14,13 +14,11 @@ import (
 
 // ActDeps はactコマンドの依存を保持する。
 type ActDeps struct {
-	Reader            app.ScriptReader
-	ClientFactory     func(engineURL string) app.VoicevoxClient
-	Player            app.AudioPlayer
-	Mover             app.FileMover
-	DirWatcherFactory func(logger *slog.Logger) app.DirWatcher
-	LockPathResolver  func() (string, error)
-	Logger            *slog.Logger
+	Reader           app.ScriptReader
+	ClientFactory    func(engineURL string) app.VoicevoxClient
+	Player           app.AudioPlayer
+	LockPathResolver func() (string, error)
+	Logger           *slog.Logger
 }
 
 func makeActCmd(deps *ActDeps) *cobra.Command {
@@ -34,14 +32,26 @@ func makeActCmd(deps *ActDeps) *cobra.Command {
 			}
 			return nil
 		},
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if cmd.Flags().Changed("watch") {
+				return fmt.Errorf("%w: --watch is removed; use 'vox-actor watch <dir>' instead", ErrUsage)
+			}
+			if cmd.Flags().Changed("watch-delete") {
+				return fmt.Errorf("%w: --watch-delete is removed; use 'vox-actor watch --delete <dir>' instead", ErrUsage)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAct(cmd, args, deps)
 		},
 	}
 
 	registerCommonFlags(cmd)
-	cmd.Flags().Bool("watch", false, "ディレクトリ監視モードを有効化")
-	cmd.Flags().Bool("watch-delete", false, "ディレクトリ監視モード（処理済みファイルを削除）")
+	// --watch / --watch-delete は廃止済み。廃止フラグが渡された場合は PreRunE でエラーを返す。
+	cmd.Flags().Bool("watch", false, "")
+	cmd.Flags().Bool("watch-delete", false, "")
+	_ = cmd.Flags().MarkHidden("watch")
+	_ = cmd.Flags().MarkHidden("watch-delete")
 
 	return cmd
 }
@@ -54,28 +64,6 @@ func resolveActLockPath(deps *ActDeps) (string, error) {
 }
 
 func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
-	watch, _ := cmd.Flags().GetBool("watch")
-	watchDelete, _ := cmd.Flags().GetBool("watch-delete")
-
-	if watch && watchDelete {
-		return fmt.Errorf("%w: --watch and --watch-delete cannot be used together", ErrUsage)
-	}
-
-	if watch || watchDelete {
-		path := args[0]
-		info, err := os.Stat(path)
-		if err != nil {
-			return fmt.Errorf("%w: %v", ErrUsage, err)
-		}
-		flagName := "--watch"
-		if watchDelete {
-			flagName = "--watch-delete"
-		}
-		if !info.IsDir() {
-			return fmt.Errorf("%w: %s requires a directory path, not a file", ErrUsage, flagName)
-		}
-	}
-
 	if deps == nil || deps.ClientFactory == nil || deps.Reader == nil || deps.Player == nil {
 		return fmt.Errorf("act command dependencies are not initialized")
 	}
@@ -100,26 +88,6 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 	client := deps.ClientFactory(engineURL)
 	if client == nil {
 		return fmt.Errorf("failed to create VoicevoxClient for %s", engineURL)
-	}
-
-	if watch || watchDelete {
-		if deps.Mover == nil || deps.DirWatcherFactory == nil {
-			return fmt.Errorf("watch mode dependencies are not initialized")
-		}
-		watcher := deps.DirWatcherFactory(logger)
-		opts := []app.WatchOption{app.WithWatchLogger(logger)}
-		if watchDelete {
-			opts = append(opts, app.WithDeleteMode())
-		}
-		uc := app.NewWatchUsecase(deps.Reader, client, deps.Player, deps.Mover, watcher, opts...)
-		return uc.Run(ctx, app.WatchParams{
-			Paths:      []string{args[0]},
-			SpeakerID:  speakerID,
-			Speed:      &speed,
-			Pitch:      &pitch,
-			Intonation: &intonation,
-			DryRun:     dryRun,
-		})
 	}
 
 	if !dryRun {

--- a/cmd/act_test.go
+++ b/cmd/act_test.go
@@ -121,47 +121,11 @@ func TestActCmd_HelpContainsFlags(t *testing.T) {
 	}
 
 	output := buf.String()
-	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--watch", "--verbose", "--dry-run"}
+	flags := []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run"}
 	for _, flag := range flags {
 		if !strings.Contains(output, flag) {
 			t.Errorf("expected help output to contain '%s'", flag)
 		}
-	}
-}
-
-func TestActCmd_WatchWithFile_ReturnsError(t *testing.T) {
-	// --watchフラグ付きでファイルパスを指定した場合はエラー
-	dir := t.TempDir()
-	file := dir + "/test.txt"
-	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	rootCmd := makeRootCmd()
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"act", "--watch", file})
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when --watch is used with a file path")
-	}
-	if !errors.Is(err, ErrUsage) {
-		t.Errorf("expected ErrUsage, got: %v", err)
-	}
-}
-
-func TestActCmd_WatchFlag_DefaultFalse(t *testing.T) {
-	rootCmd := makeRootCmd()
-	actCmd := findActCmd(t, rootCmd)
-
-	watch, err := actCmd.Flags().GetBool("watch")
-	if err != nil {
-		t.Fatalf("expected --watch flag to exist, got error: %v", err)
-	}
-	if watch {
-		t.Error("expected --watch default to be false")
 	}
 }
 
@@ -238,76 +202,6 @@ func TestActCmd_CLIFlagOverridesEnvSpeaker(t *testing.T) {
 	speaker, _ := actCmd.Flags().GetInt("speaker")
 	if speaker != 7 {
 		t.Errorf("expected CLI flag to override env var, got: %d", speaker)
-	}
-}
-
-func TestActCmd_WatchDeleteFlag_DefaultFalse(t *testing.T) {
-	rootCmd := makeRootCmd()
-	actCmd := findActCmd(t, rootCmd)
-
-	watchDelete, err := actCmd.Flags().GetBool("watch-delete")
-	if err != nil {
-		t.Fatalf("expected --watch-delete flag to exist, got error: %v", err)
-	}
-	if watchDelete {
-		t.Error("expected --watch-delete default to be false")
-	}
-}
-
-func TestActCmd_WatchAndWatchDelete_ReturnsError(t *testing.T) {
-	dir := t.TempDir()
-
-	rootCmd := makeRootCmd()
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"act", "--watch", "--watch-delete", dir})
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when both --watch and --watch-delete are specified")
-	}
-	if !errors.Is(err, ErrUsage) {
-		t.Errorf("expected ErrUsage, got: %v", err)
-	}
-}
-
-func TestActCmd_WatchDeleteWithFile_ReturnsError(t *testing.T) {
-	dir := t.TempDir()
-	file := dir + "/test.txt"
-	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	rootCmd := makeRootCmd()
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
-	rootCmd.SetArgs([]string{"act", "--watch-delete", file})
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when --watch-delete is used with a file path")
-	}
-	if !errors.Is(err, ErrUsage) {
-		t.Errorf("expected ErrUsage, got: %v", err)
-	}
-}
-
-func TestActCmd_HelpContainsWatchDeleteFlag(t *testing.T) {
-	rootCmd := makeRootCmd()
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetArgs([]string{"act", "--help"})
-
-	err := rootCmd.Execute()
-	if err != nil {
-		t.Fatalf("expected no error for --help, got: %v", err)
-	}
-
-	output := buf.String()
-	if !strings.Contains(output, "--watch-delete") {
-		t.Error("expected help output to contain '--watch-delete'")
 	}
 }
 
@@ -512,6 +406,48 @@ func TestRunAct_ViewerRunning_SilentMode_Warns(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "WARN") {
 		t.Errorf("expected WARN log for silent mode, got: %s", output)
+	}
+}
+
+func TestActCmd_WatchFlag_ReturnsMigrationError(t *testing.T) {
+	dir := t.TempDir()
+
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"act", "--watch", dir})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --watch is used, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "watch <dir>") {
+		t.Errorf("expected migration guide in error, got: %v", err)
+	}
+}
+
+func TestActCmd_WatchDeleteFlag_ReturnsMigrationError(t *testing.T) {
+	dir := t.TempDir()
+
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"act", "--watch-delete", dir})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --watch-delete is used, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "watch --delete") {
+		t.Errorf("expected migration guide in error, got: %v", err)
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -139,10 +139,15 @@ vox-actor act <path>
 | `--speed` | — | `1.0` | 話速 |
 | `--pitch` | — | `0.0` | 音高 |
 | `--intonation` | — | `1.0` | 抑揚 |
-| `--watch` | — | `false` | ディレクトリ監視モードを有効化（後方互換。[plugins.md の該当節](./plugins.md#act---watch--act---watch-delete後方互換)参照） |
-| `--watch-delete` | — | `false` | ディレクトリ監視モード（処理済みファイルを削除。後方互換） |
 | `--verbose` | — | `false` | 詳細ログを出力 |
 | `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#dry-runモード)） |
+
+> **注意**: `act --watch` および `act --watch-delete` は削除されました。ディレクトリ監視は [`watch` サブコマンド](#watch-サブコマンド)を使用してください。
+>
+> | 旧コマンド | 新コマンド |
+> |---|---|
+> | `act --watch <dir>` | `watch <dir>` |
+> | `act --watch-delete <dir>` | `watch --delete <dir>` |
 
 ## `watch` サブコマンド
 
@@ -472,4 +477,4 @@ vox-actor watch --dry-run /path/to/watch-dir
 - `synthesis completed` の `wavSize` は `0`（実際には合成していないため）です
 - `playback completed` には dry-run 時のみ `text` / `speaker` / `speed` / `pitch` / `intonation` が属性として付与されます
 - 疎通確認（`HealthCheck`）も行いません
-- `watch` / `act --watch` ではディレクトリ監視・`done/` への移動／削除は通常通り実施されるため、監視フロー全体を検証できます
+- `watch` ではディレクトリ監視・`done/` への移動／削除は通常通り実施されるため、監視フロー全体を検証できます

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -124,17 +124,6 @@ echo "こんばんは" > /path/to/watch-dir/sample.txt
 
 `watch` コマンドは `Ctrl+C`（SIGINT）または SIGTERM で停止できる。
 
-### `act --watch` / `act --watch-delete`（後方互換）
-
-従来どおり `act` コマンドでも単一ディレクトリの監視が可能です。
-
-```bash
-vox-actor act --watch /path/to/watch-dir
-vox-actor act --watch-delete /path/to/watch-dir
-```
-
-`--watch` と `--watch-delete` は同時に指定できません。複数ディレクトリを同時に監視したい場合は `watch` コマンドを使ってください。
-
 ### エラーログ
 
 `direct` モードでの失敗は以下のログに追記されます（末尾200行でローテーション）。`tail -f` で確認できます。`vox-actor config path.workspace` で解決されるワークスペースルート直下に配置されます。

--- a/main.go
+++ b/main.go
@@ -65,11 +65,9 @@ func main() {
 			Cloner: &infra.GitCloner{},
 		},
 		Act: &cmd.ActDeps{
-			Reader:            reader,
-			ClientFactory:     clientFactory,
-			Player:            player,
-			Mover:             mover,
-			DirWatcherFactory: dirWatcherFactory,
+			Reader:        reader,
+			ClientFactory: clientFactory,
+			Player:        player,
 		},
 		Watch: &cmd.WatchDeps{
 			Reader:            reader,


### PR DESCRIPTION
## Summary

- `act --watch` / `act --watch-delete` フラグを廃止し、ディレクトリ監視機能を `watch` サブコマンドに一本化した
- 廃止フラグは `MarkHidden` で非表示化し、使用時は `PreRunE` で移行ガイド付きエラーを返す（`watch.go` の `--stream` / `--stream-addr` 廃止パターンと同様）
- `ActDeps` から `Mover` / `DirWatcherFactory` を削除し、`main.go` の DI を簡素化
- `docs/reference/cli.md` と `docs/reference/plugins.md` を更新

## Migration

| 旧コマンド | 新コマンド |
|---|---|
| `act --watch <dir>` | `watch <dir>` |
| `act --watch-delete <dir>` | `watch --delete <dir>` |

## Test plan

- [x] `go test ./cmd/` — 全テスト PASS
- [x] `go build .` — ビルド PASS
- [x] `gofmt -l .` — 差分なし
- [x] `golangci-lint run` — 0 issues

Closes #421

---
🤖 Generated with [Claude Code](https://claude.ai/code)
