### PR TITLE
test(e2e): act サブコマンドの e2e カバー範囲を拡充する

### DIFF
--- a/test/e2e/act_comm_test.go
+++ b/test/e2e/act_comm_test.go
@@ -1,0 +1,336 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestActE2E_RealComm_Voicevox5xx_NonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	homeDir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, stderr, exitCode := runCLI(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": srv.URL,
+	}, "act", path)
+
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit for VOICEVOX 5xx, got 0\nstderr:\n%s", stderr)
+	}
+	if strings.TrimSpace(stderr) == "" {
+		t.Error("expected non-empty stderr for VOICEVOX 5xx")
+	}
+}
+
+func TestActE2E_RealComm_VoicevoxConnFailed_NonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	homeDir := t.TempDir()
+
+	_, stderr, exitCode := runCLI(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": "http://127.0.0.1:1",
+	}, "act", path)
+
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit for VOICEVOX connection failure, got 0\nstderr:\n%s", stderr)
+	}
+	if strings.TrimSpace(stderr) == "" {
+		t.Error("expected non-empty stderr for connection failure")
+	}
+}
+
+func TestActE2E_RealComm_VoicevoxBadBody_NonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	homeDir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		case "/audio_query":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not-json"))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	_, stderr, exitCode := runCLI(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": srv.URL,
+	}, "act", path)
+
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit for VOICEVOX bad body, got 0\nstderr:\n%s", stderr)
+	}
+	if strings.TrimSpace(stderr) == "" {
+		t.Error("expected non-empty stderr for bad body")
+	}
+}
+
+func TestActE2E_Viewer_POSTsAndExitsZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := `{"text":"いちぎょうめ"}
+{"text":"にぎょうめ"}
+{"text":"さんぎょうめ"}
+`
+	path := writeTempFile(t, dir, "script.jsonl", content)
+
+	homeDir, calls := setupFakeViewer(t, false, "")
+
+	_, stderr, exitCode := runCLI(t, map[string]string{"HOME": homeDir}, "act", path)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 with viewer running, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	if *calls != 3 {
+		t.Errorf("expected 3 POSTs to /api/play (one per script line), got %d\nstderr:\n%s", *calls, stderr)
+	}
+}
+
+func TestActE2E_Viewer_POSTFailure_EarlyExit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := `{"text":"いちぎょうめ"}
+{"text":"にぎょうめ"}
+{"text":"さんぎょうめ"}
+`
+	path := writeTempFile(t, dir, "script.jsonl", content)
+
+	var callCount atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, _ *http.Request) {
+		n := callCount.Add(1)
+		if n >= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"silent":false}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	homeDir := t.TempDir()
+	writeViewerLockFile(t, homeDir, srv.Listener.Addr().String())
+
+	_, stderr, exitCode := runCLI(t, map[string]string{"HOME": homeDir}, "act", path)
+
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit when viewer POST fails, got 0\nstderr:\n%s", stderr)
+	}
+}
+
+func TestActE2E_Viewer_SilentMode_Warns(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	homeDir, _ := setupFakeViewer(t, true, "test-reason")
+
+	_, stderr, exitCode := runCLI(t, map[string]string{"HOME": homeDir}, "act", path)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 even in silent mode, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	warnLine := extractLineContaining(t, stderr, "viewer is in silent mode")
+	if !strings.HasPrefix(warnLine, "!") {
+		t.Errorf("expected WARN-level prefix ('!') on silent mode log\nline: %s", warnLine)
+	}
+}
+
+func TestActE2E_Viewer_Unreachable_FallbackFails(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	homeDir := t.TempDir()
+	writeViewerLockFile(t, homeDir, "127.0.0.1:1")
+
+	_, stderr, exitCode := runCLI(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": "http://127.0.0.1:1",
+	}, "act", "--verbose", path)
+
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit when both viewer and VOICEVOX unreachable\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "viewer not running") {
+		t.Errorf("expected 'viewer not running' debug log with --verbose\nstderr:\n%s", stderr)
+	}
+}
+
+func TestActE2E_Viewer_DryRun_NoPOST(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	homeDir, calls := setupFakeViewer(t, false, "")
+
+	_, stderr, exitCode := runCLI(t, map[string]string{"HOME": homeDir}, "act", "--dry-run", path)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 with --dry-run, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	if *calls != 0 {
+		t.Errorf("expected no POST to /api/play in --dry-run, got %d", *calls)
+	}
+}
+
+func TestActE2E_Viewer_Detected_LogMessage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	homeDir, _ := setupFakeViewer(t, false, "")
+
+	_, stderr, exitCode := runCLI(t, map[string]string{"HOME": homeDir}, "act", path)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "viewer detected") {
+		t.Errorf("expected 'viewer detected' log in stderr\nstderr:\n%s", stderr)
+	}
+}
+
+func TestActE2E_Flag_SpeakerOverridesEnv(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	_, stderr, exitCode := runCLI(t, map[string]string{"VOX_SPEAKER": "10"},
+		"act", "--dry-run", "--speaker", "5", path)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	playbackLine := extractLineContaining(t, stderr, "playback completed")
+	if !strings.Contains(playbackLine, "speaker=5") {
+		t.Errorf("expected speaker=5 in playback line (--speaker flag should override VOX_SPEAKER=10)\nline: %s", playbackLine)
+	}
+}
+
+func TestActE2E_Flag_EngineURLOverridesEnv(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	homeDir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, stderr, exitCode := runCLI(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": "http://127.0.0.1:1",
+	}, "act", "--engine-url", srv.URL, path)
+
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit, got 0\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "500") {
+		t.Errorf("expected '500' in stderr (proving --engine-url was used, not VOX_ENGINE_URL)\nstderr:\n%s", stderr)
+	}
+}
+
+func TestActE2E_Env_VOXSpeakerInvalid_DefaultFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	_, stderr, exitCode := runCLI(t, map[string]string{"VOX_SPEAKER": "not-a-number"},
+		"act", "--dry-run", path)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 when VOX_SPEAKER is invalid, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	playbackLine := extractLineContaining(t, stderr, "playback completed")
+	if !strings.Contains(playbackLine, "speaker=3") {
+		t.Errorf("expected default speaker=3 when VOX_SPEAKER=not-a-number\nline: %s", playbackLine)
+	}
+}
+
+func TestActE2E_SIGINT_DuringVoicevox_Exits(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "テスト")
+
+	homeDir := t.TempDir()
+
+	hangCh := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-hangCh
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(func() {
+		close(hangCh)
+		srv.Close()
+	})
+
+	cmd := exec.Command(binaryPath, "act", "--engine-url", srv.URL, path)
+	cmd.Env = mergeEnv(os.Environ(), map[string]string{"HOME": homeDir})
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start act: %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatalf("failed to send SIGINT: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("act did not exit within 5s after SIGINT")
+	}
+}

