### PR TITLE
feat(script): セリフを一括書き込みする script write サブコマンドを追加する

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ type Deps struct {
 	Watch        *WatchDeps
 	Say          *SayDeps
 	ScriptAppend *ScriptAppendDeps
+	ScriptWrite  *ScriptWriteDeps
 	AudioCheck   *AudioCheckDeps
 	ViewerCheck  *ViewerCheckDeps
 	Viewer       *ViewerDeps
@@ -58,6 +59,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	var watchDeps *WatchDeps
 	var sayDeps *SayDeps
 	var scriptAppendDeps *ScriptAppendDeps
+	var scriptWriteDeps *ScriptWriteDeps
 	var audioCheckDeps *AudioCheckDeps
 	var viewerCheckDeps *ViewerCheckDeps
 	var assetsDeps *AssetsDownloadDeps
@@ -67,6 +69,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 		watchDeps = d.Watch
 		sayDeps = d.Say
 		scriptAppendDeps = d.ScriptAppend
+		scriptWriteDeps = d.ScriptWrite
 		audioCheckDeps = d.AudioCheck
 		viewerCheckDeps = d.ViewerCheck
 		assetsDeps = d.Assets
@@ -79,7 +82,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	cmd.AddCommand(makeActCmd(actDeps))
 	cmd.AddCommand(makeWatchCmd(watchDeps))
 	cmd.AddCommand(makeSayCmd(sayDeps))
-	cmd.AddCommand(makeScriptCmd(scriptAppendDeps))
+	cmd.AddCommand(makeScriptCmd(scriptAppendDeps, scriptWriteDeps))
 	cmd.AddCommand(makeConfigCmd())
 	cmd.AddCommand(makeAudioCheckCmd(audioCheckDeps))
 	cmd.AddCommand(makeViewerCheckCmd(viewerCheckDeps))

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -2,7 +2,7 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-func makeScriptCmd(appendDeps *ScriptAppendDeps) *cobra.Command {
+func makeScriptCmd(appendDeps *ScriptAppendDeps, writeDeps *ScriptWriteDeps) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "script",
 		Short: "セリフファイルを操作する",
@@ -13,6 +13,7 @@ func makeScriptCmd(appendDeps *ScriptAppendDeps) *cobra.Command {
 	}
 
 	cmd.AddCommand(makeScriptAppendCmd(appendDeps))
+	cmd.AddCommand(makeScriptWriteCmd(writeDeps))
 
 	return cmd
 }

--- a/cmd/script_write.go
+++ b/cmd/script_write.go
@@ -47,6 +47,10 @@ func makeScriptWriteCmd(deps *ScriptWriteDeps) *cobra.Command {
 }
 
 func runScriptWrite(cmd *cobra.Command, args []string, deps *ScriptWriteDeps) error {
+	if deps == nil || deps.WriterFactory == nil {
+		return fmt.Errorf("ScriptBulkWriter factory is not configured for script write")
+	}
+
 	file := args[0]
 	if !cmd.Flags().Changed("json") {
 		return fmt.Errorf("%w: required flag --json not set", ErrUsage)
@@ -68,10 +72,6 @@ func runScriptWrite(cmd *cobra.Command, args []string, deps *ScriptWriteDeps) er
 			PitchScale:      in.Pitch,
 			IntonationScale: in.Intonation,
 		}
-	}
-
-	if deps == nil || deps.WriterFactory == nil {
-		return fmt.Errorf("ScriptBulkWriter factory is not configured for script write")
 	}
 
 	logger := buildLoggerFromFlags(cmd)

--- a/cmd/script_write.go
+++ b/cmd/script_write.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/spf13/cobra"
+)
+
+// ScriptWriteDeps は script write コマンドの依存を保持する。
+type ScriptWriteDeps struct {
+	WriterFactory func(logger *slog.Logger) app.ScriptBulkWriter
+}
+
+// scriptWriteInput は --json フラグで受け取る JSON 配列の各要素のスキーマ。
+type scriptWriteInput struct {
+	Text       string   `json:"text"`
+	Speaker    *int     `json:"speaker"`
+	Speed      *float64 `json:"speed"`
+	Pitch      *float64 `json:"pitch"`
+	Intonation *float64 `json:"intonation"`
+}
+
+func makeScriptWriteCmd(deps *ScriptWriteDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "write <file>",
+		Short: "セリフを JSON 配列でファイルへ一括書き込みする",
+		Long:  "JSON 配列で渡した複数のセリフを指定ファイルへ一括書き込みする（上書き）。VOICEVOX接続・音声再生は行わない。",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return fmt.Errorf("%w: %s", ErrUsage, err)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runScriptWrite(cmd, args, deps)
+		},
+	}
+
+	cmd.Flags().String("json", "", "セリフの JSON 配列（必須）")
+	cmd.Flags().Bool("verbose", false, "詳細ログを出力")
+
+	return cmd
+}
+
+func runScriptWrite(cmd *cobra.Command, args []string, deps *ScriptWriteDeps) error {
+	file := args[0]
+	if !cmd.Flags().Changed("json") {
+		return fmt.Errorf("%w: required flag --json not set", ErrUsage)
+	}
+	jsonStr, _ := cmd.Flags().GetString("json")
+
+	var inputs []scriptWriteInput
+	if err := json.Unmarshal([]byte(jsonStr), &inputs); err != nil {
+		return fmt.Errorf("%w: invalid JSON: %s", ErrUsage, err)
+	}
+
+	scripts := make([]entity.Script, len(inputs))
+	for i, in := range inputs {
+		scripts[i] = entity.Script{
+			Text:            in.Text,
+			IsEmpty:         in.Text == "",
+			SpeakerID:       in.Speaker,
+			SpeedScale:      in.Speed,
+			PitchScale:      in.Pitch,
+			IntonationScale: in.Intonation,
+		}
+	}
+
+	if deps == nil || deps.WriterFactory == nil {
+		return fmt.Errorf("ScriptBulkWriter factory is not configured for script write")
+	}
+
+	logger := buildLoggerFromFlags(cmd)
+	writer := deps.WriterFactory(logger)
+	written, err := writer.WriteAll(file, scripts)
+	if err != nil {
+		return err
+	}
+	logger.Info("output completed", "path", written)
+	return nil
+}

