### PR TITLE
test(e2e): audio-check サブコマンドの引数バリデーション e2e を追加する

### DIFF
--- a/test/e2e/audio_check_test.go
+++ b/test/e2e/audio_check_test.go
@@ -1,0 +1,40 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAudioCheckE2E_UnexpectedArg_ExitCode2(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, exitCode := runCLI(t, nil, "audio-check", "unexpected")
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestAudioCheckE2E_UnknownFlag_NonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	_, _, exitCode := runCLI(t, nil, "audio-check", "--bogus")
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for unknown flag, got 0")
+	}
+}
+
+func TestAudioCheckE2E_Help_ExitZeroWithUsage(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, exitCode := runCLI(t, nil, "audio-check", "--help")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 for audio-check --help, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	for _, want := range []string{"audio-check", "--verbose"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("expected audio-check --help to contain %q\nstdout:\n%s", want, stdout)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `test/e2e/audio_check_test.go` を新規追加し、`audio-check` サブコマンドの引数バリデーション e2e テストを3件追加

| テスト | 内容 |
|---|---|
| `TestAudioCheckE2E_UnexpectedArg_ExitCode2` | 位置引数あり → exit 2 |
| `TestAudioCheckE2E_UnknownFlag_NonZeroExit` | 未知フラグ → non-zero exit |
| `TestAudioCheckE2E_Help_ExitZeroWithUsage` | `--help` → exit 0 + `audio-check`/`--verbose` がヘルプに含まれる |

**実装の注意点:**  
Issue では `--bogus`（未知フラグ）を exit 2 と記載していたが、cobra の unknown flag error は `ErrUsage` にラップされないため exit 1 となる（他コマンドも同様）。既存の `TestCLIUnknownFlag_NonZero` パターンに合わせて non-zero チェックとした。

Closes #429

---
🤖 Generated with [Claude Code](https://claude.ai/code)
