### PR TITLE
fix(test): TestPollingDirWatcher flaky を t.Cleanup での goroutine 終了待ちで修正する (#475)

### DIFF
--- a/internal/infra/dir_watcher_test.go
+++ b/internal/infra/dir_watcher_test.go
@@ -205,9 +205,15 @@ func TestPollingDirWatcher_RecreatesMissingDirectory(t *testing.T) {
 		infra.WithPollingDirWatcherLogger(logger),
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 
 	fileCh, errCh := watcher.Watch(ctx, dir)
+	t.Cleanup(func() {
+		cancel()
+		for range fileCh {
+		}
+		for range errCh {
+		}
+	})
 
 	// 監視ディレクトリを削除
 	if err := os.RemoveAll(dir); err != nil {
@@ -334,10 +340,20 @@ func TestPollingDirWatcher_MultipleDirsIndependentOnOneDeleted(t *testing.T) {
 		infra.WithPollingDirWatcherLogger(logger),
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 
-	_, errCh1 := watcher.Watch(ctx, dir1)
+	fileCh1, errCh1 := watcher.Watch(ctx, dir1)
 	fileCh2, errCh2 := watcher.Watch(ctx, dir2)
+	t.Cleanup(func() {
+		cancel()
+		for range fileCh1 {
+		}
+		for range errCh1 {
+		}
+		for range fileCh2 {
+		}
+		for range errCh2 {
+		}
+	})
 
 	// dir1 のみ削除
 	if err := os.RemoveAll(dir1); err != nil {


### PR DESCRIPTION
## Summary

- `TestPollingDirWatcher_RecreatesMissingDirectory` と `TestPollingDirWatcher_MultipleDirsIndependentOnOneDeleted` の flaky を修正
- `defer cancel()` を `t.Cleanup` に置き換えて context キャンセル後に `fileCh`/`errCh` を drain し、watcher goroutine の完全停止を保証する
- `t.Cleanup` は `t.TempDir` の cleanup より後に登録されるため LIFO 順で先に実行される。これにより goroutine が停止する前に TempDir が削除されて `os.MkdirAll` が競合するレースが解消される

## 変更ファイル

- `internal/infra/dir_watcher_test.go`（テストコードのみ。本体ロジックは変更なし）

## Test plan

- [x] `go test -run TestPollingDirWatcher -count=200 ./internal/infra/` がローカルで PASS することを確認済み

Closes #475

---
🤖 Generated with [Claude Code](https://claude.ai/code)