--- a/cmd/script_write_test.go
+++ b/cmd/script_write_test.go
@@ -52,7 +52,13 @@ func TestScriptWriteCmd_RegisteredUnderScript(t *testing.T) {
 }
 
 func TestScriptWriteCmd_NoJsonFlag_ReturnsUsageError(t *testing.T) {
-	rootCmd := makeRootCmd()
+	writer := &captureScriptBulkWriter{}
+	deps := &Deps{
+		ScriptWrite: &ScriptWriteDeps{
+			WriterFactory: func(_ *slog.Logger) app.ScriptBulkWriter { return writer },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)

--- a/cmd/script_write_test.go
+++ b/cmd/script_write_test.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+// script write コマンド テストリスト
+// DONE: script writeサブコマンドがscriptに登録されている
+// DONE: --json なしでErrUsageを返す
+// DONE: --json が不正なJSONのときErrUsageを返す
+// DONE: WriterFactoryがnilのときエラーになる
+// DONE: WriteAllが呼ばれる
+// DONE: JSON配列の各フィールドがScriptに正しく変換される
+// DONE: text=""の要素はIsEmpty=trueとして扱われる
+// DONE: ヘルプ出力に--verboseが含まれ--engine-url/--dry-runが含まれない
+
+type captureScriptBulkWriter struct {
+	calls []captureBulkWriterCall
+}
+
+type captureBulkWriterCall struct {
+	path    string
+	scripts []entity.Script
+}
+
+func (w *captureScriptBulkWriter) WriteAll(path string, scripts []entity.Script) (string, error) {
+	w.calls = append(w.calls, captureBulkWriterCall{path: path, scripts: scripts})
+	return path, nil
+}
+
+func TestScriptWriteCmd_RegisteredUnderScript(t *testing.T) {
+	rootCmd := makeRootCmd()
+	scriptCmd := findScriptCmd(t, rootCmd)
+	found := false
+	for _, c := range scriptCmd.Commands() {
+		if c.Name() == "write" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'write' subcommand under 'script'")
+	}
+}
+
+func TestScriptWriteCmd_NoJsonFlag_ReturnsUsageError(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	tmpDir := t.TempDir()
+	rootCmd.SetArgs([]string{"script", "write", filepath.Join(tmpDir, "out.jsonl")})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --json is missing, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func TestScriptWriteCmd_InvalidJson_ReturnsUsageError(t *testing.T) {
+	writer := &captureScriptBulkWriter{}
+	deps := &Deps{
+		ScriptWrite: &ScriptWriteDeps{
+			WriterFactory: func(_ *slog.Logger) app.ScriptBulkWriter { return writer },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	tmpDir := t.TempDir()
+	rootCmd.SetArgs([]string{"script", "write", "--json", "not-valid-json", filepath.Join(tmpDir, "out.jsonl")})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if !errors.Is(err, ErrUsage) {
+		t.Errorf("expected ErrUsage, got: %v", err)
+	}
+}
+
+func TestScriptWriteCmd_NilWriterFactory_ReturnsError(t *testing.T) {
+	deps := &Deps{
+		ScriptWrite: &ScriptWriteDeps{
+			WriterFactory: nil,
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	tmpDir := t.TempDir()
+	rootCmd.SetArgs([]string{
+		"script", "write",
+		"--json", `[{"text":"hello"}]`,
+		filepath.Join(tmpDir, "out.jsonl"),
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when WriterFactory is nil, got nil")
+	}
+}
+
+func TestScriptWriteCmd_CallsWriteAll(t *testing.T) {
+	writer := &captureScriptBulkWriter{}
+	deps := &Deps{
+		ScriptWrite: &ScriptWriteDeps{
+			WriterFactory: func(_ *slog.Logger) app.ScriptBulkWriter { return writer },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "out.jsonl")
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{
+		"script", "write",
+		"--json", `[{"text":"hello"}]`,
+		dest,
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(writer.calls) != 1 {
+		t.Fatalf("expected 1 WriteAll call, got: %d", len(writer.calls))
+	}
+	if writer.calls[0].path != dest {
+		t.Errorf("expected path=%q, got %q", dest, writer.calls[0].path)
+	}
+	if len(writer.calls[0].scripts) != 1 {
+		t.Fatalf("expected 1 script, got: %d", len(writer.calls[0].scripts))
+	}
+	if writer.calls[0].scripts[0].Text != "hello" {
+		t.Errorf("expected text=hello, got %q", writer.calls[0].scripts[0].Text)
+	}
+}
+
+func TestScriptWriteCmd_JsonFieldsMappedToScript(t *testing.T) {
+	writer := &captureScriptBulkWriter{}
+	deps := &Deps{
+		ScriptWrite: &ScriptWriteDeps{
+			WriterFactory: func(_ *slog.Logger) app.ScriptBulkWriter { return writer },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "out.jsonl")
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{
+		"script", "write",
+		"--json", `[{"text":"セリフ","speaker":3,"speed":1.2,"pitch":0.05,"intonation":1.1}]`,
+		dest,
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(writer.calls) != 1 || len(writer.calls[0].scripts) != 1 {
+		t.Fatalf("unexpected calls: %v", writer.calls)
+	}
+	s := writer.calls[0].scripts[0]
+	if s.Text != "セリフ" {
+		t.Errorf("Text: expected 'セリフ', got %q", s.Text)
+	}
+	if s.SpeakerID == nil || *s.SpeakerID != 3 {
+		t.Errorf("SpeakerID: expected 3, got %v", s.SpeakerID)
+	}
+	if s.SpeedScale == nil || *s.SpeedScale != 1.2 {
+		t.Errorf("SpeedScale: expected 1.2, got %v", s.SpeedScale)
+	}
+	if s.PitchScale == nil || *s.PitchScale != 0.05 {
+		t.Errorf("PitchScale: expected 0.05, got %v", s.PitchScale)
+	}
+	if s.IntonationScale == nil || *s.IntonationScale != 1.1 {
+		t.Errorf("IntonationScale: expected 1.1, got %v", s.IntonationScale)
+	}
+}
+
+func TestScriptWriteCmd_EmptyTextIsEmpty(t *testing.T) {
+	writer := &captureScriptBulkWriter{}
+	deps := &Deps{
+		ScriptWrite: &ScriptWriteDeps{
+			WriterFactory: func(_ *slog.Logger) app.ScriptBulkWriter { return writer },
+		},
+	}
+	rootCmd := makeRootCmd(deps)
+
+	tmpDir := t.TempDir()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{
+		"script", "write",
+		"--json", `[{"text":""}]`,
+		filepath.Join(tmpDir, "out.jsonl"),
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(writer.calls) != 1 || len(writer.calls[0].scripts) != 1 {
+		t.Fatalf("unexpected calls: %v", writer.calls)
+	}
+	if !writer.calls[0].scripts[0].IsEmpty {
+		t.Error("expected IsEmpty=true for empty text")
+	}
+}
+
+func TestScriptWriteCmd_HelpContainsVerboseNotEngineURL(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"script", "write", "--help"})
+
+	_ = rootCmd.Execute()
+
+	output := buf.String()
+	if !strings.Contains(output, "--verbose") {
+		t.Errorf("expected help to contain '--verbose'\nstdout:\n%s", output)
+	}
+	if !strings.Contains(output, "--json") {
+		t.Errorf("expected help to contain '--json'\nstdout:\n%s", output)
+	}
+	for _, flag := range []string{"--engine-url", "--dry-run"} {
+		if strings.Contains(output, flag) {
+			t.Errorf("expected help NOT to contain %q\nstdout:\n%s", flag, output)
+		}
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -124,6 +124,47 @@ vox-actor script append "$(vox-actor config path.queue)/01.txt" "こんにちは
 vox-actor script append "$(vox-actor config path.queue)/01.json" --speaker 5 --speed 1.2 "こんにちは"
 ```
 
+### `script write` サブコマンド
+
+```
+vox-actor script write <file> --json '<JSON配列>'
+```
+
+JSON 配列で渡した複数のセリフを指定ファイルへ一括書き込みする（上書き）。VOICEVOX接続・音声再生は行わない。`talk` スキルなど複数セリフを 1 回で書き出したいユースケースに利用できる。
+
+| オプション | 環境変数 | デフォルト値 | 説明 |
+|---|---|---|---|
+| `--json` | — | （必須） | セリフの JSON 配列 |
+| `--verbose` | — | `false` | 詳細ログを出力 |
+
+`--json` の各オブジェクトのキー:
+
+| キー | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `text` | string | ✓ | セリフ本文 |
+| `speaker` | int | | キャラクターID |
+| `speed` | float | | 話速 |
+| `pitch` | float | | 音高 |
+| `intonation` | float | | 抑揚 |
+
+- 出力先ファイルを**新規作成または上書き**します（`append` と異なり既存内容は削除されます）。
+- 省略したキーは出力 JSONL に含まれません（既存の JSONL フォーマットと同一）。
+- `--json` の JSON パースエラー時は終了コード 2 で失敗します。
+
+```bash
+vox-actor script write sample.jsonl --json '[
+  {"text":"おはようなのだ","speaker":3,"intonation":1.1},
+  {"text":"今日もがんばるのだ","speaker":3,"speed":1.0}
+]'
+```
+
+出力（`sample.jsonl`）:
+
+```jsonl
+{"text":"おはようなのだ","speaker":3,"intonation":1.1}
+{"text":"今日もがんばるのだ","speaker":3,"speed":1.0}
+```
+
 ## `act` サブコマンド
 
 ```

--- a/internal/app/port.go
+++ b/internal/app/port.go
@@ -23,6 +23,14 @@ type ScriptWriter interface {
 	Write(path string, script entity.Script) (string, error)
 }
 
+// ScriptBulkWriter は複数の entity.Script をファイルへ一括書き出すインターフェース。
+type ScriptBulkWriter interface {
+	// WriteAll は scripts を path に上書き書き出す。
+	// 既存ファイルがある場合は上書きされる。
+	// 戻り値は実際の書き出し先パス。
+	WriteAll(path string, scripts []entity.Script) (string, error)
+}
+
 // FileMover はファイルを処理済みディレクトリに移動または削除するインターフェース。
 type FileMover interface {
 	// MoveToDone はファイルを親ディレクトリのdone/サブディレクトリに移動する。

--- a/internal/infra/file_writer.go
+++ b/internal/infra/file_writer.go
@@ -101,14 +101,8 @@ func (w *FileWriter) Write(path string, script entity.Script) (string, error) {
 		}
 	}
 
-	// 親ディレクトリの存在確認
-	parent := filepath.Dir(path)
-	info, err := os.Stat(parent)
-	if err != nil {
-		return "", fmt.Errorf("parent directory does not exist: %s: %w", parent, err)
-	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("parent path is not a directory: %s", parent)
+	if err := validateParentDir(path); err != nil {
+		return "", err
 	}
 
 	dest := path
@@ -180,15 +174,22 @@ func writeText(path string, text string) error {
 	return appendToFile(path, []byte(text))
 }
 
-// WriteAll は scripts を path に上書き書き出す。既存ファイルがある場合は上書きされる。
-func (w *FileWriter) WriteAll(path string, scripts []entity.Script) (string, error) {
+func validateParentDir(path string) error {
 	parent := filepath.Dir(path)
 	info, err := os.Stat(parent)
 	if err != nil {
-		return "", fmt.Errorf("parent directory does not exist: %s: %w", parent, err)
+		return fmt.Errorf("parent directory does not exist: %s: %w", parent, err)
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("parent path is not a directory: %s", parent)
+		return fmt.Errorf("parent path is not a directory: %s", parent)
+	}
+	return nil
+}
+
+// WriteAll は scripts を path に上書き書き出す。既存ファイルがある場合は上書きされる。
+func (w *FileWriter) WriteAll(path string, scripts []entity.Script) (string, error) {
+	if err := validateParentDir(path); err != nil {
+		return "", err
 	}
 
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)

--- a/internal/infra/file_writer.go
+++ b/internal/infra/file_writer.go
@@ -28,6 +28,7 @@ type FileWriter struct {
 }
 
 var _ app.ScriptWriter = (*FileWriter)(nil)
+var _ app.ScriptBulkWriter = (*FileWriter)(nil)
 
 // FileWriterOption は FileWriter の生成時に指定するオプション。
 type FileWriterOption func(*FileWriter)
@@ -177,6 +178,36 @@ func writeJSONLine(path string, script entity.Script) error {
 
 func writeText(path string, text string) error {
 	return appendToFile(path, []byte(text))
+}
+
+// WriteAll は scripts を path に上書き書き出す。既存ファイルがある場合は上書きされる。
+func (w *FileWriter) WriteAll(path string, scripts []entity.Script) (string, error) {
+	parent := filepath.Dir(path)
+	info, err := os.Stat(parent)
+	if err != nil {
+		return "", fmt.Errorf("parent directory does not exist: %s: %w", parent, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("parent path is not a directory: %s", parent)
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("failed to open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	for _, script := range scripts {
+		data, err := json.Marshal(toJSONScript(script))
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		data = append(data, '\n')
+		if _, err := f.Write(data); err != nil {
+			return "", fmt.Errorf("failed to write %s: %w", path, err)
+		}
+	}
+	return path, nil
 }
 
 func appendToFile(path string, data []byte) error {

--- a/internal/infra/file_writer_test.go
+++ b/internal/infra/file_writer_test.go
@@ -504,6 +504,176 @@ func TestFileWriter_Write_UnsupportedExtension_ReturnsError(t *testing.T) {
 	}
 }
 
+// ─────────────────────────────────────────
+// FileWriter.WriteAll テスト
+// ─────────────────────────────────────────
+//
+// テストリスト:
+// - 複数要素を一括書き込みし既存 JSONL フォーマットと一致する → TestFileWriter_WriteAll_MultipleScripts
+// - 空配列を渡すと空ファイルが作成される                  → TestFileWriter_WriteAll_EmptySlice
+// - 既存ファイルを上書きする                            → TestFileWriter_WriteAll_OverwritesExisting
+// - 各要素の IsEmpty=true が text="" のとき伝わる         → TestFileWriter_WriteAll_EmptyTextIsEmpty
+// - 親ディレクトリ未存在時はエラー                       → TestFileWriter_WriteAll_MissingParentDir
+
+func TestFileWriter_WriteAll_MultipleScripts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.jsonl")
+
+	w := infra.NewFileWriter()
+	scripts := []entity.Script{
+		{Text: "おはようなのだ", SpeakerID: ptrInt(3), IntonationScale: ptrFloat64(1.1)},
+		{Text: "今日もがんばるのだ", SpeakerID: ptrInt(3), SpeedScale: ptrFloat64(1.0)},
+	}
+	written, err := w.WriteAll(dest, scripts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if written != dest {
+		t.Errorf("expected written=%q, got %q", dest, written)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), string(data))
+	}
+
+	var got0 map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &got0); err != nil {
+		t.Fatalf("invalid JSON line 0: %v", err)
+	}
+	if got0["text"] != "おはようなのだ" {
+		t.Errorf("line0 text: %v", got0["text"])
+	}
+	if got0["speaker"].(float64) != 3 {
+		t.Errorf("line0 speaker: %v", got0["speaker"])
+	}
+	if got0["intonation"].(float64) != 1.1 {
+		t.Errorf("line0 intonation: %v", got0["intonation"])
+	}
+	if _, exists := got0["speed"]; exists {
+		t.Errorf("line0: speed should be omitted")
+	}
+
+	var got1 map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &got1); err != nil {
+		t.Fatalf("invalid JSON line 1: %v", err)
+	}
+	if got1["text"] != "今日もがんばるのだ" {
+		t.Errorf("line1 text: %v", got1["text"])
+	}
+	if got1["speed"].(float64) != 1.0 {
+		t.Errorf("line1 speed: %v", got1["speed"])
+	}
+	if _, exists := got1["intonation"]; exists {
+		t.Errorf("line1: intonation should be omitted")
+	}
+}
+
+func TestFileWriter_WriteAll_EmptySlice(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.jsonl")
+
+	w := infra.NewFileWriter()
+	written, err := w.WriteAll(dest, []entity.Script{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if written != dest {
+		t.Errorf("expected written=%q, got %q", dest, written)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty file, got: %q", string(data))
+	}
+}
+
+func TestFileWriter_WriteAll_OverwritesExisting(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.jsonl")
+
+	// 既存ファイルを作成
+	if err := os.WriteFile(dest, []byte(`{"text":"old"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to create existing file: %v", err)
+	}
+
+	w := infra.NewFileWriter()
+	scripts := []entity.Script{{Text: "new"}}
+	if _, err := w.WriteAll(dest, scripts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line after overwrite, got %d: %q", len(lines), string(data))
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["text"] != "new" {
+		t.Errorf("expected 'new', got %v", got["text"])
+	}
+}
+
+func TestFileWriter_WriteAll_EmptyTextIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.jsonl")
+
+	w := infra.NewFileWriter()
+	scripts := []entity.Script{{Text: ""}}
+	if _, err := w.WriteAll(dest, scripts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got["text"] != "" {
+		t.Errorf("expected empty text, got %v", got["text"])
+	}
+}
+
+func TestFileWriter_WriteAll_MissingParentDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "missing", "out.jsonl")
+
+	w := infra.NewFileWriter()
+	if _, err := w.WriteAll(dest, []entity.Script{{Text: "本文"}}); err == nil {
+		t.Fatal("expected error for missing parent directory, got nil")
+	}
+}
+
 func TestFileWriter_Write_SupportedExtensions_AllWork(t *testing.T) {
 	t.Parallel()
 

--- a/main.go
+++ b/main.go
@@ -97,6 +97,11 @@ func main() {
 				return infra.NewFileWriter(infra.WithFileWriterLogger(logger))
 			},
 		},
+		ScriptWrite: &cmd.ScriptWriteDeps{
+			WriterFactory: func(logger *slog.Logger) app.ScriptBulkWriter {
+				return infra.NewFileWriter(infra.WithFileWriterLogger(logger))
+			},
+		},
 		AudioCheck: &cmd.AudioCheckDeps{
 			CheckFunc: func() (string, error) {
 				return infra.CheckAudioDevice(infra.NewOtoAudioProbe())

--- a/plugins/vox-actor-plugin/skills/talk/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/talk/SKILL.md
@@ -7,10 +7,8 @@ allowed-tools: Bash(vox-actor *) Bash(scripts/play-script.sh *)
 
 ## 手順
 1. 指示内容に従ってセリフを生成する。
-2. セリフファイルを作成する。
-    - `touch $(vox-actor config path.tmp)/$(date +%s%3N).jsonl`
-3. セリフファイルにセリフを追記する。
-4. セリフファイルを再生する。
+2. `vox-actor script write $(vox-actor config path.tmp)/$(date +%s%3N).jsonl --json '[...]'` でセリフファイルを一括作成する。
+3. `scripts/play-script.sh {セリフファイルパス}` で再生する。
 
 ## 利用可能なスクリプト
 スキルディレクトリの `scripts` フォルダ内に以下のスクリプトを格納しています。
@@ -20,15 +18,13 @@ allowed-tools: Bash(vox-actor *) Bash(scripts/play-script.sh *)
 - 使用可能なキャラクター一覧: `vox-actor speakers list`
 - キャラクター設定の確認方法: `vox-actor speakers profile --id {profile_id}`
     - `profile_id` は `vox-actor speakers list` の結果から選ぶ
-- セリフファイルへのセリフ追記方法: `vox-actor script append {セリフファイルパス} {オプション} "{セリフ}"`
-    - 話者指定オプション（省略化）: `--speaker {speaker_id}`
-        - `speaker_id` は `vox-actor speakers profile` の結果の `speakers` フィールドから選ぶ
-    - 抑揚変更オプション（省略化）: `--intonation {0.0〜1.5}`
-        - 目安: 0.0（棒読み） 〜 1.0（標準） 〜 1.5（表現豊か）
-    - 音高変更オプション（省略化）: `--pitch {-0.05〜0.05}`
-        - 目安: -0.05（低い） 〜 0.0（標準） 〜 0.05（高い）
-    - 話速変更オプション（省略化）: `--speed {0.8〜1.2}`
-        - 目安: 0.8（ゆっくり） 〜 1.0（標準） 〜 1.2（早口）
+- セリフファイルの一括作成方法: `vox-actor script write {セリフファイルパス} --json '[{セリフオブジェクト}, ...]'`
+    - `--json` の各オブジェクトのキー:
+        - `text` (string, 必須): セリフ本文
+        - `speaker` (int, 省略可): `vox-actor speakers profile` の `speakers` フィールドの値
+        - `intonation` (float, 省略可): 抑揚。目安: 0.0（棒読み） 〜 1.0（標準） 〜 1.5（表現豊か）
+        - `pitch` (float, 省略可): 音高。目安: -0.05（低い） 〜 0.0（標準） 〜 0.05（高い）
+        - `speed` (float, 省略可): 話速。目安: 0.8（ゆっくり） 〜 1.0（標準） 〜 1.2（早口）
 - セリフファイルの再生方法: `scripts/play-script.sh {セリフファイルパス}`
 - 指示内容: $ARGUMENTS
 

--- a/test/e2e/script_test.go
+++ b/test/e2e/script_test.go
@@ -513,3 +513,113 @@ func TestScriptAppendE2E_Encoding_EmptyText(t *testing.T) {
 		t.Errorf("expected empty text, got %q", s.Text)
 	}
 }
+
+// ─────────────────────────────────────────
+// script write E2E テスト
+// ─────────────────────────────────────────
+
+func TestScriptWriteE2E_Basic(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.jsonl")
+	jsonInput := `[{"text":"おはようなのだ","speaker":3,"intonation":1.1},{"text":"今日もがんばるのだ","speaker":3,"speed":1.0}]`
+
+	_, stderr, exitCode := runCLI(t, nil, "script", "write", "--json", jsonInput, dest)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d\ncontent:\n%s", len(lines), string(data))
+	}
+
+	var s0, s1 scriptJSON
+	if err := json.Unmarshal([]byte(lines[0]), &s0); err != nil {
+		t.Fatalf("parse line 0: %v", err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &s1); err != nil {
+		t.Fatalf("parse line 1: %v", err)
+	}
+
+	if s0.Text != "おはようなのだ" {
+		t.Errorf("line0 text: expected 'おはようなのだ', got %q", s0.Text)
+	}
+	if s0.Speaker == nil || *s0.Speaker != 3 {
+		t.Errorf("line0 speaker: expected 3, got %v", s0.Speaker)
+	}
+	if s0.IntonationScale == nil || *s0.IntonationScale != 1.1 {
+		t.Errorf("line0 intonation: expected 1.1, got %v", s0.IntonationScale)
+	}
+	if s0.SpeedScale != nil {
+		t.Errorf("line0 speed: expected omitted, got %v", *s0.SpeedScale)
+	}
+
+	if s1.Text != "今日もがんばるのだ" {
+		t.Errorf("line1 text: expected '今日もがんばるのだ', got %q", s1.Text)
+	}
+	if s1.SpeedScale == nil || *s1.SpeedScale != 1.0 {
+		t.Errorf("line1 speed: expected 1.0, got %v", s1.SpeedScale)
+	}
+}
+
+func TestScriptWriteE2E_OverwritesExisting(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.jsonl")
+
+	// 既存ファイルに追記しておく
+	_, _, exitCode := runCLI(t, nil, "script", "append", dest, "古いセリフ")
+	if exitCode != 0 {
+		t.Fatalf("append failed with exit %d", exitCode)
+	}
+
+	// write で上書き
+	_, stderr, exitCode := runCLI(t, nil, "script", "write", "--json", `[{"text":"新しいセリフ"}]`, dest)
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr:\n%s", exitCode, stderr)
+	}
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line after overwrite, got %d\ncontent:\n%s", len(lines), string(data))
+	}
+	s := readScriptJSON(t, dest)
+	if s.Text != "新しいセリフ" {
+		t.Errorf("expected '新しいセリフ', got %q", s.Text)
+	}
+}
+
+func TestScriptWriteE2E_InvalidJson_ExitCode2(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.jsonl")
+
+	_, _, exitCode := runCLI(t, nil, "script", "write", "--json", "not-json", dest)
+	if exitCode != 2 {
+		t.Fatalf("expected exit 2 for invalid JSON, got %d", exitCode)
+	}
+}
+
+func TestScriptE2E_Help_ContainsWrite(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runCLI(t, nil, "script")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout, "write") {
+		t.Errorf("expected help output to contain 'write'\nstdout:\n%s", stdout)
+	}
+}


### PR DESCRIPTION
## Summary

- `vox-actor script write <file> --json '[...]'` サブコマンドを追加
- JSON 配列で複数セリフを一括書き込み（上書き）することで、talk スキルの Bash 呼び出しを 4→2 回に削減
- `app.ScriptBulkWriter` インターフェースと `FileWriter.WriteAll` を新設
- `validateParentDir` ヘルパーを抽出し `Write`/`WriteAll` の重複を解消
- talk スキルの手順を `script write` 利用に更新
- `docs/reference/cli.md` に `script write` セクションを追加

## Test plan

- [x] 単体テスト: `cmd/script_write_test.go` (8件) 追加 — 正常系・空配列・パースエラー・上書き・フィールドマッピングを検証
- [x] `internal/infra/file_writer_test.go` に `WriteAll` テスト5件追加
- [x] e2e テスト: `test/e2e/script_test.go` に4件追加 — 基本動作・上書き・不正JSON・ヘルプ表示
- [x] `go test ./...` 全 PASS
- [x] `gofmt -l .` 問題なし
- [x] `golangci-lint run ./...` 0 issues
- [ ] VOICEVOX接続を要する受け入れ条件（talk スキル経由での実機再生確認）は CI 自動検証不可のため手動確認要

Closes #473

---
🤖 Generated with [Claude Code](https://claude.ai/code)
