### PR TITLE
fix: git管理外でのワークスペースパスを {cwd}/.vox-actor に統一する

### DIFF
--- a/cmd/assets_download.go
+++ b/cmd/assets_download.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var resolveWorkspaceFunc = resolveWorkspaceWithFallback
+var resolveWorkspaceFunc = infra.ResolveWorkspacePath
 var resolveHomeAssetsFunc = infra.ResolveHomeAssetsPath
 
 const (

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -44,18 +42,18 @@ func runConfig(cmd *cobra.Command, key string) error {
 	switch key {
 	case "path.queue":
 		var ws string
-		ws, err = resolveWorkspaceWithFallback()
+		ws, err = infra.ResolveWorkspacePath()
 		if err == nil {
 			path = filepath.Join(ws, "queue")
 		}
 	case "path.tmp":
 		var ws string
-		ws, err = resolveWorkspaceWithFallback()
+		ws, err = infra.ResolveWorkspacePath()
 		if err == nil {
 			path = filepath.Join(ws, "tmp")
 		}
 	case "path.workspace":
-		path, err = resolveWorkspaceWithFallback()
+		path, err = infra.ResolveWorkspacePath()
 	default:
 		return fmt.Errorf("%w: unknown key: %s\nsupported keys:\n%s", ErrUsage, key, formatSupportedKeys())
 	}
@@ -66,19 +64,6 @@ func runConfig(cmd *cobra.Command, key string) error {
 		return err
 	}
 	return nil
-}
-
-// resolveWorkspaceWithFallback はワークスペースルートを解決し、git管理外の場合はカレントディレクトリにフォールバックする。
-func resolveWorkspaceWithFallback() (string, error) {
-	path, err := infra.ResolveWorkspacePath()
-	if errors.Is(err, infra.ErrNotInGitRepo) {
-		cwd, cwdErr := os.Getwd()
-		if cwdErr != nil {
-			return "", cwdErr
-		}
-		return cwd, nil
-	}
-	return path, err
 }
 
 func formatSupportedKeys() string {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/canpok1/vox-actor/internal/infra"
@@ -41,17 +40,9 @@ func runConfig(cmd *cobra.Command, key string) error {
 	)
 	switch key {
 	case "path.queue":
-		var ws string
-		ws, err = infra.ResolveWorkspacePath()
-		if err == nil {
-			path = filepath.Join(ws, "queue")
-		}
+		path, err = infra.ResolveQueuePath()
 	case "path.tmp":
-		var ws string
-		ws, err = infra.ResolveWorkspacePath()
-		if err == nil {
-			path = filepath.Join(ws, "tmp")
-		}
+		path, err = infra.ResolveTmpPath()
 	case "path.workspace":
 		path, err = infra.ResolveWorkspacePath()
 	default:

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -138,7 +138,7 @@ func TestConfigCmd_PathWorkspace_WithEnv_PrintsEnvValue(t *testing.T) {
 	}
 }
 
-func TestConfigCmd_PathWorkspace_OutsideGitRepo_PrintsCwd(t *testing.T) {
+func TestConfigCmd_PathWorkspace_OutsideGitRepo_PrintsVoxActorSubdir(t *testing.T) {
 	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	cwd := withTempNonGitDir(t)
 
@@ -154,11 +154,12 @@ func TestConfigCmd_PathWorkspace_OutsideGitRepo_PrintsCwd(t *testing.T) {
 	}
 
 	got := strings.TrimRight(outBuf.String(), "\n")
+	want := filepath.Join(cwd, ".vox-actor")
 	// macOS の /var → /private/var シンボリックリンクを考慮して比較する。
-	gotEval, _ := filepath.EvalSymlinks(got)
-	cwdEval, _ := filepath.EvalSymlinks(cwd)
-	if gotEval != cwdEval {
-		t.Errorf("got %q, want %q", got, cwd)
+	gotEval, _ := filepath.EvalSymlinks(filepath.Dir(got))
+	wantEval, _ := filepath.EvalSymlinks(filepath.Dir(want))
+	if gotEval != wantEval || filepath.Base(got) != filepath.Base(want) {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 
@@ -200,7 +201,7 @@ func TestConfigCmd_PathQueue_OutsideGitRepo_PrintsCwdQueue(t *testing.T) {
 	}
 
 	got := strings.TrimRight(outBuf.String(), "\n")
-	want := filepath.Join(cwd, "queue")
+	want := filepath.Join(cwd, ".vox-actor", "queue")
 	wantEval, _ := filepath.EvalSymlinks(filepath.Dir(want))
 	gotEval, _ := filepath.EvalSymlinks(filepath.Dir(got))
 	if gotEval != wantEval || filepath.Base(got) != filepath.Base(want) {
@@ -248,7 +249,7 @@ func TestConfigCmd_PathTmp_OutsideGitRepo_PrintsCwdTmp(t *testing.T) {
 	}
 
 	got := strings.TrimRight(outBuf.String(), "\n")
-	want := filepath.Join(cwd, "tmp")
+	want := filepath.Join(cwd, ".vox-actor", "tmp")
 	wantEval, _ := filepath.EvalSymlinks(filepath.Dir(want))
 	gotEval, _ := filepath.EvalSymlinks(filepath.Dir(got))
 	if gotEval != wantEval || filepath.Base(got) != filepath.Base(want) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -279,7 +279,7 @@ vox-actor config <key>
 
 1. 環境変数 `VOX_ACTOR_WORKSPACE` が設定されていればその値をワークスペースルートとして扱う
 2. gitリポジトリ内であれば `git rev-parse --path-format=absolute --git-common-dir` の結果の親ディレクトリ配下の `.vox-actor` をワークスペースルートとする
-3. git管理外の場合はカレントディレクトリをワークスペースルートとして扱う
+3. git管理外の場合はカレントディレクトリの `.vox-actor` サブディレクトリをワークスペースルートとして扱う
 
 `path.queue` と `path.tmp` はワークスペースルートに各サブディレクトリを結合した値を返すため、常に以下の関係が成立します:
 - `path.workspace`/queue = `path.queue`

--- a/internal/infra/git_workspace.go
+++ b/internal/infra/git_workspace.go
@@ -62,15 +62,21 @@ func cwdDotVoxActor() (string, error) {
 }
 
 // ResolveQueuePath はワークスペースルート配下の queue ディレクトリ絶対パスを返す。
-//
-// 実装は ResolveWorkspacePath の結果に `queue` を結合するだけで、環境変数/git解決は
-// ResolveWorkspacePath に一元化する。ディレクトリの作成は行わない。
 func ResolveQueuePath() (string, error) {
 	workspace, err := ResolveWorkspacePath()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(workspace, "queue"), nil
+}
+
+// ResolveTmpPath はワークスペースルート配下の tmp ディレクトリ絶対パスを返す。
+func ResolveTmpPath() (string, error) {
+	workspace, err := ResolveWorkspacePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(workspace, "tmp"), nil
 }
 
 func resolveHomeViewerDir() (string, error) {

--- a/internal/infra/git_workspace.go
+++ b/internal/infra/git_workspace.go
@@ -26,7 +26,7 @@ var gitRunner = exec.Command
 // 解決順:
 //  1. 環境変数 VOX_ACTOR_WORKSPACE が設定されていればその値
 //  2. git リポジトリ内であれば `<repoRoot>/.vox-actor`
-//  3. それ以外は ErrNotInGitRepo
+//  3. それ以外は `<cwd>/.vox-actor`
 func ResolveWorkspacePath() (string, error) {
 	if v := os.Getenv(envWorkspaceKey); v != "" {
 		return v, nil
@@ -35,22 +35,30 @@ func ResolveWorkspacePath() (string, error) {
 	cmd := gitRunner("git", "rev-parse", "--path-format=absolute", "--git-common-dir")
 	out, err := cmd.Output()
 	if err != nil {
-		// ExitError（非0終了）は git 外で rev-parse を呼んだ想定に寄せて
-		// ErrNotInGitRepo に分類する。それ以外（バイナリ不在など）は ErrGitNotFound。
+		// ExitError（非0終了）は git 管理外で rev-parse を呼んだ想定に寄せて
+		// cwd/.vox-actor にフォールバックする。それ以外（バイナリ不在など）は ErrGitNotFound。
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return "", ErrNotInGitRepo
+			return cwdDotVoxActor()
 		}
 		return "", ErrGitNotFound
 	}
 
 	gitCommonDir := strings.TrimSpace(string(out))
 	if gitCommonDir == "" {
-		return "", ErrNotInGitRepo
+		return cwdDotVoxActor()
 	}
 
 	repoRoot := filepath.Dir(gitCommonDir)
 	return filepath.Join(repoRoot, ".vox-actor"), nil
+}
+
+func cwdDotVoxActor() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cwd, ".vox-actor"), nil
 }
 
 // ResolveQueuePath はワークスペースルート配下の queue ディレクトリ絶対パスを返す。
@@ -104,13 +112,6 @@ func ResolveHomeAssetsPath() (string, error) {
 // git リポジトリ内なら <repoRoot>/.vox-actor/assets/、それ以外は <cwd>/.vox-actor/assets/。
 func ResolveProjectAssetsPath() (string, error) {
 	path, err := ResolveWorkspacePath()
-	if errors.Is(err, ErrNotInGitRepo) {
-		cwd, cwdErr := os.Getwd()
-		if cwdErr != nil {
-			return "", cwdErr
-		}
-		return filepath.Join(cwd, ".vox-actor", "assets"), nil
-	}
 	if err != nil {
 		return "", err
 	}

--- a/internal/infra/git_workspace_test.go
+++ b/internal/infra/git_workspace_test.go
@@ -149,6 +149,24 @@ func TestResolveTmpPath_ReturnsGitCommonDirParentJoinedWithVoxActorTmp(t *testin
 	}
 }
 
+func TestResolveTmpPath_ReturnsCwdVoxActorTmp_WhenGitCommonDirEmpty(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		// 空文字列を標準出力に出すだけのコマンド（=gitリポジトリ外の想定）
+		return exec.Command("true")
+	})
+
+	cwd, _ := os.Getwd()
+	got, err := ResolveTmpPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(cwd, ".vox-actor", "tmp")
+	if got != want {
+		t.Errorf("ResolveTmpPath() = %q, want %q", got, want)
+	}
+}
+
 func TestResolveTmpPath_ReturnsCwdVoxActorTmp_WhenGitRunnerFailsWithNonZeroExit(t *testing.T) {
 	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	withGitRunner(t, func(name string, args ...string) *exec.Cmd {

--- a/internal/infra/git_workspace_test.go
+++ b/internal/infra/git_workspace_test.go
@@ -39,29 +39,39 @@ func TestResolveQueuePath_ReturnsGitCommonDirParentJoinedWithVoxActorQueue(t *te
 	}
 }
 
-func TestResolveQueuePath_ReturnsErrNotInGitRepo_WhenGitCommonDirEmpty(t *testing.T) {
+func TestResolveQueuePath_ReturnsCwdVoxActorQueue_WhenGitCommonDirEmpty(t *testing.T) {
 	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
 		// 空文字列を標準出力に出すだけのコマンド（=gitリポジトリ外の想定）
 		return exec.Command("true")
 	})
 
-	_, err := ResolveQueuePath()
-	if !errors.Is(err, ErrNotInGitRepo) {
-		t.Errorf("expected ErrNotInGitRepo, got: %v", err)
+	cwd, _ := os.Getwd()
+	got, err := ResolveQueuePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(cwd, ".vox-actor", "queue")
+	if got != want {
+		t.Errorf("ResolveQueuePath() = %q, want %q", got, want)
 	}
 }
 
-func TestResolveQueuePath_ReturnsErrNotInGitRepo_WhenGitRunnerFailsWithNonZeroExit(t *testing.T) {
+func TestResolveQueuePath_ReturnsCwdVoxActorQueue_WhenGitRunnerFailsWithNonZeroExit(t *testing.T) {
 	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
 		// 非0終了（gitリポジトリ外で git rev-parse した時の挙動を模倣）
 		return exec.Command("false")
 	})
 
-	_, err := ResolveQueuePath()
-	if !errors.Is(err, ErrNotInGitRepo) {
-		t.Errorf("expected ErrNotInGitRepo, got: %v", err)
+	cwd, _ := os.Getwd()
+	got, err := ResolveQueuePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(cwd, ".vox-actor", "queue")
+	if got != want {
+		t.Errorf("ResolveQueuePath() = %q, want %q", got, want)
 	}
 }
 
@@ -157,27 +167,37 @@ func TestResolveWorkspacePath_ReturnsGitCommonDirParentJoinedWithVoxActor(t *tes
 	}
 }
 
-func TestResolveWorkspacePath_ReturnsErrNotInGitRepo_WhenGitCommonDirEmpty(t *testing.T) {
+func TestResolveWorkspacePath_ReturnsCwdVoxActor_WhenGitCommonDirEmpty(t *testing.T) {
 	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
 		return exec.Command("true")
 	})
 
-	_, err := ResolveWorkspacePath()
-	if !errors.Is(err, ErrNotInGitRepo) {
-		t.Errorf("expected ErrNotInGitRepo, got: %v", err)
+	cwd, _ := os.Getwd()
+	got, err := ResolveWorkspacePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(cwd, ".vox-actor")
+	if got != want {
+		t.Errorf("ResolveWorkspacePath() = %q, want %q", got, want)
 	}
 }
 
-func TestResolveWorkspacePath_ReturnsErrNotInGitRepo_WhenGitRunnerFailsWithNonZeroExit(t *testing.T) {
+func TestResolveWorkspacePath_ReturnsCwdVoxActor_WhenGitRunnerFailsWithNonZeroExit(t *testing.T) {
 	t.Setenv("VOX_ACTOR_WORKSPACE", "")
 	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
 		return exec.Command("false")
 	})
 
-	_, err := ResolveWorkspacePath()
-	if !errors.Is(err, ErrNotInGitRepo) {
-		t.Errorf("expected ErrNotInGitRepo, got: %v", err)
+	cwd, _ := os.Getwd()
+	got, err := ResolveWorkspacePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(cwd, ".vox-actor")
+	if got != want {
+		t.Errorf("ResolveWorkspacePath() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/infra/git_workspace_test.go
+++ b/internal/infra/git_workspace_test.go
@@ -130,6 +130,60 @@ func TestResolveQueuePath_ReturnsVoxActorWorkspaceQueue_WhenEnvIsSet(t *testing.
 	}
 }
 
+func TestResolveTmpPath_ReturnsGitCommonDirParentJoinedWithVoxActorTmp(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	repoRoot := t.TempDir()
+	gitCommonDir := filepath.Join(repoRoot, ".git")
+
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("echo", gitCommonDir)
+	})
+
+	got, err := ResolveTmpPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(repoRoot, ".vox-actor", "tmp")
+	if got != want {
+		t.Errorf("ResolveTmpPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTmpPath_ReturnsCwdVoxActorTmp_WhenGitRunnerFailsWithNonZeroExit(t *testing.T) {
+	t.Setenv("VOX_ACTOR_WORKSPACE", "")
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	})
+
+	cwd, _ := os.Getwd()
+	got, err := ResolveTmpPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(cwd, ".vox-actor", "tmp")
+	if got != want {
+		t.Errorf("ResolveTmpPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTmpPath_ReturnsVoxActorWorkspaceTmp_WhenEnvIsSet(t *testing.T) {
+	workspace := t.TempDir()
+	t.Setenv("VOX_ACTOR_WORKSPACE", workspace)
+
+	withGitRunner(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	})
+
+	got, err := ResolveTmpPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(workspace, "tmp")
+	if got != want {
+		t.Errorf("ResolveTmpPath() = %q, want %q", got, want)
+	}
+}
+
 func TestResolveWorkspacePath_ReturnsVoxActorWorkspace_WhenEnvIsSet(t *testing.T) {
 	workspace := t.TempDir()
 	t.Setenv("VOX_ACTOR_WORKSPACE", workspace)

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -151,8 +151,9 @@ func TestConfigE2E_PathWorkspace_OutsideGitRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to eval symlinks for %q: %v", dir, err)
 	}
-	if got != resolved {
-		t.Errorf("got %q, want %q", got, resolved)
+	want := filepath.Join(resolved, ".vox-actor")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 
@@ -170,7 +171,7 @@ func TestConfigE2E_PathQueue_OutsideGitRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to eval symlinks for %q: %v", dir, err)
 	}
-	want := filepath.Join(resolved, "queue")
+	want := filepath.Join(resolved, ".vox-actor", "queue")
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -190,7 +191,7 @@ func TestConfigE2E_PathTmp_OutsideGitRepo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to eval symlinks for %q: %v", dir, err)
 	}
-	want := filepath.Join(resolved, "tmp")
+	want := filepath.Join(resolved, ".vox-actor", "tmp")
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- `ResolveWorkspacePath` のフォールバック動作を変更し、git 管理外かつ `VOX_ACTOR_WORKSPACE` 未設定の場合に `{cwd}` ではなく `{cwd}/.vox-actor` を返すよう修正
- `cmd/config.go` の `resolveWorkspaceWithFallback` を削除し、infra 層の関数を直接呼び出すことでフォールバックロジックを `internal/infra` に一元化
- `ResolveProjectAssetsPath` 内の重複したフォールバックロジックを削除（`ResolveWorkspacePath` が処理するため不要）
- `infra.ResolveTmpPath()` を新規追加し、`ResolveQueuePath` と対称化
- `cmd/config_test.go` の OutsideGitRepo 系テスト 3 件の期待値を更新
- `docs/reference/cli.md` の解決順記述を修正

## Before / After

| キー | 変更前 (git外) | 変更後 (git外) |
|---|---|---|
| `path.workspace` | `{cwd}` | `{cwd}/.vox-actor` |
| `path.queue` | `{cwd}/queue` | `{cwd}/.vox-actor/queue` |
| `path.tmp` | `{cwd}/tmp` | `{cwd}/.vox-actor/tmp` |

`VOX_ACTOR_WORKSPACE` が設定されている場合・git リポジトリ内の挙動は変更なし。

## Test plan

- [ ] `go test ./...` が全通過することを確認
- [ ] `golangci-lint run ./...` が 0 issues であることを確認
- [ ] (手動) git 管理外ディレクトリで `vox-actor config path.workspace` が `{cwd}/.vox-actor` を返すことを確認

Closes #452

---
🤖 Generated with [Claude Code](https://claude.ai/code)
