### PR TITLE
feat: viewer-check サブコマンドを追加して talk スキルの再生判定を改善し VOX_ACTOR_MONOLOGUE_MODE を削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ vox-actor watch "$(vox-actor config path.queue)"
 ```bash
 # claude code 側: 同じ共有ディレクトリを指定
 export VOX_ACTOR_WORKSPACE=/path/to/shared/directory
-export VOX_ACTOR_MONOLOGUE_MODE=file
 ```
 
 詳細なセットアップ手順は [プラグイン／スキルリファレンス](./docs/reference/plugins.md) を参照してください。

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ type Deps struct {
 	Say          *SayDeps
 	ScriptAppend *ScriptAppendDeps
 	AudioCheck   *AudioCheckDeps
+	ViewerCheck  *ViewerCheckDeps
 	Viewer       *ViewerDeps
 	Assets       *AssetsDownloadDeps
 	Speakers     *SpeakersDeps
@@ -58,6 +59,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	var sayDeps *SayDeps
 	var scriptAppendDeps *ScriptAppendDeps
 	var audioCheckDeps *AudioCheckDeps
+	var viewerCheckDeps *ViewerCheckDeps
 	var assetsDeps *AssetsDownloadDeps
 	var speakersDeps *SpeakersDeps
 	if d != nil {
@@ -66,6 +68,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 		sayDeps = d.Say
 		scriptAppendDeps = d.ScriptAppend
 		audioCheckDeps = d.AudioCheck
+		viewerCheckDeps = d.ViewerCheck
 		assetsDeps = d.Assets
 		speakersDeps = d.Speakers
 	}
@@ -79,6 +82,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	cmd.AddCommand(makeScriptCmd(scriptAppendDeps))
 	cmd.AddCommand(makeConfigCmd())
 	cmd.AddCommand(makeAudioCheckCmd(audioCheckDeps))
+	cmd.AddCommand(makeViewerCheckCmd(viewerCheckDeps))
 	cmd.AddCommand(makeViewerCmd(viewerDeps))
 	cmd.AddCommand(makeAssetsCmd(assetsDeps))
 	cmd.AddCommand(makeSpeakersCmd(speakersDeps))

--- a/cmd/viewer_check.go
+++ b/cmd/viewer_check.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/canpok1/vox-actor/internal/infra"
+	"github.com/spf13/cobra"
+)
+
+// ErrViewerCheckFailed はviewer-checkがviewer未起動を検出した場合のセンチネルエラー。
+// main側で終了コード1にマップされる（usageエラーではないため2にはならない）。
+var ErrViewerCheckFailed = errors.New("viewer not running")
+
+// ViewerCheckDeps はviewer-checkコマンドの依存を保持する。
+type ViewerCheckDeps struct {
+	// LockPathResolver はviewerロックファイルのパスを返す関数。
+	LockPathResolver func() (string, error)
+	// DetectFunc はviewer起動有無を判定する関数。
+	// 起動中の場合はアドレスとtrueを返し、未起動の場合は空文字とfalseを返す。
+	DetectFunc func(lockPath string) (addr string, ok bool)
+}
+
+func makeViewerCheckCmd(deps *ViewerCheckDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "viewer-check",
+		Short: "viewer の起動有無を確認する",
+		Long: "viewer のロックファイルと /api/status への疎通確認を行い、起動有無を終了コードで返す診断サブコマンド。\n" +
+			"通常実行時は標準出力・標準エラー出力ともに空で、--verbose 指定時のみ stdout に診断メッセージを出す。",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.NoArgs(cmd, args); err != nil {
+				return fmt.Errorf("%w: %s", ErrUsage, err)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runViewerCheck(cmd, deps)
+		},
+	}
+	cmd.Flags().BoolP("verbose", "v", false, "診断メッセージを標準出力に出力する")
+	// 失敗時も stderr を汚さないため、cobraの自動エラー表示を抑制する。
+	cmd.SilenceErrors = true
+	return cmd
+}
+
+func runViewerCheck(cmd *cobra.Command, deps *ViewerCheckDeps) error {
+	if deps == nil || deps.LockPathResolver == nil || deps.DetectFunc == nil {
+		return fmt.Errorf("viewer-check command dependencies are not initialized")
+	}
+
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	lockPath, err := deps.LockPathResolver()
+	if err != nil {
+		return fmt.Errorf("failed to resolve viewer lock path: %w", err)
+	}
+
+	addr, ok := deps.DetectFunc(lockPath)
+	if !ok {
+		return ErrViewerCheckFailed
+	}
+
+	if verbose {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "viewer addr: %s\n", addr)
+	}
+	return nil
+}
+
+// NewViewerCheckDeps は本番用の ViewerCheckDeps を返す。
+func NewViewerCheckDeps() *ViewerCheckDeps {
+	return &ViewerCheckDeps{
+		LockPathResolver: infra.ResolveHomeViewerLockPath,
+		DetectFunc:       infra.DetectViewer,
+	}
+}

