### PR TITLE
docs: Linux 実行に必要な libasound2 ランタイム依存を README に明記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 - [VOICEVOXエンジン](https://voicevox.hiroshiba.jp/) が起動していること（デフォルト: `http://localhost:50021`）
   - インストーラー版: [公式サイト](https://voicevox.hiroshiba.jp/)からダウンロードしてインストール後、アプリを起動する
   - Docker版: `docker run --rm -p 50021:50021 voicevox/voicevox_engine:latest`
+- **Linux のみ**: ALSA ランタイムライブラリ（`libasound2` / `alsa-lib`）がインストールされていること
+  - Debian/Ubuntu: `sudo apt install libasound2` （Ubuntu 24.04 Noble 以降は `sudo apt install libasound2t64`）
+  - RHEL/Fedora 系: `sudo dnf install alsa-lib`
 - Go 1.26.1 以上（ソースからビルドする場合のみ）
 
 ## 🚀 クイックスタート
@@ -130,6 +133,8 @@ export VOX_ACTOR_MONOLOGUE_MODE=file
 
    [GitHub Releases](https://github.com/canpok1/vox-actor/releases)からビルド済みバイナリをダウンロードして配置します。
 
+   > **Linux ユーザーへ**: バイナリは ALSA ランタイムに動的リンクされています。実行前に `libasound2`（Ubuntu 24.04 以降は `libasound2t64`）または `alsa-lib`（RHEL/Fedora 系）をインストールしてください。詳細は[前提条件](#-前提条件)を参照してください。
+
    ```bash
    # Linux (x86_64) の場合
    curl -fLo vox-actor.tar.gz https://github.com/canpok1/vox-actor/releases/latest/download/vox-actor_Linux_x86_64.tar.gz
@@ -164,6 +169,22 @@ export VOX_ACTOR_MONOLOGUE_MODE=file
 - [CLIリファレンス](./docs/reference/cli.md) — `say` / `script` / `act` / `watch` サブコマンドの詳細
 - [プラグイン／スキルリファレンス](./docs/reference/plugins.md) — 対応キャラクター、スキルごとの仕様、再生モード、音声デバイス利用不可環境のセットアップ
 - [開発者向け情報](./docs/development/contributing.md) — ビルド・テスト・Lint等のコマンド、レイヤー構成と責務ルール
+
+## 🔧 トラブルシューティング
+
+### Linux: `error while loading shared libraries: libasound.so.2`
+
+```
+vox-actor: error while loading shared libraries: libasound.so.2: cannot open shared object file: No such file or directory
+```
+
+Linux 向けバイナリは ALSA（Advanced Linux Sound Architecture）ランタイムに動的リンクされています。上記エラーが出た場合は ALSA ランタイムをインストールしてください。
+
+| ディストリビューション | コマンド |
+|---|---|
+| Debian/Ubuntu（Ubuntu 23.10 以前） | `sudo apt install libasound2` |
+| Ubuntu 24.04 Noble 以降 | `sudo apt install libasound2t64` |
+| RHEL/Fedora 系 | `sudo dnf install alsa-lib` |
 
 ## ライセンス
 


### PR DESCRIPTION
## 概要

Linux 環境でリリースバイナリ実行時に `libasound.so.2` が見つからずエラー終了する問題について、Issue #450 の案A（README 明記）を実施しました。

## 変更内容

- `## 🧩 前提条件` に Linux では ALSA ランタイム（`libasound2` / `alsa-lib`）が必要な旨を追記
- `## 📦 インストール方法` のバイナリダウンロード手順に Linux ユーザー向け注意書きを追加
- `## 🔧 トラブルシューティング` セクションを新設し、エラーメッセージと対処コマンド表を記載

## 確認した受け入れ条件

- [x] `README.md` の前提条件およびインストール手順に、Linux ランタイムで `libasound2` 系パッケージが必要である旨が記載されている
- [x] 主要ディストリ（Debian/Ubuntu, RHEL/Fedora 系）でのインストールコマンド例が示されている
- [x] `error while loading shared libraries: libasound.so.2 ...` のエラーメッセージと対処を README から検索できる（トラブルシューティングセクション）

## テスト計画

- README の表示確認（GitHub 上でレンダリング確認）
- アンカーリンク `#-前提条件` が正しくジャンプすること

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
