### PR TITLE
test(e2e): viewer の GET / (index.html) エンドポイントに e2e を追加する

### DIFF
--- a/test/e2e/viewer_index_test.go
+++ b/test/e2e/viewer_index_test.go
@@ -1,0 +1,150 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var indexAssetRe = regexp.MustCompile(`/assets/[^"'\s]+`)
+
+func TestViewerE2E_Index_StatusCode(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	url := fmt.Sprintf("http://%s/", addr)
+	resp := getURLWithRetry(t, url)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /: expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestViewerE2E_Index_ContentType(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	url := fmt.Sprintf("http://%s/", addr)
+	resp := getURLWithRetry(t, url)
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type: expected to contain %q, got %q", "text/html", ct)
+	}
+}
+
+func TestViewerE2E_Index_HashedAssets(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	url := fmt.Sprintf("http://%s/", addr)
+	resp := getURLWithRetry(t, url)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	matches := indexAssetRe.FindAllString(string(body), -1)
+	if len(matches) == 0 {
+		t.Fatalf("expected index.html to contain hashed asset references (/assets/<hash>.*), got none\nbody:\n%s", body)
+	}
+
+	for _, assetPath := range matches {
+		assetURL := fmt.Sprintf("http://%s%s", addr, assetPath)
+		assetResp := getURLWithRetry(t, assetURL)
+		assetResp.Body.Close()
+		if assetResp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200 for asset %s, got %d", assetPath, assetResp.StatusCode)
+		}
+	}
+}
+
+func TestViewerE2E_Index_KeyStrings(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	url := fmt.Sprintf("http://%s/", addr)
+	resp := getURLWithRetry(t, url)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	bodyStr := string(body)
+
+	wants := []string{
+		"<!DOCTYPE html>",
+		`id="root"`,
+		"vox-actor",
+	}
+	for _, w := range wants {
+		if !strings.Contains(bodyStr, w) {
+			t.Errorf("expected index.html to contain %q\nbody:\n%s", w, bodyStr)
+		}
+	}
+}
+
+// TestViewerE2E_Index_UnknownPath は存在しないパスへの GET が 404 を返すことを確認する。
+// http.FileServer ベースの静的配信のため SPA フォールバックはなく、404 が仕様となる。
+func TestViewerE2E_Index_UnknownPath(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	_, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+	}, port)
+
+	url := fmt.Sprintf("http://%s/unknown-path", addr)
+	resp := getURLWithRetry(t, url)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET /unknown-path: expected 404, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

- `test/e2e/viewer_index_test.go` を新規追加し、viewer の `GET /` エンドポイントを e2e で検証する
- 以下の5観点をそれぞれ独立したテスト関数でカバーする
  - `GET /` → 200 ステータス
  - `Content-Type: text/html` を含む
  - レスポンス本文にハッシュ付きアセット参照（`/assets/<hash>.*`）が含まれ、各アセットが 200 で取得できる
  - `<!DOCTYPE html>`・`id="root"`・`vox-actor` 等のキー文字列が含まれる
  - `GET /unknown-path` → 404（SPA フォールバックなし、静的ファイルサーバー仕様）

## Test plan

- [ ] `make test-e2e` で `TestViewerE2E_Index_*` が全て PASS することを確認
- CI の e2e ワークフローが通ること

## 仕様補足

`GET /unknown-path` は 404 を返す仕様（`http.FileServer` ベースの静的配信のため SPA フォールバックなし）。

Closes #440

---
🤖 Generated with [Claude Code](https://claude.ai/code)
