### PR TITLE
fix(makefile): dev-backend を dev-viewer にリネームし dev-watch ターゲットを追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,24 +53,28 @@ test-frontend-e2e: frontend/node_modules
 	cd frontend && npm run test:e2e
 
 # 配信画面のローカル開発用ターゲット。
-# dev-backend は frontend/dist を参照せず起動できる前提（assets.go の //go:embed all: と frontend/dist/.gitkeep でビルド可）。
+# dev-viewer は frontend/dist を参照せず起動できる前提（assets.go の //go:embed all: と frontend/dist/.gitkeep でビルド可）。
 # dev-frontend の Vite dev server (既定 :5173) は vite.config.ts の proxy で /events, /speakers.json, /test-clip, /clips/ を :8080 に中継する。
 # 詳細な起動フローは docs/development/contributing.md の「配信画面のローカル開発フロー」を参照。
 dev-frontend: frontend/node_modules
 	cd frontend && npm run dev
 
 # VOICEVOX エンジン URL は CLI 既定値（http://localhost:50021）または環境変数 VOX_ENGINE_URL に従う。
-# dev container 等で voicevox:50021 を使う場合は `VOX_ENGINE_URL=http://voicevox:50021 make dev-backend` のように指定する。
+# dev container 等で voicevox:50021 を使う場合は `VOX_ENGINE_URL=http://voicevox:50021 make dev-viewer` のように指定する。
 # viewer サブコマンドで HTTP サーバーを起動し、0.0.0.0:8080 でリッスンする。
-dev-backend:
-	go run . viewer --engine-url http://voicevox:50021 --host 0.0.0.0 --port 8080 --watch-queue
+dev-viewer:
+	go run . viewer --engine-url http://voicevox:50021 --host 0.0.0.0 --port 8080
+
+# watch サブコマンドでキュー監視を起動する。notify_queue イベントを受信して VOICEVOX 合成依頼を処理する。
+dev-watch:
+	go run . watch --queue --engine-url http://voicevox:50021
 
 dev:
-	$(MAKE) -j2 dev-backend dev-frontend
+	$(MAKE) -j3 dev-viewer dev-frontend dev-watch
 
 install: build-frontend
 	go install .
 
 all: build
 
-.PHONY: all setup build build-frontend clean test test-e2e test-frontend-unit test-frontend-e2e fmt lint lint-frontend typecheck depcheck dev dev-frontend dev-backend install
+.PHONY: all setup build build-frontend clean test test-e2e test-frontend-unit test-frontend-e2e fmt lint lint-frontend typecheck depcheck dev dev-frontend dev-viewer dev-watch install

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -58,14 +58,17 @@ make clean
 make dev
 ```
 
-個別に起動したい場合は、2 つのターミナルで以下を実行します。
+個別に起動したい場合は、3 つのターミナルで以下を実行します。
 
 ```bash
-# ターミナル1: Go バックエンド（ストリーム配信モード、127.0.0.1:8080 でリッスン）
-make dev-backend
+# ターミナル1: viewer（HTTP サーバー、127.0.0.1:8080 でリッスン）
+make dev-viewer
 
 # ターミナル2: Vite dev server（既定で http://localhost:5173）
 make dev-frontend
+
+# ターミナル3: watch（キュー監視）
+make dev-watch
 ```
 
 ブラウザで **Vite の URL（例: `http://localhost:5173`）** を開きます。`/events`（SSE）, `/speakers.json`, `/test-clip`, `/clips/*` は `frontend/vite.config.ts` の `server.proxy` 経由で Go バックエンド（`localhost:8080`）に中継されます。
@@ -140,7 +143,7 @@ make test-frontend-e2e
 cd frontend && npm run test:e2e
 ```
 
-`playwright.config.ts` の `webServer` がスタブ（既定 `127.0.0.1:8080`）と Vite dev server（既定 `127.0.0.1:5173`）を自動起動します。`8080` が既に使われている場合（例: `make dev-backend` を起動中）は、`VOX_STUB_PORT` と `PLAYWRIGHT_BASE_URL` で別ポートに振り分けてください。
+`playwright.config.ts` の `webServer` がスタブ（既定 `127.0.0.1:8080`）と Vite dev server（既定 `127.0.0.1:5173`）を自動起動します。`8080` が既に使われている場合（例: `make dev-viewer` を起動中）は、`VOX_STUB_PORT` と `PLAYWRIGHT_BASE_URL` で別ポートに振り分けてください。
 
 ```bash
 cd frontend


### PR DESCRIPTION
## Summary

- `dev-backend` ターゲットを `dev-viewer` にリネームし、廃止された `--watch-queue` フラグを除去
- `dev-watch` ターゲットを新設（`watch --queue --engine-url http://voicevox:50021`）
- `dev` ターゲットを `-j3` で `dev-viewer` / `dev-frontend` / `dev-watch` の3プロセス並列起動に更新
- `.PHONY` 宣言を新ターゲット名に追従
- `docs/development/contributing.md` の `dev-backend` 参照（L65, L143 付近）を新ターゲット名に置き換え

## Test plan

- [ ] `make dev-viewer` がエラーなく viewer 単独で起動すること（手動確認）
- [ ] `make dev-watch` で `watch --queue` が起動し、`notify_queue` イベントを処理すること（VOICEVOX 接続が必要なため手動確認）
- [ ] `make dev` で3プロセスが並列起動すること（手動確認）

Closes #469

---
🤖 Generated with [Claude Code](https://claude.ai/code)
