### PR TITLE
test(e2e): フロントエンド e2e カバレッジを拡充する

### DIFF
--- a/frontend/test/e2e/lip-sync-image.spec.ts
+++ b/frontend/test/e2e/lip-sync-image.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "@playwright/test";
+import { pushClip, resetStub, setApiCharacters } from "./helpers";
+
+const CHARACTER = {
+  speakerName: "ずんだもん",
+  styleName: "ノーマル",
+  mouthClosed: "zundamon_closed.png",
+  mouthOpen: "zundamon_open.png",
+};
+
+test.describe("LipSyncImage 表示", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test("charactersEnabled=false のとき「キャラ画像」チェックボックスが表示されず画像エリアも非表示", async ({
+    page,
+    request,
+  }) => {
+    await setApiCharacters(request, { enabled: false, characters: [] });
+
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    await expect(
+      page.getByRole("checkbox", { name: "キャラ画像" }),
+    ).not.toBeVisible();
+    await expect(
+      page.locator('img[alt="character mouth closed"]'),
+    ).not.toBeVisible();
+  });
+
+  test("charactersEnabled=true でキャラ画像チェックON・clip受信後に口パク画像が表示される", async ({
+    page,
+    request,
+  }) => {
+    await setApiCharacters(request, {
+      enabled: true,
+      characters: [CHARACTER],
+    });
+
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    // 消音解除（再生キューを有効にするため）
+    await page.getByRole("checkbox", { name: "消音" }).uncheck();
+
+    // キャラ画像チェックを ON にする
+    await page
+      .getByRole("checkbox", { name: "キャラ画像" })
+      .check();
+
+    const ts = 1700004000001;
+
+    // clip を待ち受けてから受信
+    const requestPromise = page.waitForRequest(
+      (req) => req.url().includes(`/clips/${ts}.wav`),
+    );
+
+    await pushClip(request, {
+      url: `/clips/${ts}.wav`,
+      text: "口パクテスト",
+      speakerName: CHARACTER.speakerName,
+      styleName: CHARACTER.styleName,
+      timestamp: ts,
+    });
+
+    // audio.src が更新されるのを待つ（再生が開始された証拠）
+    await requestPromise;
+
+    // LipSyncImage の img 要素が存在する
+    await expect(
+      page.locator('img[alt="character mouth closed"]'),
+    ).toBeAttached();
+    await expect(
+      page.locator('img[alt="character mouth open"]'),
+    ).toBeAttached();
+  });
+
+  test("「キャラ画像」チェックを OFF にするとキャラ画像エリアが非表示になる", async ({
+    page,
+    request,
+  }) => {
+    await setApiCharacters(request, {
+      enabled: true,
+      characters: [CHARACTER],
+    });
+
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    const checkbox = page.getByRole("checkbox", { name: "キャラ画像" });
+    await expect(checkbox).toBeVisible();
+
+    // チェックボックスが ON になっていることを確認（デフォルト状態）してから OFF にする
+    if (await checkbox.isChecked()) {
+      await checkbox.uncheck();
+    }
+
+    // 口パク画像エリアが非表示
+    await expect(
+      page.locator('img[alt="character mouth closed"]'),
+    ).not.toBeVisible();
+  });
+
+  test("キャラに対応しない speakerName の clip 受信時は画像が表示されない", async ({
+    page,
+    request,
+  }) => {
+    await setApiCharacters(request, {
+      enabled: true,
+      characters: [CHARACTER],
+    });
+
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    await page.getByRole("checkbox", { name: "キャラ画像" }).check();
+
+    // 登録キャラと一致しない話者の clip を受信
+    const ts = 1700004100001;
+    await pushClip(request, {
+      url: `/clips/${ts}.wav`,
+      text: "不一致話者テスト",
+      speakerName: "四国めたん",
+      styleName: "ノーマル",
+      timestamp: ts,
+    });
+
+    // タイムラインには表示される
+    await expect(page.locator(`[data-clip-timestamp="${ts}"]`)).toBeVisible();
+
+    // キャラ対応なしのためLipSyncImage は表示されない
+    await expect(
+      page.locator('img[alt="character mouth closed"]'),
+    ).not.toBeVisible();
+  });
+});

