### PR TITLE
test(e2e): watch サブコマンドの e2e カバー範囲を拡充する

### DIFF
--- a/test/e2e/watch_comm_test.go
+++ b/test/e2e/watch_comm_test.go
@@ -1,0 +1,174 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// minimalSilentWAV は beep/wav が解析できる最小の無音 WAV バイト列を返す。
+// 音声再生に失敗しても watch がファイルを done/ に移動することを確認するために使う。
+func minimalSilentWAV() []byte {
+	var buf bytes.Buffer
+	buf.WriteString("RIFF")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(36))
+	buf.WriteString("WAVE")
+	buf.WriteString("fmt ")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(16))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1))
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(24000))
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(48000))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(2))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(16))
+	buf.WriteString("data")
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(0))
+	return buf.Bytes()
+}
+
+func TestWatchE2E_RealComm_HealthCheck5xx_ExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	homeDir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	wp := startWatch(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": srv.URL,
+	}, dir)
+
+	select {
+	case <-wp.done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("watch did not exit within 10s after HealthCheck 5xx")
+	}
+
+	exitCode, _ := wp.stop(3 * time.Second)
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit for HealthCheck 5xx, got 0\nstderr:\n%s", wp.stderr.String())
+	}
+	if strings.TrimSpace(wp.stderr.String()) == "" {
+		t.Error("expected non-empty stderr for HealthCheck 5xx")
+	}
+}
+
+func TestWatchE2E_RealComm_HealthCheckConnFailed_ExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	homeDir := t.TempDir()
+
+	wp := startWatch(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": "http://127.0.0.1:1",
+	}, dir)
+
+	select {
+	case <-wp.done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("watch did not exit within 10s after HealthCheck connection failure")
+	}
+
+	exitCode, _ := wp.stop(3 * time.Second)
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit for HealthCheck connection failure, got 0\nstderr:\n%s", wp.stderr.String())
+	}
+}
+
+func TestWatchE2E_RealComm_QueryFails_MonitoringContinues(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	homeDir := t.TempDir()
+
+	// HealthCheck が通った後に query/synthesis が 500 を返す場合、エラーを記録して監視継続する
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	wp := startWatch(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": srv.URL,
+	}, dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	src1 := writeTempFile(t, dir, "a.txt", "テスト1")
+	wp.waitForStderr("create query error", 10*time.Second)
+	assertMovedToDone(t, src1, 5*time.Second)
+
+	src2 := writeTempFile(t, dir, "b.txt", "テスト2")
+	wp.waitForStderr("create query error", 10*time.Second)
+	assertMovedToDone(t, src2, 5*time.Second)
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_RealComm_SynthPipeline_Invoked(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	homeDir := t.TempDir()
+
+	var queryCalls, synthCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			w.WriteHeader(http.StatusOK)
+		case "/audio_query":
+			queryCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "/synthesis":
+			synthCalls.Add(1)
+			w.Header().Set("Content-Type", "audio/wav")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(minimalSilentWAV())
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	wp := startWatch(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": srv.URL,
+	}, dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	writeTempFile(t, dir, "a.txt", "テスト")
+
+	// /audio_query と /synthesis の各エンドポイントが呼ばれることを確認する。
+	// CI環境では音声再生がブロックするため、ファイル移動ではなくAPI呼び出しで検証する。
+	waitUntil(t, 10*time.Second, "/audio_query should be called at least once",
+		func() bool { return queryCalls.Load() >= 1 })
+	waitUntil(t, 10*time.Second, "/synthesis should be called at least once",
+		func() bool { return synthCalls.Load() >= 1 })
+
+	stderr := wp.stderr.String()
+	if strings.Contains(stderr, "create query error") {
+		t.Errorf("unexpected 'create query error': synthesis pipeline should have succeeded\nstderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "synthesize error") {
+		t.Errorf("unexpected 'synthesize error': synthesis pipeline should have succeeded\nstderr:\n%s", stderr)
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}

--- a/test/e2e/watch_test.go
+++ b/test/e2e/watch_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -299,4 +301,494 @@ func TestWatchE2E_NoArgs_NonZero(t *testing.T) {
 	if exitCode == 0 {
 		t.Fatalf("expected non-zero exit code for 'watch' without args, got 0\nstderr:\n%s", stderr)
 	}
+}
+
+// waitForStderrCount は stderr に needle を含む行が count 個以上出るまで待機する。
+func (w *watchProcess) waitForStderrCount(needle string, count int, timeout time.Duration) {
+	w.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		found := 0
+		for _, line := range w.stderr.snapshot() {
+			if strings.Contains(line, needle) {
+				found++
+			}
+		}
+		if found >= count {
+			return
+		}
+		select {
+		case <-w.done:
+			w.t.Fatalf("watch exited before %q appeared %d time(s) (found %d): err=%v\nstderr:\n%s",
+				needle, count, found, w.waitErr, w.stderr.String())
+		default:
+		}
+		if time.Now().After(deadline) {
+			w.t.Fatalf("timed out after %s waiting for stderr to contain %q %d time(s)\nstderr:\n%s",
+				timeout, needle, count, w.stderr.String())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// --- Group B: ファイル形式ごとの処理 ---
+
+func TestWatchE2E_TxtFile_DryRun_SingleScript(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	src := writeTempFile(t, dir, "a.txt", "いちぎょうめ\nにぎょうめ\n")
+	wp.waitForStderr("playback completed", 10*time.Second)
+
+	// .txt はファイル全体が1スクリプト → playback completed は1回
+	if got := strings.Count(wp.stderr.String(), "playback completed"); got != 1 {
+		t.Errorf("expected 1 'playback completed' for .txt, got %d\nstderr:\n%s", got, wp.stderr.String())
+	}
+	assertMovedToDone(t, src, 3*time.Second)
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_JsonFile_DryRun_OverrideParams(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	content := `{"text":"こんにちは","speaker":11,"speedScale":1.2,"pitchScale":0.1,"intonationScale":1.5}`
+	src := writeTempFile(t, dir, "b.json", content)
+
+	line := wp.waitForStderr("playback completed", 10*time.Second)
+	wants := []string{"text=こんにちは", "speaker=11", "speed=1.2", "pitch=0.1", "intonation=1.5"}
+	for _, w := range wants {
+		if !strings.Contains(line, w) {
+			t.Errorf("expected playback line to contain %q\nline: %s", w, line)
+		}
+	}
+	assertMovedToDone(t, src, 3*time.Second)
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_JsonlFile_DryRun_MultipleScripts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	content := `{"text":"いちぎょうめ"}` + "\n" +
+		`{"text":"にぎょうめ"}` + "\n" +
+		`{"text":"さんぎょうめ"}` + "\n"
+	src := writeTempFile(t, dir, "c.jsonl", content)
+
+	wp.waitForStderrCount("playback completed", 3, 15*time.Second)
+	assertMovedToDone(t, src, 3*time.Second)
+
+	stderr := wp.stderr.String()
+	i1 := strings.Index(stderr, "text=いちぎょうめ")
+	i2 := strings.Index(stderr, "text=にぎょうめ")
+	i3 := strings.Index(stderr, "text=さんぎょうめ")
+	if i1 < 0 || i2 < 0 || i3 < 0 {
+		t.Fatalf("expected all three texts in stderr\nstderr:\n%s", stderr)
+	}
+	if i1 >= i2 || i2 >= i3 {
+		t.Errorf("expected texts in order いち→に→さん, positions %d,%d,%d", i1, i2, i3)
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_InvalidJson_ErrorThenContinues(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	invalidSrc := writeTempFile(t, dir, "a.json", "not-valid-json")
+	wp.waitForStderr("read error", 10*time.Second)
+	assertMovedToDone(t, invalidSrc, 3*time.Second)
+
+	// 有効ファイルも処理できること（監視継続確認）
+	validSrc := writeTempFile(t, dir, "b.txt", "ただしいてきすと")
+	wp.waitForStderr("playback completed", 10*time.Second)
+	assertMovedToDone(t, validSrc, 3*time.Second)
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_UnsupportedExtension_ProcessedAsText(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	src := writeTempFile(t, dir, "readme.md", "マークダウンのテキスト")
+	wp.waitForStderr("playback completed", 10*time.Second)
+	assertMovedToDone(t, src, 3*time.Second)
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_EmptyFile_MovedToDone(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	src := writeTempFile(t, dir, "empty.txt", "")
+	assertMovedToDone(t, src, 10*time.Second)
+
+	if strings.Contains(wp.stderr.String(), "playback completed") {
+		t.Errorf("expected no 'playback completed' for empty file\nstderr:\n%s", wp.stderr.String())
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+// --- Group C: 複数ディレクトリ並列監視 ---
+
+func TestWatchE2E_MultipleDir_WatchingLogs(t *testing.T) {
+	t.Parallel()
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir1, dir2)
+
+	wp.waitForStderrCount("watching directory", 2, 10*time.Second)
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_MultipleDir_BothProcessed(t *testing.T) {
+	t.Parallel()
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir1, dir2)
+	wp.waitForStderrCount("watching directory", 2, 10*time.Second)
+
+	src1 := writeTempFile(t, dir1, "a.txt", "でぃあいりーわん")
+	src2 := writeTempFile(t, dir2, "b.txt", "でぃれくとりーつー")
+
+	wp.waitForStderrCount("playback completed", 2, 15*time.Second)
+	assertMovedToDone(t, src1, 3*time.Second)
+	assertMovedToDone(t, src2, 3*time.Second)
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_MultipleDir_EachDoneCreated(t *testing.T) {
+	t.Parallel()
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir1, dir2)
+	wp.waitForStderrCount("watching directory", 2, 10*time.Second)
+
+	src1 := writeTempFile(t, dir1, "a.txt", "でぃあいりーわん")
+	src2 := writeTempFile(t, dir2, "b.txt", "でぃれくとりーつー")
+
+	assertMovedToDone(t, src1, 10*time.Second)
+	assertMovedToDone(t, src2, 10*time.Second)
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+// --- Group D: 引数バリデーション ---
+
+func TestWatchE2E_FilePath_ExitCode2(t *testing.T) {
+	t.Parallel()
+	filePath := writeTempFile(t, t.TempDir(), "notadir.txt", "")
+
+	_, stderr, exitCode := runCLI(t, nil, "watch", "--dry-run", filePath)
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2 for file path, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestWatchE2E_NonExistentPath_ExitCode2(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runCLI(t, nil, "watch", "--dry-run", "/nonexistent/path/12345")
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2 for nonexistent path, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestWatchE2E_MultiplePathsOneMissing_ExitCode2(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, stderr, exitCode := runCLI(t, nil, "watch", "--dry-run", dir, "/nonexistent/path/12345")
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2 when one of multiple paths is missing, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+// --- Group E: フラグと環境変数の優先順位 ---
+
+func TestWatchE2E_Flag_SpeakerOverridesEnv(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, map[string]string{"VOX_SPEAKER": "10"}, "--dry-run", "--speaker", "5", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	writeTempFile(t, dir, "a.txt", "すぴーかーてすと")
+	line := wp.waitForStderr("playback completed", 10*time.Second)
+
+	if !strings.Contains(line, "speaker=5") {
+		t.Errorf("expected speaker=5 (--speaker flag overrides VOX_SPEAKER=10)\nline: %s", line)
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_Flag_EngineURLOverridesEnv(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	homeDir := t.TempDir()
+
+	// --engine-url に 5xx サーバーを指定。VOX_ENGINE_URL は到達不能アドレス
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	wp := startWatch(t, map[string]string{
+		"HOME":           homeDir,
+		"VOX_ENGINE_URL": "http://127.0.0.1:1",
+	}, "--engine-url", srv.URL, dir)
+
+	select {
+	case <-wp.done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("watch did not exit within 10s")
+	}
+
+	exitCode, _ := wp.stop(3 * time.Second)
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit (proving --engine-url was used, not VOX_ENGINE_URL)\nstderr:\n%s", wp.stderr.String())
+	}
+	// 5xx サーバーに到達できたことを確認（接続失敗ではなく HTTP エラー）
+	if !strings.Contains(wp.stderr.String(), "500") {
+		t.Errorf("expected '500' in stderr (proving --engine-url was used)\nstderr:\n%s", wp.stderr.String())
+	}
+}
+
+func TestWatchE2E_Env_VOXSpeakerInvalid_DefaultFallback(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, map[string]string{"VOX_SPEAKER": "not-a-number"}, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	writeTempFile(t, dir, "a.txt", "でふぉるとすぴーかー")
+	line := wp.waitForStderr("playback completed", 10*time.Second)
+
+	if !strings.Contains(line, "speaker=3") {
+		t.Errorf("expected default speaker=3 when VOX_SPEAKER=not-a-number\nline: %s", line)
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_JsonlPerLineOverride_DryRun(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	content := `{"text":"てきすと","speaker":11,"speedScale":1.2,"pitchScale":0.1,"intonationScale":1.5}` + "\n"
+	writeTempFile(t, dir, "a.jsonl", content)
+
+	line := wp.waitForStderr("playback completed", 10*time.Second)
+	wants := []string{"speaker=11", "speed=1.2", "pitch=0.1", "intonation=1.5"}
+	for _, w := range wants {
+		if !strings.Contains(line, w) {
+			t.Errorf("expected playback line to contain %q\nline: %s", w, line)
+		}
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+// --- Group F: ライフサイクル / シグナル ---
+
+func TestWatchE2E_SIGINT_GracefulShutdown(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	if err := wp.cmd.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatalf("failed to send SIGINT: %v", err)
+	}
+
+	select {
+	case <-wp.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watch did not exit within 5s after SIGINT")
+	}
+
+	exitCode, _ := wp.stop(3 * time.Second)
+	if exitCode != 0 {
+		t.Errorf("expected clean exit (0) after SIGINT, got %d\nstderr:\n%s", exitCode, wp.stderr.String())
+	}
+}
+
+// --- Group G: ヘルプ / 境界 ---
+
+func TestWatchE2E_Help_ExitZero(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runCLI(t, nil, "watch", "--help")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 for 'watch --help', got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	wants := []string{"--delete", "--queue", "--dry-run", "--speaker", "--engine-url"}
+	for _, w := range wants {
+		if !strings.Contains(stdout, w) {
+			t.Errorf("expected help to contain %q\nstdout:\n%s", w, stdout)
+		}
+	}
+}
+
+func TestWatchE2E_DoneCollision_TimestampRename(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	doneDir := filepath.Join(dir, "done")
+	if err := os.MkdirAll(doneDir, 0o755); err != nil {
+		t.Fatalf("failed to create done/: %v", err)
+	}
+	existingDone := writeTempFile(t, doneDir, "a.txt", "きぞんのふぁいる")
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	src := writeTempFile(t, dir, "a.txt", "あたらしいふぁいる")
+	wp.waitForStderr("playback completed", 10*time.Second)
+
+	waitUntil(t, 5*time.Second, "src should be gone", func() bool {
+		_, err := os.Stat(src)
+		return os.IsNotExist(err)
+	})
+
+	if _, err := os.Stat(existingDone); err != nil {
+		t.Errorf("expected existing done/a.txt to remain: %v", err)
+	}
+	entries, err := os.ReadDir(doneDir)
+	if err != nil {
+		t.Fatalf("failed to read done/: %v", err)
+	}
+	if len(entries) < 2 {
+		t.Errorf("expected at least 2 files in done/ (original + timestamp-renamed), got %d", len(entries))
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_DoneDir_NotMonitored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	doneDir := filepath.Join(dir, "done")
+	if err := os.MkdirAll(doneDir, 0o755); err != nil {
+		t.Fatalf("failed to create done/: %v", err)
+	}
+	doneFile := writeTempFile(t, doneDir, "existing.txt", "どんのない")
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	time.Sleep(2 * time.Second)
+
+	if _, err := os.Stat(doneFile); err != nil {
+		t.Errorf("expected done/existing.txt to remain untouched: %v", err)
+	}
+	if strings.Contains(wp.stderr.String(), "file detected") {
+		t.Errorf("watch should not detect files inside done/\nstderr:\n%s", wp.stderr.String())
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+// --- Group H: ログ内容 ---
+
+func TestWatchE2E_Verbose_DebugLogs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", "--verbose", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	writeTempFile(t, dir, "a.txt", "ばーぼーすてすと")
+	wp.waitForStderr("playback completed", 10*time.Second)
+
+	if !strings.Contains(wp.stderr.String(), "watch mode starting") {
+		t.Errorf("expected DEBUG log 'watch mode starting' with --verbose\nstderr:\n%s", wp.stderr.String())
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_WatchingDirectoryLog(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", dir)
+	line := wp.waitForStderr("watching directory", 5*time.Second)
+
+	if !strings.Contains(line, dir) {
+		t.Errorf("expected 'watching directory' log to contain dir path\nline: %s", line)
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+func TestWatchE2E_FileDetectedLog(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	wp := startWatch(t, nil, "--dry-run", "--verbose", dir)
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	writeTempFile(t, dir, "detected.txt", "ふぁいるけんちてすと")
+	line := wp.waitForStderr("file detected", 10*time.Second)
+
+	if !strings.Contains(line, "detected.txt") {
+		t.Errorf("expected 'file detected' log to contain filename\nline: %s", line)
+	}
+
+	wp.assertCleanExit(3 * time.Second)
+}
+
+// --- Group I: --queue 系の追加検証 ---
+
+func TestWatchE2E_Queue_Delete_Combination(t *testing.T) {
+	t.Parallel()
+	workspace := t.TempDir()
+	env := map[string]string{"VOX_ACTOR_WORKSPACE": workspace}
+
+	wp := startWatch(t, env, "--queue", "--delete", "--dry-run")
+	wp.waitForStderr("watching directory", 5*time.Second)
+
+	queueDir := filepath.Join(workspace, "queue")
+	src := writeTempFile(t, queueDir, "a.txt", "きゅーでりーとてすと")
+	wp.waitForStderr("playback completed", 10*time.Second)
+
+	waitUntil(t, 3*time.Second, "src should be deleted", func() bool {
+		_, err := os.Stat(src)
+		return os.IsNotExist(err)
+	})
+	doneDir := filepath.Join(queueDir, "done")
+	if _, err := os.Stat(doneDir); !os.IsNotExist(err) {
+		t.Errorf("expected done/ NOT to be created in --delete mode")
+	}
+
+	wp.assertCleanExit(3 * time.Second)
 }


### PR DESCRIPTION
## Summary

- `watch_comm_test.go` を新規追加（Group A: fake VOICEVOX を使った実通信パスの検証）
- `watch_test.go` に Groups B〜I の e2e テストを28件追加
- 既存の dry-run 系 5 テストはそのまま維持

## 追加テスト一覧

| グループ | 内容 | テスト数 |
|---|---|---|
| A. 実通信パス | HealthCheck 5xx/接続失敗/query 失敗後監視継続/合成パイプライン呼び出し | 4 |
| B. ファイル形式 | .txt/.json/.jsonl/不正JSON/未対応拡張子/空ファイル | 6 |
| C. 複数ディレクトリ | watching ログ×2/両ディレクトリ処理/各 done/ 作成 | 3 |
| D. 引数バリデーション | ファイルパス/存在しないパス/複数パスの1つが欠け | 3 |
| E. フラグ/env 優先順位 | --speaker 上書き/--engine-url 上書き/VOX_SPEAKER 不正値/jsonl 行単位 override | 4 |
| F. シグナル | SIGINT でグレースフルシャットダウン | 1 |
| G. ヘルプ/境界 | --help フラグ一覧/done/ 衝突タイムスタンプリネーム/done/ 監視対象外 | 3 |
| H. ログ内容 | --verbose DEBUG ログ/watching directory パス/file detected パス | 3 |
| I. --queue 系 | --queue + --delete 組み合わせ | 1 |

## 実装メモ

- CI 環境では oto バックエンドがオーディオデバイスなしで `speaker.Play` がブロックする（コールバックが発火しない）ため、Group A の「合成パイプライン成功」テストはファイル移動ではなく `/audio_query` `/synthesis` への HTTP 呼び出し回数でアサートする方式を採用

Closes #426

---
🤖 Generated with [Claude Code](https://claude.ai/code)
