### PR TITLE
test(e2e): viewer の非 HTTP 系挙動（silent / lockfile / 監視統合 / フラグ / シャットダウン / ログ）に e2e を追加する

### DIFF
--- a/test/e2e/helper_test.go
+++ b/test/e2e/helper_test.go
@@ -3,7 +3,10 @@
 package e2e
 
 import (
+	"bufio"
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -133,6 +136,99 @@ func getURLWithRetry(t *testing.T, url string) *http.Response {
 		t.Fatalf("GET %s: %v", url, getErr)
 	}
 	return resp
+}
+
+// waitForSSEClipEvent は resp から SSE clip イベントが届くまで最大 timeout 待機して返す。
+func waitForSSEClipEvent(t *testing.T, resp *http.Response, timeout time.Duration) sseEvent {
+	t.Helper()
+	ch := make(chan sseEvent, 1)
+	go func() {
+		r := bufio.NewReader(resp.Body)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		for {
+			ev, err := readSSEEvent(ctx, r)
+			if err != nil {
+				return
+			}
+			if ev.EventType == "clip" {
+				ch <- ev
+				return
+			}
+		}
+	}()
+	select {
+	case ev := <-ch:
+		return ev
+	case <-time.After(timeout):
+		t.Fatalf("timeout (%s) waiting for SSE clip event", timeout)
+		return sseEvent{}
+	}
+}
+
+// assertSSEClipText は SSE clip イベントの data.text が want と一致することを検証する。
+func assertSSEClipText(t *testing.T, ev sseEvent, want string) {
+	t.Helper()
+	var data struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(ev.Data), &data); err != nil {
+		t.Fatalf("unmarshal clip data: %v\nraw: %s", err, ev.Data)
+	}
+	if data.Text != want {
+		t.Errorf("clip text: expected %q, got %q", want, data.Text)
+	}
+}
+
+// waitForFileInDir は dir 内に prefix で始まるファイルが現れるまで最大 timeout 待機して
+// そのパスを返す。タイムアウト時は t.Errorf を呼ぶ。
+func waitForFileInDir(t *testing.T, dir, prefix string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), prefix) {
+				return filepath.Join(dir, e.Name())
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Errorf("timeout (%s): no file with prefix %q found in %s\n%s", timeout, prefix, dir, dumpDir(t, dir))
+	return ""
+}
+
+// waitForFileGone は path が消えるまで最大 timeout 待機する。タイムアウト時は t.Errorf を呼ぶ。
+func waitForFileGone(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Errorf("timeout (%s): file still exists: %s", timeout, path)
+}
+
+// dumpDir はディレクトリ内のファイル一覧を文字列で返す（デバッグ用）。
+func dumpDir(t *testing.T, dir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Sprintf("(ReadDir error: %v)", err)
+	}
+	var sb strings.Builder
+	for _, e := range entries {
+		fmt.Fprintf(&sb, "%s\n", e.Name())
+		if e.IsDir() {
+			sub, _ := os.ReadDir(filepath.Join(dir, e.Name()))
+			for _, s := range sub {
+				fmt.Fprintf(&sb, "  %s/%s\n", e.Name(), s.Name())
+			}
+		}
+	}
+	return sb.String()
 }
 
 // writeViewerLockFile は homeDir 配下に viewer ロックファイルを書き込む。

