### PR TITLE
test(e2e): viewer の GET /assets/images/... エンドポイントに e2e を追加する

### DIFF
--- a/test/e2e/helper_test.go
+++ b/test/e2e/helper_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -112,6 +113,26 @@ func countNonEmptyLines(s string) int {
 		}
 	}
 	return n
+}
+
+// getURLWithRetry は url に GET して成功するまで最大 20 回リトライする。
+func getURLWithRetry(t *testing.T, url string) *http.Response {
+	t.Helper()
+	var (
+		resp   *http.Response
+		getErr error
+	)
+	for i := 0; i < 20; i++ {
+		resp, getErr = http.Get(url) //nolint:noctx
+		if getErr == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if getErr != nil {
+		t.Fatalf("GET %s: %v", url, getErr)
+	}
+	return resp
 }
 
 // writeViewerLockFile は homeDir 配下に viewer ロックファイルを書き込む。

--- a/test/e2e/viewer_images_test.go
+++ b/test/e2e/viewer_images_test.go
@@ -1,0 +1,205 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeImageFile は assetsDir/<charID>/<file> にダミーバイナリを書き込む。
+// 親ディレクトリが存在しない場合は自動作成する。
+func makeImageFile(t *testing.T, assetsDir, charID, file string, content []byte) {
+	t.Helper()
+	charDir := filepath.Join(assetsDir, charID)
+	if err := os.MkdirAll(charDir, 0o755); err != nil {
+		t.Fatalf("mkdir charDir %s: %v", charDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(charDir, file), content, 0o644); err != nil {
+		t.Fatalf("write image file: %v", err)
+	}
+}
+
+// getImage は addr の /assets/images/<charID>/<file> に GET してレスポンスを返す。
+func getImage(t *testing.T, addr, charID, file string) *http.Response {
+	t.Helper()
+	url := fmt.Sprintf("http://%s/assets/images/%s/%s", addr, charID, file)
+	return getURLWithRetry(t, url)
+}
+
+func TestViewerE2E_Image_ProjectAssets_200(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+	port := freePort(t)
+
+	imgContent := []byte{0x89, 0x50, 0x4e, 0x47} // fake PNG header
+	projectAssetsDir := filepath.Join(workspace, "assets")
+	makeImageFile(t, projectAssetsDir, "zundamon", "face.png", imgContent)
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	resp := getImage(t, addr, "zundamon", "face.png")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(body, imgContent) {
+		t.Errorf("expected body %v, got %v", imgContent, body)
+	}
+}
+
+func TestViewerE2E_Image_HomeAssets_200(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+	port := freePort(t)
+
+	imgContent := []byte{0x89, 0x50, 0x4e, 0x47} // fake PNG header
+	homeAssetsDir := filepath.Join(homeDir, ".vox-actor", "assets")
+	makeImageFile(t, homeAssetsDir, "metan", "face.png", imgContent)
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	resp := getImage(t, addr, "metan", "face.png")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(body, imgContent) {
+		t.Errorf("expected body %v, got %v", imgContent, body)
+	}
+}
+
+func TestViewerE2E_Image_ProjectPriorityOverHome(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+	port := freePort(t)
+
+	projectContent := []byte("project-image-data")
+	homeContent := []byte("home-image-data")
+
+	// 同じ charID "zundamon" を project と home 両方に配置し、内容を変える
+	projectAssetsDir := filepath.Join(workspace, "assets")
+	makeImageFile(t, projectAssetsDir, "zundamon", "face.png", projectContent)
+
+	homeAssetsDir := filepath.Join(homeDir, ".vox-actor", "assets")
+	makeImageFile(t, homeAssetsDir, "zundamon", "face.png", homeContent)
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	resp := getImage(t, addr, "zundamon", "face.png")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(body, projectContent) {
+		t.Errorf("expected project image content %q, got %q", projectContent, body)
+	}
+}
+
+func TestViewerE2E_Image_NotFound_404(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+	port := freePort(t)
+
+	// assets dir は存在するが、リクエストする charID は存在しない
+	projectAssetsDir := filepath.Join(workspace, "assets")
+	makeImageFile(t, projectAssetsDir, "zundamon", "face.png", []byte("data"))
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	resp := getImage(t, addr, "nonexistent-char", "face.png")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestViewerE2E_Image_PathTraversal_Rejected(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+	port := freePort(t)
+
+	projectAssetsDir := filepath.Join(workspace, "assets")
+	makeImageFile(t, projectAssetsDir, "zundamon", "face.png", []byte("data"))
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	url := fmt.Sprintf("http://%s/assets/images/zundamon/../../../etc/passwd", addr)
+	resp := getURLWithRetry(t, url)
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		t.Errorf("expected non-200 for path traversal, got %d", resp.StatusCode)
+	}
+}
+
+func TestViewerE2E_Image_NoAssetsDir_404(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+	port := freePort(t)
+
+	// assets dir を一切作成しない
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	resp := getImage(t, addr, "zundamon", "face.png")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 when no assets dir, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

- `GET /assets/images/<charID>/<file>` エンドポイントの e2e テストを新規追加
- 以下の6ケースをカバー:
  - project assets 配下の画像配信 → 200 + バイナリ一致
  - home assets 配下の画像配信 → 200 + バイナリ一致
  - 同一 charID が project/home 両方に存在する場合の project 優先
  - 存在しない charID へのリクエスト → 404
  - パストラバーサル試行（`..` 含むパス） → 非200
  - assets dir 未作成での起動 → 404
- `getURLWithRetry` ヘルパーを `helper_test.go` に追加し、リトライロジックを共通化

## Test plan

- [x] `go test -tags=e2e ./test/e2e/... -run TestViewerE2E_Image` で全テスト PASS を確認済み
- [x] `gofmt -l .` → 出力なし
- [x] `golangci-lint run --build-tags e2e ./test/e2e/...` → 0 issues

Closes #439

---
🤖 Generated with [Claude Code](https://claude.ai/code)