--- a/cmd/viewer_check_test.go
+++ b/cmd/viewer_check_test.go
@@ -1,0 +1,239 @@
+package cmd
+
+// viewer-check コマンド テストリスト
+// DONE: viewer-checkサブコマンドがrootに登録されている
+// DONE: 正常系 / non-verbose: viewer起動中なら終了コード0、stdout/stderrともに空
+// DONE: 正常系 / verbose: stdoutに "viewer addr: <addr>" が出力される
+// DONE: 正常系 / verbose short flag (-v)
+// DONE: 異常系 / non-verbose: viewer未起動なら非0終了、stdout/stderrともに空
+// DONE: 異常系 / verbose: viewer未起動でも stdout/stderr は空
+// DONE: 異常系はErrUsageではない（ランタイム失敗のため）
+// DONE: 未知のフラグはエラーを返す
+// DONE: 引数を受け付けない（位置引数がある場合エラー）
+// DONE: --help でコマンド説明が出力される
+// DONE: 依存が未設定だとエラーを返す（セーフティネット）
+// DONE: LockPathResolverがエラーを返す場合は非0終了
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func newViewerCheckDepsRunning(addr string) *ViewerCheckDeps {
+	return &ViewerCheckDeps{
+		LockPathResolver: func() (string, error) { return "/tmp/fake.lock", nil },
+		DetectFunc:       func(_ string) (string, bool) { return addr, true },
+	}
+}
+
+func newViewerCheckDepsNotRunning() *ViewerCheckDeps {
+	return &ViewerCheckDeps{
+		LockPathResolver: func() (string, error) { return "/tmp/fake.lock", nil },
+		DetectFunc:       func(_ string) (string, bool) { return "", false },
+	}
+}
+
+func TestViewerCheckCmd_RegisteredAsSubcommand(t *testing.T) {
+	rootCmd := makeRootCmd()
+
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "viewer-check" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'viewer-check' subcommand to be registered")
+	}
+}
+
+func TestViewerCheckCmd_ViewerRunning_NoVerbose_ExitZeroSilentOutput(t *testing.T) {
+	deps := &Deps{ViewerCheck: newViewerCheckDepsRunning("127.0.0.1:8080")}
+	rootCmd := makeRootCmd(deps)
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"viewer-check"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%q)", err, errBuf.String())
+	}
+	if got := outBuf.String(); got != "" {
+		t.Errorf("expected empty stdout, got: %q", got)
+	}
+	if got := errBuf.String(); got != "" {
+		t.Errorf("expected empty stderr, got: %q", got)
+	}
+}
+
+func TestViewerCheckCmd_ViewerRunning_Verbose_StdoutHasAddr(t *testing.T) {
+	addr := "127.0.0.1:8080"
+	deps := &Deps{ViewerCheck: newViewerCheckDepsRunning(addr)}
+	rootCmd := makeRootCmd(deps)
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"viewer-check", "--verbose"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v (stderr=%q)", err, errBuf.String())
+	}
+	if got := errBuf.String(); got != "" {
+		t.Errorf("expected empty stderr, got: %q", got)
+	}
+	want := "viewer addr: " + addr
+	if !strings.Contains(outBuf.String(), want) {
+		t.Errorf("expected stdout to contain %q, got: %q", want, outBuf.String())
+	}
+}
+
+func TestViewerCheckCmd_ViewerRunning_VerboseShortFlag(t *testing.T) {
+	addr := "127.0.0.1:9999"
+	deps := &Deps{ViewerCheck: newViewerCheckDepsRunning(addr)}
+	rootCmd := makeRootCmd(deps)
+	outBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"viewer-check", "-v"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "viewer addr: " + addr
+	if !strings.Contains(outBuf.String(), want) {
+		t.Errorf("expected stdout to contain %q, got: %q", want, outBuf.String())
+	}
+}
+
+func TestViewerCheckCmd_ViewerNotRunning_NoVerbose_NonZeroExitSilentOutput(t *testing.T) {
+	deps := &Deps{ViewerCheck: newViewerCheckDepsNotRunning()}
+	rootCmd := makeRootCmd(deps)
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"viewer-check"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when viewer is not running, got nil")
+	}
+	if got := outBuf.String(); got != "" {
+		t.Errorf("expected empty stdout on failure, got: %q", got)
+	}
+	if got := errBuf.String(); got != "" {
+		t.Errorf("expected empty stderr on failure (non-verbose), got: %q", got)
+	}
+}
+
+func TestViewerCheckCmd_ViewerNotRunning_Verbose_SilentOutput(t *testing.T) {
+	deps := &Deps{ViewerCheck: newViewerCheckDepsNotRunning()}
+	rootCmd := makeRootCmd(deps)
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"viewer-check", "--verbose"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when viewer is not running, got nil")
+	}
+	if got := outBuf.String(); got != "" {
+		t.Errorf("expected empty stdout on failure (verbose), got: %q", got)
+	}
+	if got := errBuf.String(); got != "" {
+		t.Errorf("expected empty stderr on failure (verbose), got: %q", got)
+	}
+}
+
+func TestViewerCheckCmd_Failure_NotErrUsage(t *testing.T) {
+	deps := &Deps{ViewerCheck: newViewerCheckDepsNotRunning()}
+	rootCmd := makeRootCmd(deps)
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"viewer-check"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrUsage) {
+		t.Errorf("viewer check failure should not be ErrUsage (runtime failure, not argument error)")
+	}
+}
+
+func TestViewerCheckCmd_UnknownFlag(t *testing.T) {
+	deps := &Deps{ViewerCheck: newViewerCheckDepsRunning("127.0.0.1:8080")}
+	rootCmd := makeRootCmd(deps)
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"viewer-check", "--bogus"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error for unknown flag, got nil")
+	}
+}
+
+func TestViewerCheckCmd_RejectsPositionalArgs(t *testing.T) {
+	deps := &Deps{ViewerCheck: newViewerCheckDepsRunning("127.0.0.1:8080")}
+	rootCmd := makeRootCmd(deps)
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"viewer-check", "unexpected"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error when positional args provided, got nil")
+	}
+}
+
+func TestViewerCheckCmd_Help(t *testing.T) {
+	deps := &Deps{ViewerCheck: newViewerCheckDepsRunning("127.0.0.1:8080")}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"viewer-check", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error for --help: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"viewer-check", "--verbose"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected help output to contain %q, got: %s", want, out)
+		}
+	}
+}
+
+func TestViewerCheckCmd_MissingDeps_ReturnsError(t *testing.T) {
+	rootCmd := makeRootCmd(&Deps{})
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"viewer-check"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when ViewerCheck deps are missing, got nil")
+	}
+}
+
+func TestViewerCheckCmd_LockPathResolveError_NonZeroExit(t *testing.T) {
+	deps := &Deps{ViewerCheck: &ViewerCheckDeps{
+		LockPathResolver: func() (string, error) { return "", errors.New("home not found") },
+		DetectFunc:       func(_ string) (string, bool) { return "", false },
+	}}
+	rootCmd := makeRootCmd(deps)
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"viewer-check"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when lock path resolution fails, got nil")
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -341,7 +341,7 @@ supported keys:
 vox-actor audio-check [-v|--verbose]
 ```
 
-音声出力デバイスを **open → 即 close** のみ行い、実再生を伴わずに可用性を**終了コード**で返す診断用サブコマンド。シェルスクリプトから `VOX_ACTOR_MONOLOGUE_MODE` 未指定時のモード判定（direct / file）に利用できる。
+音声出力デバイスを **open → 即 close** のみ行い、実再生を伴わずに可用性を**終了コード**で返す診断用サブコマンド。シェルスクリプトからのモード判定（direct / file）に利用できる。
 
 | オプション | 環境変数 | デフォルト値 | 説明 |
 |---|---|---|---|
@@ -389,17 +389,47 @@ $ echo $?
 1
 ```
 
-**シェルスクリプトからのモード判定例:**
+## `viewer-check` サブコマンド
+
+```
+vox-actor viewer-check [-v|--verbose]
+```
+
+viewer のロックファイルと `/api/status` への疎通確認を行い、起動有無を**終了コード**で返す診断用サブコマンド。シェルスクリプトからのモード判定（direct / file）に利用できる。
+
+| オプション | 環境変数 | デフォルト値 | 説明 |
+|---|---|---|---|
+| `--verbose` / `-v` | — | `false` | 診断メッセージを標準出力に出力する |
+
+**出力と終了コード:**
+
+| 状況 | 終了コード | stdout | stderr |
+|---|---|---|---|
+| viewer 起動中（ロックファイルあり＋ `/api/status` 応答 200） | `0` | 空 | 空 |
+| viewer 未起動 or 応答なし | `1` | 空 | 空 |
+
+- `--verbose` 指定時は起動中の場合のみ `viewer addr: <addr>` を stdout に出力する。
+- 機械可読な判定は**終了コード**で行う。
+- `/api/status` への HTTP プローブが入るため、呼び出しごとに数十〜数百ms のオーバーヘッドが発生する。
+
+**使用例:**
 
 ```bash
-MODE="${VOX_ACTOR_MONOLOGUE_MODE:-}"
-if [ -z "$MODE" ]; then
-  if vox-actor audio-check >/dev/null 2>&1; then
-    MODE="direct"
-  else
-    MODE="file"
-  fi
-fi
+# 直接実行（viewer 起動中）
+$ vox-actor viewer-check
+$ echo $?
+0
+
+# verbose 出力
+$ vox-actor viewer-check -v
+viewer addr: 127.0.0.1:8080
+$ echo $?
+0
+
+# viewer 未起動時
+$ vox-actor viewer-check
+$ echo $?
+1
 ```
 
 ## ストリーム配信モード

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -73,7 +73,11 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 >
 > git 管理外ディレクトリで `VOX_ACTOR_WORKSPACE` を明示しないまま実行すると CLI が非0終了し、そのエラーがユーザーに表示されてスクリプトも終了します。git 外で利用する場合は `VOX_ACTOR_WORKSPACE` を明示してください。`file` モードでホストとLLM実行環境を分ける場合も、双方から参照可能な共有パスを明示的に指定します。
 
-モードは `VOX_ACTOR_MONOLOGUE_MODE` 環境変数で明示するか、未設定時は `vox-actor audio-check` の終了コードで自動判定されます（0 → `direct`、非0 → `file`）。
+モードは `vox-actor audio-check` と `vox-actor viewer-check` の終了コードで自動判定されます。どちらか一方でも成功（終了コード 0）であれば `direct` モードで動作します。両方失敗した場合のみ `file` モードに切り替わります。
+
+- `audio-check` 成功: 音声デバイスが利用可能 → `direct`（ローカル再生）
+- `viewer-check` 成功: viewer が起動中 → `direct`（`act` が viewer を検出してブラウザ再生に切替）
+- 両方失敗: `file` モード（queue に滞留）
 
 ### `file` モードのセットアップ（音声デバイス利用不可環境での利用）
 
@@ -87,11 +91,9 @@ claude code をコンテナ／リモートで動かし、音声デバイスは�
    vox-actor watch "$(vox-actor config path.queue)"
    ```
 
-2. **claude code 側で `file` モードを明示し、共有ディレクトリを指定する**
+2. **claude code 側で共有ディレクトリを指定する**
    ```bash
    export VOX_ACTOR_WORKSPACE=/path/to/shared/directory
-   # vox-actorコマンドがある環境で file モードを強制したい場合は以下も指定
-   export VOX_ACTOR_MONOLOGUE_MODE=file
    ```
 
 3. **claude code にプラグインを導入する**（README のクイックスタートと同じ手順）

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func main() {
 				return infra.CheckAudioDevice(infra.NewOtoAudioProbe())
 			},
 		},
+		ViewerCheck: cmd.NewViewerCheckDeps(),
 	}
 
 	if err := cmd.Execute(deps); err != nil {

--- a/plugins/vox-actor-plugin/skills/talk/scripts/play-script.sh
+++ b/plugins/vox-actor-plugin/skills/talk/scripts/play-script.sh
@@ -19,13 +19,10 @@ fi
 QUEUE_DIR=$(vox-actor config path.queue) || exit 1
 WORKSPACE_DIR=$(vox-actor config path.workspace) || exit 1
 
-MODE="${VOX_ACTOR_MONOLOGUE_MODE:-}"
-if [ -z "$MODE" ]; then
-  if vox-actor audio-check >/dev/null 2>&1; then
-    MODE="direct"
-  else
-    MODE="file"
-  fi
+if vox-actor audio-check >/dev/null 2>&1 || vox-actor viewer-check >/dev/null 2>&1; then
+  MODE="direct"
+else
+  MODE="file"
 fi
 
 case "$MODE" in
@@ -54,9 +51,5 @@ case "$MODE" in
     mkdir -p "$QUEUE_DIR"
     DEST="${QUEUE_DIR}/$(basename "$JSONL_PATH")"
     mv "$JSONL_PATH" "$DEST"
-    ;;
-  *)
-    echo "[ERROR] VOX_ACTOR_MONOLOGUE_MODE は 'direct' または 'file' で指定してください: '$MODE'"
-    exit 1
     ;;
 esac

--- a/test/e2e/viewer_check_test.go
+++ b/test/e2e/viewer_check_test.go
@@ -1,0 +1,50 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestViewerCheckE2E_UnexpectedArg_ExitCode2(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, exitCode := runCLI(t, nil, "viewer-check", "unexpected")
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+}
+
+func TestViewerCheckE2E_UnknownFlag_NonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	_, _, exitCode := runCLI(t, nil, "viewer-check", "--bogus")
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for unknown flag, got 0")
+	}
+}
+
+func TestViewerCheckE2E_Help_ExitZeroWithUsage(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, exitCode := runCLI(t, nil, "viewer-check", "--help")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 for viewer-check --help, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+	for _, want := range []string{"viewer-check", "--verbose"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("expected viewer-check --help to contain %q\nstdout:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestViewerCheckE2E_NoViewer_NonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	// viewer が起動していない環境では非0終了することを確認
+	_, _, exitCode := runCLI(t, nil, "viewer-check")
+	if exitCode == 0 {
+		t.Logf("viewer-check returned exit 0 (viewer may be running in this environment)")
+	}
+}


### PR DESCRIPTION
## Summary

- `vox-actor viewer-check` サブコマンドを新設（`infra.DetectViewer` で viewer 起動有無を終了コードで返す）
- `play-script.sh` の MODE 判定を `audio-check OR viewer-check` の OR 条件に変更
- `VOX_ACTOR_MONOLOGUE_MODE` 環境変数を削除（play-script.sh・README・docs 全て）
- `docs/reference/cli.md` に `viewer-check` 章を追加
- `docs/reference/plugins.md` の再生モード説明を更新

## 修正前後の挙動

| 音声デバイス | viewer | 修正前 | 修正後 |
|---|---|---|---|
| あり | – | direct（ローカル再生） | direct（ローカル再生） |
| あり | あり | direct（viewer 検出 → ブラウザ） | direct（viewer 検出 → ブラウザ） |
| なし | – | file（queue 滞留） | file（queue 滞留） |
| なし | あり | **file**（queue 滞留・無音） | **direct**（act が viewer 検出 → ブラウザ）← 改善 |

## Test plan

- [ ] `go test ./...` 全テスト通過確認（CI）
- [ ] `gofmt -l .` / `golangci-lint run` / `shellcheck` 通過確認（CI）
- [ ] 「音声デバイスなし＋viewer 起動」の環境で talk スキル実行 → ブラウザ再生されること（手動）
- [ ] 「音声デバイスなし＋viewer 未起動」の環境で talk スキル実行 → queue に滞留のみで失敗しないこと（手動）

Closes #471

---
🤖 Generated with [Claude Code](https://claude.ai/code)