--- a/test/e2e/viewer_flags_test.go
+++ b/test/e2e/viewer_flags_test.go
@@ -1,0 +1,152 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestViewerE2E_Help_ExitZero は `viewer --help` が exit 0 で終了し、
+// 主要フラグが表示されることを検証する。
+func TestViewerE2E_Help_ExitZero(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runCLI(t, nil, "viewer", "--help")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 for viewer --help, got %d", exitCode)
+	}
+
+	wantFlags := []string{"--port", "--watch", "--watch-queue", "--delete", "--host", "--engine-url", "--speaker"}
+	for _, flag := range wantFlags {
+		if !strings.Contains(stdout, flag) {
+			t.Errorf("expected --help output to contain flag %q\nstdout:\n%s", flag, stdout)
+		}
+	}
+}
+
+// TestViewerE2E_Env_VOXEngineURL_Applied は VOX_ENGINE_URL 環境変数で指定したサーバーに
+// viewer が接続することを検証する（speakers loaded ログで確認）。
+func TestViewerE2E_Env_VOXEngineURL_Applied(t *testing.T) {
+	t.Parallel()
+
+	fakeVox := startFakeVoicevox(t)
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	// VOX_ENGINE_URL を環境変数で指定（--engine-url フラグは使わない）
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      fakeVox.URL,
+	}, "--port", fmt.Sprintf("%d", port))
+
+	// VOICEVOX に接続成功 → "speakers loaded" ログが出る
+	vp.waitForStderr("speakers loaded", 10*time.Second)
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+// TestViewerE2E_Env_VOXSpeaker_Applied は VOX_SPEAKER 環境変数で指定したスピーカーID が
+// --watch 時のファイル処理に使われることを検証する。
+// fake VOICEVOX サーバーへの /audio_query リクエストに speaker パラメータが含まれることで確認する。
+func TestViewerE2E_Env_VOXSpeaker_Applied(t *testing.T) {
+	t.Parallel()
+
+	// リクエストを受け取った speaker パラメータを記録する fake VOICEVOX
+	var capturedSpeaker atomic.Value
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/speakers", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[{"name":"テスト","styles":[{"name":"ノーマル","id":5}]}]`) //nolint:errcheck
+	})
+	mux.HandleFunc("/audio_query", func(w http.ResponseWriter, r *http.Request) {
+		capturedSpeaker.Store(r.URL.Query().Get("speaker"))
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"accent_phrases":[],"speedScale":1.0,"pitchScale":0.0,"intonationScale":1.0,"volumeScale":1.0,"prePhonemeLength":0.1,"postPhonemeLength":0.1,"outputSamplingRate":24000,"outputStereo":false,"kana":""}`) //nolint:errcheck
+	})
+	mux.HandleFunc("/synthesis", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "audio/wav")
+		w.Write(make([]byte, 64)) //nolint:errcheck
+	})
+	fakeVox := httptest.NewServer(mux)
+	t.Cleanup(fakeVox.Close)
+
+	watchDir := t.TempDir()
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	// VOX_SPEAKER=5 を環境変数で指定（--speaker フラグは使わない）
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      fakeVox.URL,
+		"VOX_SPEAKER":         "5",
+	}, "--port", fmt.Sprintf("%d", port), "--watch", watchDir)
+
+	vp.waitForStderr("watching directory", 10*time.Second)
+
+	// ファイルを投入してスピーカーID の使用を検証
+	writeTempFile(t, watchDir, "speak.txt", "スピーカーテスト")
+
+	found := false
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if s, ok := capturedSpeaker.Load().(string); ok && s != "" {
+			if s != "5" {
+				t.Errorf("expected speaker=5 from VOX_SPEAKER env, got %q", s)
+			}
+			found = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !found {
+		t.Error("timeout: /audio_query was not called, VOX_SPEAKER env may not have been applied")
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+// TestViewerE2E_Host_0000_Binds は --host 0.0.0.0 を指定したとき
+// 127.0.0.1 でも接続できることを検証する。
+// Go の net.Listen("tcp", "0.0.0.0:N") は IPv6 dual-stack では [::] として表示されるため
+// ログ内の addr 表現は 0.0.0.0 または [::] のいずれかを許容する。
+func TestViewerE2E_Host_0000_Binds(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, "--port", fmt.Sprintf("%d", port), "--host", "0.0.0.0")
+
+	vp.waitForStderr("stream server listening", 10*time.Second)
+
+	// 127.0.0.1 でアクセス可能か確認（0.0.0.0 バインドの主目的）
+	url := fmt.Sprintf("http://127.0.0.1:%d/api/status", port)
+	resp := getURLWithRetry(t, url)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 from 127.0.0.1 with --host 0.0.0.0, got %d", resp.StatusCode)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}

--- a/test/e2e/viewer_lockfile_test.go
+++ b/test/e2e/viewer_lockfile_test.go
@@ -1,0 +1,124 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestViewerE2E_Lockfile_CreatedOnStart は viewer 起動時にロックファイルが作成されることを検証する。
+func TestViewerE2E_Lockfile_CreatedOnStart(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp, _ := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, port)
+
+	lockPath := filepath.Join(homeDir, ".vox-actor", "viewer", "viewer.lock")
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Errorf("expected lockfile to exist at %s: %v", lockPath, err)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+// TestViewerE2E_Lockfile_UnderHome_NotWorkspace はロックファイルが HOME 配下に作成され、
+// VOX_ACTOR_WORKSPACE の影響を受けないことを検証する。
+func TestViewerE2E_Lockfile_UnderHome_NotWorkspace(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp, _ := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, port)
+
+	expectedLock := filepath.Join(homeDir, ".vox-actor", "viewer", "viewer.lock")
+	if _, err := os.Stat(expectedLock); err != nil {
+		t.Errorf("expected lockfile at HOME path %s: %v", expectedLock, err)
+	}
+
+	entries, _ := os.ReadDir(workspace)
+	for _, e := range entries {
+		if e.Name() == "viewer.lock" {
+			t.Errorf("lockfile must not be created under VOX_ACTOR_WORKSPACE=%s", workspace)
+		}
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+// TestViewerE2E_Lockfile_DoubleStart_ErrorExit は二重起動時に2番目の viewer が
+// 非ゼロ終了コードで終了することを検証する。
+func TestViewerE2E_Lockfile_DoubleStart_ErrorExit(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+	port1 := freePort(t)
+	port2 := freePort(t)
+
+	vp1, _ := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, port1)
+
+	// 2番目の viewer を同じ HOME で起動する → ロック競合でエラー終了
+	_, _, exitCode := runCLI(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, "viewer", "--port", fmt.Sprintf("%d", port2))
+
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit code for double-start, got 0")
+	}
+
+	vp1.assertCleanExit(3 * time.Second)
+}
+
+// TestViewerE2E_Lockfile_Restart_AfterStop は1番目の viewer 終了後に再起動が成功することを検証する。
+func TestViewerE2E_Lockfile_Restart_AfterStop(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+	port1 := freePort(t)
+	port2 := freePort(t)
+
+	// 1番目の viewer を起動
+	vp1 := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, "--port", fmt.Sprintf("%d", port1))
+	vp1.waitForStderr("stream server listening", 10*time.Second)
+
+	// 1番目を停止
+	vp1.assertCleanExit(3 * time.Second)
+
+	// 2番目の viewer を同じ HOME で起動 → 成功するはず
+	vp2 := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, "--port", fmt.Sprintf("%d", port2))
+	vp2.waitForStderr("stream server listening", 10*time.Second)
+
+	vp2.assertCleanExit(3 * time.Second)
+}

--- a/test/e2e/viewer_log_test.go
+++ b/test/e2e/viewer_log_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestViewerE2E_Log_SpeakersLoaded は VOICEVOX 接続成功時に "speakers loaded" ログが
+// 出力されることを検証する。
+func TestViewerE2E_Log_SpeakersLoaded(t *testing.T) {
+	t.Parallel()
+
+	fakeVox := startFakeVoicevox(t)
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      fakeVox.URL,
+	}, "--port", fmt.Sprintf("%d", port))
+
+	line := vp.waitForStderr("speakers loaded", 10*time.Second)
+	if !strings.Contains(line, "speakerCount") && !strings.Contains(line, "styleCount") {
+		t.Errorf("expected speakers loaded log to include speaker counts\nline: %s", line)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+// TestViewerE2E_Log_SilentModeWarn は VOICEVOX 不在時に silent モード移行 WARN ログの
+// 内容が正しいことを検証する。
+func TestViewerE2E_Log_SilentModeWarn(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, "--port", fmt.Sprintf("%d", port))
+
+	line := vp.waitForStderr("VOICEVOX engine unreachable", 10*time.Second)
+
+	// HumanHandler の形式: "WARN ... VOICEVOX engine unreachable, continuing in silent mode..."
+	if !strings.Contains(line, "silent mode") {
+		t.Errorf("expected warn log to contain 'silent mode'\nline: %s", line)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}

--- a/test/e2e/viewer_shutdown_test.go
+++ b/test/e2e/viewer_shutdown_test.go
@@ -1,0 +1,60 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestViewerE2E_SIGINT_GracefulShutdown は SIGINT 受信時に viewer が
+// graceful shutdown（exit code 0）することを検証する。
+func TestViewerE2E_SIGINT_GracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp, _ := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, port)
+
+	// SIGINT を送信
+	if err := vp.cmd.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatalf("failed to send SIGINT: %v", err)
+	}
+
+	select {
+	case <-vp.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: viewer did not exit after SIGINT")
+	}
+
+	exitCode := exitCodeFromErr(vp.waitErr)
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0 after SIGINT, got %d\nstderr:\n%s",
+			exitCode, vp.stderr.String())
+	}
+}
+
+// TestViewerE2E_SIGTERM_GracefulShutdown は SIGTERM 受信時に viewer が
+// graceful shutdown（exit code 0）することを検証する。
+func TestViewerE2E_SIGTERM_GracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp, _ := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, port)
+
+	vp.assertCleanExit(3 * time.Second)
+}

--- a/test/e2e/viewer_silent_test.go
+++ b/test/e2e/viewer_silent_test.go
@@ -1,0 +1,112 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestViewerE2E_SilentMode_WarnLog(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, "--port", fmt.Sprintf("%d", port))
+
+	vp.waitForStderr("VOICEVOX engine unreachable", 10*time.Second)
+
+	listenLine := vp.waitForStderr("stream server listening", 10*time.Second)
+	if !strings.Contains(listenLine, "silent=true") {
+		t.Errorf("expected silent=true in listening log\nline: %s", listenLine)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_SilentMode_StatusFields(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp, addr := startViewerGetAddr(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, port)
+
+	resp := getURLWithRetry(t, fmt.Sprintf("http://%s/api/status", addr))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var result struct {
+		Silent       bool   `json:"silent"`
+		SilentReason string `json:"silentReason"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, body)
+	}
+	if !result.Silent {
+		t.Errorf("expected silent=true in /api/status, got false\nbody: %s", body)
+	}
+	if result.SilentReason == "" {
+		t.Errorf("expected non-empty silentReason in /api/status\nbody: %s", body)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_SilentMode_WatchFileMoved(t *testing.T) {
+	t.Parallel()
+
+	watchDir := t.TempDir()
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, "--port", fmt.Sprintf("%d", port), "--watch", watchDir)
+
+	vp.waitForStderr("watching directory", 10*time.Second)
+
+	filePath := filepath.Join(watchDir, "test.txt")
+	if err := os.WriteFile(filePath, []byte("サイレントテスト"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	doneDir := filepath.Join(watchDir, "done")
+	moved := waitForFileInDir(t, doneDir, "test", 10*time.Second)
+	if moved != "" {
+		if _, err := os.Stat(filePath); err == nil {
+			t.Errorf("expected original file to be removed after done/ move")
+		}
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}

--- a/test/e2e/viewer_watch_sse_test.go
+++ b/test/e2e/viewer_watch_sse_test.go
@@ -1,0 +1,248 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestViewerE2E_Watch_FileDeliveredViaSSE(t *testing.T) {
+	t.Parallel()
+
+	fakeVox := startFakeVoicevox(t)
+	watchDir := t.TempDir()
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      fakeVox.URL,
+	}, "--port", fmt.Sprintf("%d", port), "--watch", watchDir)
+
+	line := vp.waitForStderr("stream server listening", 10*time.Second)
+	addr := extractAddrFromLog(line)
+	if addr == "" {
+		t.Fatalf("failed to extract addr: %q", line)
+	}
+	vp.waitForStderr("watching directory", 10*time.Second)
+
+	sseResp := connectSSE(t, addr)
+	defer sseResp.Body.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(watchDir, "hello.txt"), []byte("SSE配信テスト"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	ev := waitForSSEClipEvent(t, sseResp, 15*time.Second)
+	assertSSEClipText(t, ev, "SSE配信テスト")
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_Watch_DeleteMode_FileDeleted(t *testing.T) {
+	t.Parallel()
+
+	fakeVox := startFakeVoicevox(t)
+	watchDir := t.TempDir()
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      fakeVox.URL,
+	}, "--port", fmt.Sprintf("%d", port), "--watch", watchDir, "--delete")
+
+	vp.waitForStderr("watching directory", 10*time.Second)
+
+	filePath := filepath.Join(watchDir, "del.txt")
+	if err := os.WriteFile(filePath, []byte("削除モードテスト"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	waitForFileGone(t, filePath, 10*time.Second)
+
+	doneDir := filepath.Join(watchDir, "done")
+	if _, err := os.Stat(doneDir); err == nil {
+		entries, _ := os.ReadDir(doneDir)
+		if len(entries) > 0 {
+			t.Errorf("expected done/ to be empty in --delete mode, got: %v", entries)
+		}
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_WatchQueue_FileDeliveredViaSSE(t *testing.T) {
+	t.Parallel()
+
+	fakeVox := startFakeVoicevox(t)
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      fakeVox.URL,
+	}, "--port", fmt.Sprintf("%d", port), "--watch-queue")
+
+	line := vp.waitForStderr("stream server listening", 10*time.Second)
+	addr := extractAddrFromLog(line)
+	if addr == "" {
+		t.Fatalf("failed to extract addr: %q", line)
+	}
+	vp.waitForStderr("watching directory", 10*time.Second)
+
+	queueDir := filepath.Join(workspace, "queue")
+	if _, err := os.Stat(queueDir); err != nil {
+		t.Fatalf("expected queue dir to be auto-created: %v", err)
+	}
+
+	sseResp := connectSSE(t, addr)
+	defer sseResp.Body.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(queueDir, "queue.txt"), []byte("キューテスト"), 0o644); err != nil {
+		t.Fatalf("write queue file: %v", err)
+	}
+
+	ev := waitForSSEClipEvent(t, sseResp, 15*time.Second)
+	assertSSEClipText(t, ev, "キューテスト")
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_Watch_MultipleDirectories_BothWatched(t *testing.T) {
+	t.Parallel()
+
+	fakeVox := startFakeVoicevox(t)
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      fakeVox.URL,
+	}, "--port", fmt.Sprintf("%d", port), "--watch", dir1, "--watch", dir2)
+
+	line := vp.waitForStderr("stream server listening", 10*time.Second)
+	addr := extractAddrFromLog(line)
+	if addr == "" {
+		t.Fatalf("failed to extract addr: %q", line)
+	}
+
+	vp.waitForStderr("watching directory", 10*time.Second)
+	stderr := vp.stderr.String()
+	if strings.Count(stderr, "watching directory") < 2 {
+		t.Errorf("expected at least 2 'watching directory' log entries, got:\n%s", stderr)
+	}
+
+	sseResp := connectSSE(t, addr)
+	defer sseResp.Body.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	eventCh := make(chan sseEvent, 2)
+	go func() {
+		r := bufio.NewReader(sseResp.Body)
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		for {
+			ev, err := readSSEEvent(ctx, r)
+			if err != nil {
+				return
+			}
+			if ev.EventType == "clip" {
+				eventCh <- ev
+			}
+		}
+	}()
+
+	if err := os.WriteFile(filepath.Join(dir1, "a.txt"), []byte("ディレクトリ1"), 0o644); err != nil {
+		t.Fatalf("write dir1 file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir2, "b.txt"), []byte("ディレクトリ2"), 0o644); err != nil {
+		t.Fatalf("write dir2 file: %v", err)
+	}
+
+	received := make(map[string]bool)
+	timeout := time.After(15 * time.Second)
+	for len(received) < 2 {
+		select {
+		case ev := <-eventCh:
+			var data struct {
+				Text string `json:"text"`
+			}
+			if err := json.Unmarshal([]byte(ev.Data), &data); err == nil {
+				received[data.Text] = true
+			}
+		case <-timeout:
+			t.Fatalf("timeout: only received events for %v, expected both dir1 and dir2", received)
+		}
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_Watch_WatchAndQueueCombined(t *testing.T) {
+	t.Parallel()
+
+	watchDir := t.TempDir()
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, "--port", fmt.Sprintf("%d", port), "--watch", watchDir, "--watch-queue")
+
+	vp.waitForStderr("stream server listening", 10*time.Second)
+	vp.waitForStderr("watching directory", 10*time.Second)
+	time.Sleep(200 * time.Millisecond)
+
+	stderr := vp.stderr.String()
+	if strings.Count(stderr, "watching directory") < 2 {
+		t.Errorf("expected at least 2 'watching directory' log entries for --watch + --watch-queue, got:\n%s", stderr)
+	}
+
+	queueDir := filepath.Join(workspace, "queue")
+	if _, err := os.Stat(queueDir); err != nil {
+		t.Errorf("expected queue dir to be auto-created: %v", err)
+	}
+
+	vp.assertCleanExit(3 * time.Second)
+}
+
+func TestViewerE2E_Delete_WithoutWatch_StartsNormally(t *testing.T) {
+	t.Parallel()
+
+	port := freePort(t)
+	homeDir := t.TempDir()
+	workspace := t.TempDir()
+
+	vp := startViewer(t, map[string]string{
+		"HOME":                homeDir,
+		"VOX_ACTOR_WORKSPACE": workspace,
+		"VOX_ENGINE_URL":      "http://127.0.0.1:1",
+	}, "--port", fmt.Sprintf("%d", port), "--delete")
+
+	vp.waitForStderr("stream server listening", 10*time.Second)
+	vp.assertCleanExit(3 * time.Second)
+}


### PR DESCRIPTION
## Summary

viewer コマンドの非 HTTP 系挙動（silent モード・ロックファイル・監視+SSE 統合・フラグ/環境変数・シャットダウン・ログ）に対して e2e テストを追加する。

### 追加テスト一覧

**A. silent モード** (`viewer_silent_test.go`)
- `TestViewerE2E_SilentMode_WarnLog` — VOICEVOX 不在時に WARN ログが stderr に出力される
- `TestViewerE2E_SilentMode_StatusFields` — `/api/status` で `silent:true` + `silentReason` が返る
- `TestViewerE2E_SilentMode_WatchFileMoved` — silent モードでもファイル検知→ done/ 移動（無音）

**B. ロックファイル / 二重起動** (`viewer_lockfile_test.go`)
- `TestViewerE2E_Lockfile_CreatedOnStart` — 起動時にロックファイルが作成される
- `TestViewerE2E_Lockfile_UnderHome_NotWorkspace` — ロックファイルが HOME 配下に作成される（VOX_ACTOR_WORKSPACE 影響なし）
- `TestViewerE2E_Lockfile_DoubleStart_ErrorExit` — 二重起動で非ゼロ終了コード
- `TestViewerE2E_Lockfile_Restart_AfterStop` — 1 個目終了後に再起動成功

**C. 監視 + 配信統合** (`viewer_watch_sse_test.go`)
- `TestViewerE2E_Watch_FileDeliveredViaSSE` — `--watch` + ファイル投入 → SSE clip イベント
- `TestViewerE2E_Watch_DeleteMode_FileDeleted` — `--delete` モードでファイル削除
- `TestViewerE2E_WatchQueue_FileDeliveredViaSSE` — `--watch-queue` + ファイル投入 → SSE 配信
- `TestViewerE2E_Watch_MultipleDirectories_BothWatched` — 複数 `--watch` ディレクトリ並列監視
- `TestViewerE2E_Watch_WatchAndQueueCombined` — `--watch` + `--watch-queue` 同時指定
- `TestViewerE2E_Delete_WithoutWatch_StartsNormally` — `--delete` 単独で正常起動

**D. フラグ・環境変数** (`viewer_flags_test.go`)
- `TestViewerE2E_Help_ExitZero` — `viewer --help` が exit 0 + 全フラグ表示
- `TestViewerE2E_Env_VOXEngineURL_Applied` — `VOX_ENGINE_URL` 環境変数の反映
- `TestViewerE2E_Env_VOXSpeaker_Applied` — `VOX_SPEAKER` 環境変数の反映
- `TestViewerE2E_Host_0000_Binds` — `--host 0.0.0.0` で 127.0.0.1 からアクセス可能

**E. シャットダウン** (`viewer_shutdown_test.go`)
- `TestViewerE2E_SIGINT_GracefulShutdown` — SIGINT で graceful shutdown
- `TestViewerE2E_SIGTERM_GracefulShutdown` — SIGTERM で graceful shutdown

**F. ログ** (`viewer_log_test.go`)
- `TestViewerE2E_Log_SpeakersLoaded` — VOICEVOX 接続成功時に "speakers loaded" ログ
- `TestViewerE2E_Log_SilentModeWarn` — silent 時の WARN ログ内容

### ヘルパー追加 (`helper_test.go`)

- `waitForSSEClipEvent` — SSE clip イベントを待機して返す
- `assertSSEClipText` — clip イベントの text フィールドを検証
- `waitForFileInDir` — ディレクトリ内にファイルが現れるまで待機
- `waitForFileGone` — ファイルが消えるまで待機
- `dumpDir` — ディレクトリ内容をデバッグ用文字列で返す

## Test plan

- [x] `go test -tags=e2e -run "TestViewerE2E_SilentMode|TestViewerE2E_Lockfile|TestViewerE2E_Watch|TestViewerE2E_WatchQueue|TestViewerE2E_Delete|TestViewerE2E_Help|TestViewerE2E_Env|TestViewerE2E_Host|TestViewerE2E_SIGINT|TestViewerE2E_SIGTERM|TestViewerE2E_Log" ./test/e2e/...` — 全 23 件パス
- [x] `golangci-lint run --build-tags=e2e ./test/e2e/...` — 0 issues
- [x] 既存 viewer e2e テストに影響なし

Closes #442

---
🤖 Generated with [Claude Code](https://claude.ai/code)
