### PR TITLE
build(goreleaser): Linux arm64 向けリリースバイナリを追加する

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install ALSA development libraries (amd64 + arm64) and cross compiler
         run: |
           sudo dpkg --add-architecture arm64
+          sudo sed -i 's/^Types: deb$/Types: deb\nArchitectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources
+          printf 'Types: deb\nURIs: http://ports.ubuntu.com/ubuntu-ports\nSuites: noble noble-updates noble-backports noble-security\nComponents: main restricted universe multiverse\nArchitectures: arm64\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' \
+            | sudo tee /etc/apt/sources.list.d/ubuntu-ports-arm64.sources
           sudo apt-get update
           sudo apt-get install -y \
             libasound2-dev \

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,8 +22,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.checkout-ref || github.ref }}
 
-      - name: Install ALSA development library
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - name: Install ALSA development libraries (amd64 + arm64) and cross compiler
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2-dev \
+            libasound2-dev:arm64 \
+            gcc-aarch64-linux-gnu
 
       - uses: actions/setup-go@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,8 +11,14 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     ldflags:
       - -s -w -X github.com/canpok1/vox-actor/cmd.version={{.Version}}
+    overrides:
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=aarch64-linux-gnu-gcc
 
   - id: darwin
     env:


### PR DESCRIPTION
## Summary

- `.goreleaser.yaml` の linux ビルドに `arm64` を追加し、`overrides` で arm64 専用のクロスコンパイラ（`CC=aarch64-linux-gnu-gcc`）を指定
- `.github/workflows/goreleaser.yml` の ALSA インストールステップを更新し、multiarch（arm64）パッケージとクロスコンパイラ（`gcc-aarch64-linux-gnu`）をインストールするよう変更

## Test Plan

- [ ] PR の `goreleaser` ワークフロー（snapshot 経路）が成功すること
- [ ] CI 成功後、`dist/` に `linux_linux_arm64*/vox-actor` が生成されていること（`file` コマンドで `ELF 64-bit LSB ... ARM aarch64` と判定）
- [ ] （手動・CI対象外）arm64 Linux 実機（例: Raspberry Pi 4/5）で配布 tar.gz を展開し、`./vox-actor --version` および音声再生の最低限の動作確認

Closes #444

---
🤖 Generated with [Claude Code](https://claude.ai/code)
