### PR TITLE
refactor(script): セリフファイルのフィールド名をCLI引数に揃える（破壊的変更）#474

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### Breaking Changes
+
+- **セリフファイルフィールド名の変更** ([#474](https://github.com/canpok1/vox-actor/issues/474))
+  - `.json` / `.jsonl` ファイルのフィールド名を CLI 引数と揃えました。
+  - `speedScale` → `speed`
+  - `pitchScale` → `pitch`
+  - `intonationScale` → `intonation`
+  - 旧フィールド名を含むファイルは読み込みエラーとなります（後方互換なし）。

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,9 +34,9 @@ vox-actor act --speed 1.2 --pitch 0.1 --intonation 1.5 script.txt
 {
   "text": "こんにちは",
   "speaker": 3,
-  "speedScale": 1.2,
-  "pitchScale": 0.1,
-  "intonationScale": 1.5
+  "speed": 1.2,
+  "pitch": 0.1,
+  "intonation": 1.5
 }
 ```
 
@@ -54,7 +54,7 @@ vox-actor act script.json
 
 ```jsonl
 {"text": "こんにちは", "speaker": 3}
-{"text": "また会いましょう", "speaker": 3, "speedScale": 1.2}
+{"text": "また会いましょう", "speaker": 3, "speed": 1.2}
 ```
 
 ```bash
@@ -106,7 +106,7 @@ vox-actor script append <file> <text>
 | `--verbose` | — | `false` | 詳細ログを出力 |
 
 - 出力先ファイルの拡張子で書き出し形式を自動判定します。
-  - `.json` → 1ファイル1スクリプトのJSON。`text` に加え、明示指定された `--speaker` / `--speed` / `--pitch` / `--intonation` を `speaker` / `speedScale` / `pitchScale` / `intonationScale` として保存
+  - `.json` → 1ファイル1スクリプトのJSON。`text` に加え、明示指定された `--speaker` / `--speed` / `--pitch` / `--intonation` を `speaker` / `speed` / `pitch` / `intonation` として保存
   - `.jsonl` → 1行JSON（フィールドは `.json` と同じ）
   - `.txt` および **未知の拡張子** → 本文のみのテキストファイル（拡張子はそのまま）
     - このとき `--speaker` / `--speed` / `--pitch` / `--intonation` がコマンドラインで明示指定されていたら、これらは保存できない旨を WARN ログで通知します（処理は継続）

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -38,12 +38,12 @@ claude code に `vox-actor-plugin` を導入すると、以下のスラッシュ
 ずんだもん（`speakers.ノーマル: 3`、`あまあま: 1`）と四国めたん（`ノーマル: 2`、`ツンツン: 6`）の会話例:
 
 ```jsonl
-{"text": "今日はクロージャについて解説するのだ！", "speaker": 3, "speedScale": 1.1}
-{"text": "あら、わたくしも勉強させてもらおうかしら", "speaker": 2, "speedScale": 1.0}
-{"text": "簡単に言うと、関数が作られた時の周りの変数を覚えておく仕組みなのだ", "speaker": 3, "speedScale": 1.0}
-{"text": "なるほど、お弁当箱みたいなものですわね", "speaker": 2, "speedScale": 1.0}
-{"text": "そう、そんな感じなのだー", "speaker": 1, "speedScale": 0.9}
-{"text": "よく分かりましたわ。ありがとう、ずんだもん", "speaker": 2, "speedScale": 1.0}
+{"text": "今日はクロージャについて解説するのだ！", "speaker": 3, "speed": 1.1}
+{"text": "あら、わたくしも勉強させてもらおうかしら", "speaker": 2, "speed": 1.0}
+{"text": "簡単に言うと、関数が作られた時の周りの変数を覚えておく仕組みなのだ", "speaker": 3, "speed": 1.0}
+{"text": "なるほど、お弁当箱みたいなものですわね", "speaker": 2, "speed": 1.0}
+{"text": "そう、そんな感じなのだー", "speaker": 1, "speed": 0.9}
+{"text": "よく分かりましたわ。ありがとう、ずんだもん", "speaker": 2, "speed": 1.0}
 ```
 
 ## 再生モード（direct／file）

--- a/internal/infra/file_reader.go
+++ b/internal/infra/file_reader.go
@@ -30,9 +30,9 @@ var supportedExts = map[string]bool{
 type jsonScript struct {
 	Text            *string  `json:"text"`
 	Speaker         *int     `json:"speaker"`
-	SpeedScale      *float64 `json:"speedScale"`
-	PitchScale      *float64 `json:"pitchScale"`
-	IntonationScale *float64 `json:"intonationScale"`
+	SpeedScale      *float64 `json:"speed"`
+	PitchScale      *float64 `json:"pitch"`
+	IntonationScale *float64 `json:"intonation"`
 }
 
 // toScript は jsonScript を entity.Script に変換する。

--- a/internal/infra/file_reader_test.go
+++ b/internal/infra/file_reader_test.go
@@ -327,7 +327,7 @@ func TestFileReader_Read_JSONFile_AllParams(t *testing.T) {
 
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "script.json")
-	content := `{"text": "感情込めて", "speaker": 5, "speedScale": 1.5, "pitchScale": 0.1, "intonationScale": 1.8}`
+	content := `{"text": "感情込めて", "speaker": 5, "speed": 1.5, "pitch": 0.1, "intonation": 1.8}`
 	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -381,7 +381,7 @@ func TestFileReader_Read_JSONFile_MissingText(t *testing.T) {
 
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "notext.json")
-	content := `{"speaker": 5, "speedScale": 1.0}`
+	content := `{"speaker": 5, "speed": 1.0}`
 	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +525,7 @@ func TestFileReader_Read_JSONLFile_AllParams(t *testing.T) {
 
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "script.jsonl")
-	content := `{"text": "感情込めて", "speaker": 5, "speedScale": 1.5, "pitchScale": 0.1, "intonationScale": 1.8}`
+	content := `{"text": "感情込めて", "speaker": 5, "speed": 1.5, "pitch": 0.1, "intonation": 1.8}`
 	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/infra/file_reader_test.go
+++ b/internal/infra/file_reader_test.go
@@ -444,6 +444,34 @@ func TestFileReader_Read_JSONFile_UnknownField(t *testing.T) {
 	}
 }
 
+func TestFileReader_Read_JSONFile_LegacyFieldsRejected(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"speedScale", `{"text": "こんにちは", "speedScale": 1.2}`},
+		{"pitchScale", `{"text": "こんにちは", "pitchScale": 0.1}`},
+		{"intonationScale", `{"text": "こんにちは", "intonationScale": 1.5}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			filePath := filepath.Join(dir, "script.json")
+			if err := os.WriteFile(filePath, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			reader := infra.NewFileReader()
+			_, err := reader.Read(filePath)
+			if err == nil {
+				t.Fatalf("expected error for legacy field %q, got nil", tc.name)
+			}
+		})
+	}
+}
+
 // --- JSONL朗読劇モード テスト ---
 
 func TestFileReader_Read_JSONLFile_MultipleLines(t *testing.T) {

--- a/internal/infra/file_writer.go
+++ b/internal/infra/file_writer.go
@@ -151,9 +151,9 @@ func (w *FileWriter) warnUnsavedParams(path string, script entity.Script) {
 type jsonScriptOut struct {
 	Text            string   `json:"text"`
 	Speaker         *int     `json:"speaker,omitempty"`
-	SpeedScale      *float64 `json:"speedScale,omitempty"`
-	PitchScale      *float64 `json:"pitchScale,omitempty"`
-	IntonationScale *float64 `json:"intonationScale,omitempty"`
+	SpeedScale      *float64 `json:"speed,omitempty"`
+	PitchScale      *float64 `json:"pitch,omitempty"`
+	IntonationScale *float64 `json:"intonation,omitempty"`
 }
 
 func toJSONScript(script entity.Script) jsonScriptOut {

--- a/internal/infra/file_writer_test.go
+++ b/internal/infra/file_writer_test.go
@@ -61,14 +61,14 @@ func TestFileWriter_Write_JSON_TextOnly(t *testing.T) {
 	if _, exists := got["speaker"]; exists {
 		t.Errorf("expected speaker omitted, got %v", got["speaker"])
 	}
-	if _, exists := got["speedScale"]; exists {
-		t.Errorf("expected speedScale omitted, got %v", got["speedScale"])
+	if _, exists := got["speed"]; exists {
+		t.Errorf("expected speed omitted, got %v", got["speed"])
 	}
-	if _, exists := got["pitchScale"]; exists {
-		t.Errorf("expected pitchScale omitted, got %v", got["pitchScale"])
+	if _, exists := got["pitch"]; exists {
+		t.Errorf("expected pitch omitted, got %v", got["pitch"])
 	}
-	if _, exists := got["intonationScale"]; exists {
-		t.Errorf("expected intonationScale omitted, got %v", got["intonationScale"])
+	if _, exists := got["intonation"]; exists {
+		t.Errorf("expected intonation omitted, got %v", got["intonation"])
 	}
 }
 
@@ -104,14 +104,14 @@ func TestFileWriter_Write_JSON_AllParams(t *testing.T) {
 	if got["speaker"].(float64) != 5 {
 		t.Errorf("speaker mismatch: %v", got["speaker"])
 	}
-	if got["speedScale"].(float64) != 1.5 {
-		t.Errorf("speedScale mismatch: %v", got["speedScale"])
+	if got["speed"].(float64) != 1.5 {
+		t.Errorf("speed mismatch: %v", got["speed"])
 	}
-	if got["pitchScale"].(float64) != 0.1 {
-		t.Errorf("pitchScale mismatch: %v", got["pitchScale"])
+	if got["pitch"].(float64) != 0.1 {
+		t.Errorf("pitch mismatch: %v", got["pitch"])
 	}
-	if got["intonationScale"].(float64) != 1.8 {
-		t.Errorf("intonationScale mismatch: %v", got["intonationScale"])
+	if got["intonation"].(float64) != 1.8 {
+		t.Errorf("intonation mismatch: %v", got["intonation"])
 	}
 }
 
@@ -136,14 +136,14 @@ func TestFileWriter_Write_JSON_OmitNilFields(t *testing.T) {
 	}
 
 	contents := string(data)
-	if strings.Contains(contents, "speedScale") {
-		t.Errorf("expected speedScale omitted, got: %s", contents)
+	if strings.Contains(contents, "speed") {
+		t.Errorf("expected speed omitted, got: %s", contents)
 	}
-	if strings.Contains(contents, "pitchScale") {
-		t.Errorf("expected pitchScale omitted, got: %s", contents)
+	if strings.Contains(contents, "pitch") {
+		t.Errorf("expected pitch omitted, got: %s", contents)
 	}
-	if strings.Contains(contents, "intonationScale") {
-		t.Errorf("expected intonationScale omitted, got: %s", contents)
+	if strings.Contains(contents, "intonation") {
+		t.Errorf("expected intonation omitted, got: %s", contents)
 	}
 	if !strings.Contains(contents, `"speaker":2`) && !strings.Contains(contents, `"speaker": 2`) {
 		t.Errorf("expected speaker:2 included, got: %s", contents)

--- a/internal/infra/file_writer_test.go
+++ b/internal/infra/file_writer_test.go
@@ -136,13 +136,13 @@ func TestFileWriter_Write_JSON_OmitNilFields(t *testing.T) {
 	}
 
 	contents := string(data)
-	if strings.Contains(contents, "speed") {
+	if strings.Contains(contents, `"speed":`) {
 		t.Errorf("expected speed omitted, got: %s", contents)
 	}
-	if strings.Contains(contents, "pitch") {
+	if strings.Contains(contents, `"pitch":`) {
 		t.Errorf("expected pitch omitted, got: %s", contents)
 	}
-	if strings.Contains(contents, "intonation") {
+	if strings.Contains(contents, `"intonation":`) {
 		t.Errorf("expected intonation omitted, got: %s", contents)
 	}
 	if !strings.Contains(contents, `"speaker":2`) && !strings.Contains(contents, `"speaker": 2`) {

--- a/test/e2e/act_test.go
+++ b/test/e2e/act_test.go
@@ -28,7 +28,7 @@ func TestActE2E_TxtFile_DryRun(t *testing.T) {
 
 func TestActE2E_JsonFile_DryRun_OverrideParams(t *testing.T) {
 	dir := t.TempDir()
-	content := `{"text":"こんにちは","speaker":11,"speedScale":1.2,"pitchScale":0.1,"intonationScale":1.5}`
+	content := `{"text":"こんにちは","speaker":11,"speed":1.2,"pitch":0.1,"intonation":1.5}`
 	path := writeTempFile(t, dir, "script.json", content)
 
 	_, stderr, exitCode := runCLI(t, nil, "act", "--dry-run", path)
@@ -293,7 +293,7 @@ func TestActE2E_JsonlFile_PerLineParams_Reflected(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	content := `{"text":"いちぎょうめ","speaker":11,"speedScale":1.2,"pitchScale":0.05,"intonationScale":1.3}
+	content := `{"text":"いちぎょうめ","speaker":11,"speed":1.2,"pitch":0.05,"intonation":1.3}
 {"text":"にぎょうめ","speaker":7}
 `
 	path := writeTempFile(t, dir, "params.jsonl", content)

--- a/test/e2e/script_test.go
+++ b/test/e2e/script_test.go
@@ -14,9 +14,9 @@ import (
 type scriptJSON struct {
 	Text            string   `json:"text"`
 	Speaker         *int     `json:"speaker"`
-	SpeedScale      *float64 `json:"speedScale"`
-	PitchScale      *float64 `json:"pitchScale"`
-	IntonationScale *float64 `json:"intonationScale"`
+	SpeedScale      *float64 `json:"speed"`
+	PitchScale      *float64 `json:"pitch"`
+	IntonationScale *float64 `json:"intonation"`
 }
 
 // readScriptJSON は path のファイルの最初の行を JSON としてパースして返す。
@@ -214,13 +214,13 @@ func TestScriptAppendE2E_VoiceParams_Reflected(t *testing.T) {
 		t.Errorf("expected speaker=5, got %v", s.Speaker)
 	}
 	if s.SpeedScale == nil || *s.SpeedScale != 1.2 {
-		t.Errorf("expected speedScale=1.2, got %v", s.SpeedScale)
+		t.Errorf("expected speed=1.2, got %v", s.SpeedScale)
 	}
 	if s.PitchScale == nil || *s.PitchScale != 0.05 {
-		t.Errorf("expected pitchScale=0.05, got %v", s.PitchScale)
+		t.Errorf("expected pitch=0.05, got %v", s.PitchScale)
 	}
 	if s.IntonationScale == nil || *s.IntonationScale != 1.5 {
-		t.Errorf("expected intonationScale=1.5, got %v", s.IntonationScale)
+		t.Errorf("expected intonation=1.5, got %v", s.IntonationScale)
 	}
 }
 
@@ -240,13 +240,13 @@ func TestScriptAppendE2E_VoiceParams_Omitempty(t *testing.T) {
 		t.Errorf("expected speaker to be omitted, got %v", *s.Speaker)
 	}
 	if s.SpeedScale != nil {
-		t.Errorf("expected speedScale to be omitted, got %v", *s.SpeedScale)
+		t.Errorf("expected speed to be omitted, got %v", *s.SpeedScale)
 	}
 	if s.PitchScale != nil {
-		t.Errorf("expected pitchScale to be omitted, got %v", *s.PitchScale)
+		t.Errorf("expected pitch to be omitted, got %v", *s.PitchScale)
 	}
 	if s.IntonationScale != nil {
-		t.Errorf("expected intonationScale to be omitted, got %v", *s.IntonationScale)
+		t.Errorf("expected intonation to be omitted, got %v", *s.IntonationScale)
 	}
 }
 

--- a/test/e2e/watch_test.go
+++ b/test/e2e/watch_test.go
@@ -358,7 +358,7 @@ func TestWatchE2E_JsonFile_DryRun_OverrideParams(t *testing.T) {
 	wp := startWatch(t, nil, "--dry-run", dir)
 	wp.waitForStderr("watching directory", 5*time.Second)
 
-	content := `{"text":"こんにちは","speaker":11,"speedScale":1.2,"pitchScale":0.1,"intonationScale":1.5}`
+	content := `{"text":"こんにちは","speaker":11,"speed":1.2,"pitch":0.1,"intonation":1.5}`
 	src := writeTempFile(t, dir, "b.json", content)
 
 	line := wp.waitForStderr("playback completed", 10*time.Second)
@@ -603,7 +603,7 @@ func TestWatchE2E_JsonlPerLineOverride_DryRun(t *testing.T) {
 	wp := startWatch(t, nil, "--dry-run", dir)
 	wp.waitForStderr("watching directory", 5*time.Second)
 
-	content := `{"text":"てきすと","speaker":11,"speedScale":1.2,"pitchScale":0.1,"intonationScale":1.5}` + "\n"
+	content := `{"text":"てきすと","speaker":11,"speed":1.2,"pitch":0.1,"intonation":1.5}` + "\n"
 	writeTempFile(t, dir, "a.jsonl", content)
 
 	line := wp.waitForStderr("playback completed", 10*time.Second)


### PR DESCRIPTION
## Summary

セリフファイル（`.json` / `.jsonl`）のフィールド名を CLI 引数と揃える破壊的変更です。

| 旧フィールド名 | 新フィールド名 |
|---|---|
| `speedScale` | `speed` |
| `pitchScale` | `pitch` |
| `intonationScale` | `intonation` |

- `internal/infra/file_reader.go` / `file_writer.go` の JSON 構造体タグを変更
- ユニットテスト・e2e テストの期待値を新フィールド名に更新
- `docs/reference/cli.md` / `docs/reference/plugins.md` のサンプルを更新
- `CHANGELOG.md` を新規作成して破壊的変更を記録
- 旧フィールド名が `DisallowUnknownFields` でエラーになることを明示するテストを追加

## Breaking Changes

旧フィールド名（`speedScale` / `pitchScale` / `intonationScale`）を含むセリフファイルは読み込みエラーになります。後方互換期間は設けません。

## Test Plan

- [x] `go test ./...` が全てパスすること
- [ ] `vox-actor script append` で出力されるファイルのフィールド名が `speed` / `pitch` / `intonation` になること（VOICEVOX 接続が必要なため手動確認）

Closes #474

---
🤖 Generated with [Claude Code](https://claude.ai/code)