--- a/test/e2e/act_test.go
+++ b/test/e2e/act_test.go
@@ -200,3 +200,176 @@ func TestActE2E_JsonFile_OmittedParams_UsesCLIFlagDefaults(t *testing.T) {
 		}
 	}
 }
+
+func TestActE2E_WatchFlag_ExitCode2(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--watch", dir)
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2 for removed --watch flag, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestActE2E_WatchDeleteFlag_ExitCode2(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--watch-delete", dir)
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2 for removed --watch-delete flag, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestActE2E_Help_ExitZeroWithAllFlags(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runCLI(t, nil, "act", "--help")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 for act --help, got %d", exitCode)
+	}
+	for _, flag := range []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run"} {
+		if !strings.Contains(stdout, flag) {
+			t.Errorf("expected act --help to contain %q\nstdout:\n%s", flag, stdout)
+		}
+	}
+}
+
+func TestActE2E_EmptyFile_Txt_ExitsZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "empty.txt", "")
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--dry-run", path)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 for empty .txt, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestActE2E_EmptyFile_Jsonl_ExitsZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "empty.jsonl", "")
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--dry-run", path)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 for empty .jsonl, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestActE2E_EmptyJson_NoTextField_NonZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "empty.json", "{}")
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--dry-run", path)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit for JSON missing 'text' field, got 0\nstderr:\n%s", stderr)
+	}
+	if strings.TrimSpace(stderr) == "" {
+		t.Error("expected non-empty stderr for missing 'text' field")
+	}
+}
+
+func TestActE2E_UnsupportedExtension_ExitsZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "note.md", "# 見出し\n本文テキスト")
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--dry-run", path)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 for .md file (treated as plain text), got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestActE2E_JsonlFile_PerLineParams_Reflected(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := `{"text":"いちぎょうめ","speaker":11,"speedScale":1.2,"pitchScale":0.05,"intonationScale":1.3}
+{"text":"にぎょうめ","speaker":7}
+`
+	path := writeTempFile(t, dir, "params.jsonl", content)
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--dry-run", path)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	lines := strings.Split(stderr, "\n")
+	var playbackLines []string
+	for _, l := range lines {
+		if strings.Contains(l, "playback completed") {
+			playbackLines = append(playbackLines, l)
+		}
+	}
+	if len(playbackLines) != 2 {
+		t.Fatalf("expected 2 playback lines, got %d\nstderr:\n%s", len(playbackLines), stderr)
+	}
+	for _, want := range []string{"speaker=11", "speed=1.2", "pitch=0.05", "intonation=1.3"} {
+		if !strings.Contains(playbackLines[0], want) {
+			t.Errorf("expected first line to contain %q\nline: %s", want, playbackLines[0])
+		}
+	}
+	if !strings.Contains(playbackLines[1], "speaker=7") {
+		t.Errorf("expected second line to contain speaker=7\nline: %s", playbackLines[1])
+	}
+}
+
+func TestActE2E_JsonlFile_EmptyLines_Skipped(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := `{"text":"いちぎょうめ"}
+
+{"text":"さんぎょうめ"}
+`
+	path := writeTempFile(t, dir, "with_empty.jsonl", content)
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--dry-run", path)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	if got := strings.Count(stderr, "playback completed"); got != 2 {
+		t.Errorf("expected 2 'playback completed' (empty line skipped), got %d\nstderr:\n%s", got, stderr)
+	}
+}
+
+func TestActE2E_Verbose_ShowsDebugLogs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := writeTempFile(t, dir, "script.txt", "デバッグテスト")
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--dry-run", "--verbose", path)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	debugLine := extractLineContaining(t, stderr, "act starting")
+	if !strings.Contains(debugLine, "path=") {
+		t.Errorf("expected debug line to contain 'path='\nline: %s", debugLine)
+	}
+}
+
+func TestActE2E_Dir_ScriptsLoadedLog(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeTempFile(t, dir, "a.txt", "エー")
+	writeTempFile(t, dir, "b.txt", "ビー")
+
+	_, stderr, exitCode := runCLI(t, nil, "act", "--dry-run", dir)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "scripts loaded") {
+		t.Errorf("expected 'scripts loaded' log in stderr\nstderr:\n%s", stderr)
+	}
+}


### PR DESCRIPTION
## Summary

`act` サブコマンドの e2e テストを A〜G の7グループで拡充する（Issue #424）。

### 追加したテスト

| グループ | ファイル | テスト数 |
|---|---|---|
| A: 実通信パス | `act_comm_test.go` | 3 |
| B: viewer 連携 | `act_comm_test.go` | 6 |
| C: 廃止フラグ | `act_test.go` | 2 |
| D: フラグ / env 優先順位 | `act_comm_test.go` | 3 |
| E: ヘルプ / 境界・異常系 | `act_test.go` | 7 |
| F: シグナル / ライフサイクル | `act_comm_test.go` | 1 |
| G: ログ内容 | `act_test.go` | 2 |

### 主な検証内容

- **A**: VOICEVOX 5xx / 接続失敗 / 異常レスポンス時の非0 exit
- **B**: viewer 起動中の行ごと POST・失敗早期終了・silent WARN・到達不可フォールバック・dry-run での POST なし・検出ログ
- **C**: `--watch` / `--watch-delete` 廃止フラグで exit 2（#425 対応済み）
- **D**: `--speaker` / `--engine-url` フラグが env を上書き・不正 VOX_SPEAKER のデフォルト fallback
- **E**: `--help` 全フラグ表示・空ファイル（.txt/.jsonl）・`{}` JSON・未対応拡張子（.md = プレーンテキスト扱い）・.jsonl 行ごとパラメータ override・空行スキップ
- **F**: VOICEVOX 通信中の SIGINT で 5 秒以内に graceful exit
- **G**: `--verbose` で `act starting path=` DEBUG ログ・ディレクトリ読込時の `scripts loaded` ログ

### 既存テストへの影響

既存の `--dry-run` 系 9 テスト（`act_test.go` 冒頭部）はそのまま維持。

## Test plan

- [x] `go test -tags=e2e ./test/e2e/...` で全テスト通過確認済み（509 行追加、0 削除）
- [ ] CI の e2e テストジョブが通ることを確認

Closes #424

---
🤖 Generated with [Claude Code](https://claude.ai/code)