--- a/frontend/test/e2e/playback-queue.spec.ts
+++ b/frontend/test/e2e/playback-queue.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+import { pushClip, resetStub } from "./helpers";
+
+test.describe("再生キュー", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test("連続して clip を受信した場合 Timeline の表示順は受信順になる", async ({
+    page,
+    request,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    const baseTs = 1700003000000;
+    for (let i = 0; i < 3; i++) {
+      await pushClip(request, {
+        text: `順序テスト ${i + 1}`,
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: baseTs + i,
+      });
+    }
+
+    // 全件が Timeline に表示される
+    for (let i = 0; i < 3; i++) {
+      await expect(
+        page.locator(`[data-clip-timestamp="${baseTs + i}"]`),
+      ).toBeVisible();
+    }
+
+    // 受信順（timestamp 昇順）に並んでいることを確認
+    const items = page.locator("[data-clip-timestamp]");
+    const count = await items.count();
+    expect(count).toBe(3);
+
+    const timestamps = await Promise.all(
+      Array.from({ length: count }, (_, i) =>
+        items.nth(i).getAttribute("data-clip-timestamp"),
+      ),
+    );
+    const numericTimestamps = timestamps.map(Number);
+    for (let i = 1; i < numericTimestamps.length; i++) {
+      expect(numericTimestamps[i]).toBeGreaterThan(numericTimestamps[i - 1]);
+    }
+  });
+
+  test("muted 状態でも Timeline には clip が積まれる", async ({
+    page,
+    request,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    // デフォルトは消音チェック ON（audio.muted=true）
+    await expect(page.locator("audio")).toHaveJSProperty("muted", true);
+
+    const ts = 1700003100001;
+    await pushClip(request, {
+      text: "消音中テキスト",
+      speakerName: "ずんだもん",
+      styleName: "ノーマル",
+      timestamp: ts,
+    });
+
+    // audio.muted=true でも Timeline には表示される
+    const item = page.locator(`[data-clip-timestamp="${ts}"]`);
+    await expect(item).toBeVisible();
+    await expect(item).toContainText("消音中テキスト");
+  });
+
+  test("URL が空の clip は Timeline には表示されるが audio.src は更新されない", async ({
+    page,
+    request,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    const ts = 1700003200001;
+    await pushClip(request, {
+      url: "",
+      text: "URL空クリップ",
+      speakerName: "ずんだもん",
+      styleName: "ノーマル",
+      timestamp: ts,
+    });
+
+    // Timeline には表示される
+    const item = page.locator(`[data-clip-timestamp="${ts}"]`);
+    await expect(item).toBeVisible();
+    await expect(item).toContainText("URL空クリップ");
+
+    // audio.src は空のまま（再生キューに積まれていない）
+    const audioSrc = await page.evaluate(
+      () => document.querySelector("audio")?.src ?? "",
+    );
+    expect(audioSrc).toBe("");
+  });
+
+  test("audio.src に clip の URL が反映される（再生キューへの積み込み確認）", async ({
+    page,
+    request,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    // 消音を解除して再生キューが有効になる状態にする
+    await page.getByRole("checkbox", { name: "消音" }).uncheck();
+
+    const ts = 1700003300001;
+    const clipUrl = `/clips/${ts}.wav`;
+
+    const requestPromise = page.waitForRequest(
+      (req) => req.url().includes(`/clips/${ts}.wav`),
+    );
+
+    await pushClip(request, {
+      url: clipUrl,
+      text: "再生キューテスト",
+      speakerName: "ずんだもん",
+      styleName: "ノーマル",
+      timestamp: ts,
+    });
+
+    await requestPromise;
+
+    // audio.src に clip の URL が設定されている
+    await expect(page.locator("audio")).toHaveJSProperty(
+      "src",
+      new URL(clipUrl, page.url()).toString(),
+    );
+  });
+});

--- a/frontend/test/e2e/timeline-item.spec.ts
+++ b/frontend/test/e2e/timeline-item.spec.ts
@@ -1,0 +1,256 @@
+import { expect, test } from "@playwright/test";
+import { pushClip, pushError, resetStub } from "./helpers";
+
+test.describe("TimelineItem の個別 UI 要素", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test.describe("clip: メタ情報の表示切替", () => {
+    const ts = 1700001000001;
+
+    test("「キャラ名」ON のとき話者名が表示される", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await expect(page.getByText("● 接続中")).toBeVisible();
+
+      await pushClip(request, {
+        text: "キャラ名テスト",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: ts,
+      });
+
+      const item = page.locator(`[data-clip-timestamp="${ts}"]`);
+      await expect(item).toBeVisible();
+      // デフォルトは「キャラ名」チェック ON
+      await expect(item).toContainText("ずんだもん");
+    });
+
+    test("「キャラ名」OFF のとき話者名が非表示になる", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await page.getByRole("checkbox", { name: "キャラ名" }).uncheck();
+
+      await pushClip(request, {
+        text: "キャラ名OFFテスト",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: ts,
+      });
+
+      const item = page.locator(`[data-clip-timestamp="${ts}"]`);
+      await expect(item).toBeVisible();
+      await expect(item).not.toContainText("ずんだもん");
+    });
+
+    test("「スタイル」ON のときスタイル名が表示される", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await expect(page.getByText("● 接続中")).toBeVisible();
+
+      await pushClip(request, {
+        text: "スタイルテスト",
+        speakerName: "四国めたん",
+        styleName: "ノーマル",
+        timestamp: ts,
+      });
+
+      const item = page.locator(`[data-clip-timestamp="${ts}"]`);
+      await expect(item).toBeVisible();
+      await expect(item).toContainText("ノーマル");
+    });
+
+    test("「スタイル」OFF のときスタイル名が非表示になる", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await page.getByRole("checkbox", { name: "スタイル" }).uncheck();
+
+      await pushClip(request, {
+        text: "スタイルOFFテスト",
+        speakerName: "四国めたん",
+        styleName: "ノーマル",
+        timestamp: ts,
+      });
+
+      const item = page.locator(`[data-clip-timestamp="${ts}"]`);
+      await expect(item).toBeVisible();
+      await expect(item).not.toContainText("ノーマル");
+    });
+
+    test("「時刻」ON のときタイムスタンプが表示される", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await page.getByRole("checkbox", { name: "時刻" }).check();
+
+      const fixedTs = 1700000000000; // 2023-11-15 00:00:00 JST
+      await pushClip(request, {
+        text: "時刻テスト",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: fixedTs,
+      });
+
+      const item = page.locator(`[data-clip-timestamp="${fixedTs}"]`);
+      await expect(item).toBeVisible();
+      // 時刻表示は HH:MM:SS 形式
+      const text = await item.textContent();
+      expect(text).toMatch(/\d{2}:\d{2}:\d{2}/);
+    });
+
+    test("「時刻」OFF のときタイムスタンプが非表示になる", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await page.getByRole("checkbox", { name: "時刻" }).uncheck();
+
+      const fixedTs = 1700000000000;
+      await pushClip(request, {
+        text: "時刻OFFテスト",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: fixedTs,
+      });
+
+      const item = page.locator(`[data-clip-timestamp="${fixedTs}"]`);
+      await expect(item).toBeVisible();
+      const text = await item.textContent();
+      expect(text).not.toMatch(/\d{2}:\d{2}:\d{2}/);
+    });
+  });
+
+  test.describe("error: エラーカテゴリ別ラベル表示", () => {
+    test("synthesis エラーは「合成エラー」ラベルが表示される", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await expect(page.getByText("● 接続中")).toBeVisible();
+
+      await pushError(request, {
+        id: 1,
+        category: "synthesis",
+        message: "合成に失敗しました",
+      });
+
+      const item = page.locator('[data-error-id="1"]');
+      await expect(item).toBeVisible();
+      await expect(item).toContainText("合成エラー");
+      await expect(item).toContainText("合成に失敗しました");
+    });
+
+    test("file エラーは「ファイルエラー」ラベルが表示される", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await expect(page.getByText("● 接続中")).toBeVisible();
+
+      await pushError(request, {
+        id: 2,
+        category: "file",
+        message: "ファイルが見つかりません",
+      });
+
+      const item = page.locator('[data-error-id="2"]');
+      await expect(item).toBeVisible();
+      await expect(item).toContainText("ファイルエラー");
+    });
+
+    test("connection エラーは「接続エラー」ラベルが表示される", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await expect(page.getByText("● 接続中")).toBeVisible();
+
+      await pushError(request, {
+        id: 3,
+        category: "connection",
+        message: "接続が切断されました",
+      });
+
+      const item = page.locator('[data-error-id="3"]');
+      await expect(item).toBeVisible();
+      await expect(item).toContainText("接続エラー");
+    });
+
+    test("error に speakerName と text が含まれている場合は表示される", async ({
+      page,
+      request,
+    }) => {
+      await page.goto("/");
+      await expect(page.getByText("● 接続中")).toBeVisible();
+
+      await pushError(request, {
+        id: 4,
+        category: "synthesis",
+        message: "合成エラー",
+        text: "失敗したテキスト",
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+      });
+
+      const item = page.locator('[data-error-id="4"]');
+      await expect(item).toBeVisible();
+      await expect(item).toContainText("失敗したテキスト");
+      await expect(item).toContainText("ずんだもん");
+    });
+  });
+});
+
+test.describe("Timeline: 履歴件数上限", () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStub(request);
+  });
+
+  test("履歴件数が上限を超えると古いエントリが削除される", async ({
+    page,
+    request,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText("● 接続中")).toBeVisible();
+
+    // 履歴上限を最小値 10 に設定
+    await page.getByLabel("履歴上限").selectOption("10");
+
+    const baseTs = 1700002000000;
+
+    // 11 件送信（最初の 1 件が溢れる）。
+    // url="" にすることで再生キューに積まれず playingClipTimestamp が null のまま保たれる。
+    // これにより trimTimeline の保護条件に引っかからず純粋な件数上限の挙動を検証できる。
+    for (let i = 0; i < 11; i++) {
+      await pushClip(request, {
+        url: "",
+        text: `溢れテスト ${i + 1}`,
+        speakerName: "ずんだもん",
+        styleName: "ノーマル",
+        timestamp: baseTs + i,
+      });
+    }
+
+    // 最新の 10 件は表示される
+    await expect(
+      page.locator(`[data-clip-timestamp="${baseTs + 10}"]`),
+    ).toBeVisible();
+    await expect(
+      page.locator(`[data-clip-timestamp="${baseTs + 1}"]`),
+    ).toBeVisible();
+
+    // 最古のエントリは削除されている
+    await expect(
+      page.locator(`[data-clip-timestamp="${baseTs}"]`),
+    ).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

フロントエンドのリファクタリングを安全に進めるため、e2e カバレッジを拡充する。
単体テストはあるが e2e（実ブラウザ + スタブバックエンド経由）が無かった以下 3 領域を対象とした。

### 追加した spec ファイル

| ファイル | カバー範囲 |
|---|---|
| `frontend/test/e2e/timeline-item.spec.ts` | TimelineItem の clip/error 表示 (話者名・スタイル・タイムスタンプのON/OFF、エラーカテゴリ別ラベル) + 履歴件数上限で古いエントリが削除されること |
| `frontend/test/e2e/playback-queue.spec.ts` | 再生キューの動作 (受信順保証・muted 時も Timeline に積まれる・URL 空 clip はキューに積まない・audio.src 反映) |
| `frontend/test/e2e/lip-sync-image.spec.ts` | LipSyncImage の表示制御 (charactersEnabled 連動・showCharacters チェック ON/OFF・キャラ一致判定) |

### 対象外とした Scope

- **StatusBadge**: `stream.spec.ts` で接続/切断/再接続が既にカバー済み
- **TestControls (抑揚/音高/話速)**: 現 UI に該当スライダーが未実装のため対象外

Closes #464

---
🤖 Generated with [Claude Code](https://claude.ai/code)
