### PR TITLE
test(e2e): config サブコマンドの軽微な未カバー部分を補完する

### DIFF
--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -231,3 +231,30 @@ func TestConfigE2E_GitNotFound_ExitCode1(t *testing.T) {
 		t.Error("expected non-empty stderr for git-not-found")
 	}
 }
+
+func TestConfigE2E_NoArgs_ExitCode2(t *testing.T) {
+	_, stderr, exitCode := runCLI(t, nil, "config")
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestConfigE2E_TooManyArgs_ExitCode2(t *testing.T) {
+	_, stderr, exitCode := runCLI(t, nil, "config", "path.queue", "extra")
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestConfigE2E_Help_ExitZeroWithUsage(t *testing.T) {
+	stdout, _, exitCode := runCLI(t, nil, "config", "--help")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 for config --help, got %d", exitCode)
+	}
+	for _, want := range []string{"config", "key", "Usage:"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("expected config --help to contain %q\nstdout:\n%s", want, stdout)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`config` サブコマンドの e2e テストに以下の3ケースを追加する。

- 引数0個（`config` のみ）→ exit 2
- 引数2個以上（`config path.queue extra`）→ exit 2
- `config --help` → exit 0 + ヘルプ出力に "Usage:" / "config" / "key" を含む

既存の11テストはそのまま維持。

## Test plan

- [x] `go test -tags=e2e ./test/e2e/... -run TestConfig` で14テスト全 PASS を確認
- [x] `go test -tags=e2e ./test/e2e/...` で全体 PASS を確認

Closes #428

---
🤖 Generated with [Claude Code](https://claude.ai/code)
