### PR TITLE
feat: say/act/watch に --viewer-url オプションを追加しリモート viewer 再生を可能にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### New Features
+
+- **`--viewer-url` / `VOX_VIEWER_URL` オプション追加** ([#481](https://github.com/canpok1/vox-actor/issues/481))
+  - `say` / `act` / `watch` にリモート viewer の URL を明示指定する `--viewer-url` オプションを追加しました。
+  - `VOX_VIEWER_URL` 環境変数でデフォルト値を設定できます。
+  - 指定時は lockfile auto-detect をスキップして明示 URL の viewer に POST `/api/play` します。
+  - 接続失敗時はローカル再生にフォールバックせずエラー終了します（終了コード 1）。
+  - `--viewer-url` 指定時はローカルの `AudioProbe` をスキップします（音声デバイスなし環境でもリモート再生可能）。
+- **`watch` に viewer lockfile auto-detect を追加** ([#481](https://github.com/canpok1/vox-actor/issues/481))
+  - `watch` コマンドが `say` / `act` と同様に `~/.vox-actor/viewer/viewer.lock` で viewer を自動検知し、起動中の viewer があれば POST `/api/play` 経由で再生するようになりました。
+
 ### Breaking Changes
 
 - **セリフファイルフィールド名の変更** ([#474](https://github.com/canpok1/vox-actor/issues/474))

--- a/cmd/act.go
+++ b/cmd/act.go
@@ -94,6 +94,44 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 	}
 
 	if !dryRun {
+		viewerURL, _ := cmd.Flags().GetString("viewer-url")
+
+		if viewerURL != "" {
+			// 明示 URL: lockfile スキップ、AudioProbe スキップ、接続失敗時はエラー
+			logger.Info("using explicit viewer URL", "url", viewerURL)
+			scripts, err := deps.Reader.Read(args[0])
+			if err != nil {
+				return err
+			}
+			vc := infra.NewViewerAPIClientFromURL(viewerURL)
+			for _, script := range scripts {
+				if script.IsEmpty {
+					continue
+				}
+				if ctx.Err() != nil {
+					return nil
+				}
+				effectiveSpeakerID := script.ResolveSpeakerID(speakerID)
+				effectiveSpeed := script.ResolveSpeed(&speed)
+				effectivePitch := script.ResolvePitch(&pitch)
+				effectiveIntonation := script.ResolveIntonation(&intonation)
+				resp, postErr := vc.Play(ctx, infra.ViewerPlayRequest{
+					Text:       script.Text,
+					SpeakerID:  effectiveSpeakerID,
+					Speed:      effectiveSpeed,
+					Pitch:      effectivePitch,
+					Intonation: effectiveIntonation,
+				})
+				if postErr != nil {
+					return fmt.Errorf("act via viewer: %w", postErr)
+				}
+				if resp.Silent {
+					logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
+				}
+			}
+			return nil
+		}
+
 		lockPath, lockErr := resolveActLockPath(deps)
 		if lockErr != nil {
 			logger.Debug("could not resolve viewer lock path, using local player", "error", lockErr)

--- a/cmd/act_test.go
+++ b/cmd/act_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/canpok1/vox-actor/internal/app"
 	"github.com/canpok1/vox-actor/internal/domain/entity"
+	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
 
@@ -23,6 +25,11 @@ import (
 // DONE: viewer 未起動はローカル再生にフォールバック                         → TestRunAct_ViewerNotRunning_UsesLocalPlayer
 // DONE: --dry-run 時は viewer へ POST しない                               → TestRunAct_DryRun_NoViewerPost
 // DONE: 途中行で POST 失敗した場合即座にエラー終了する                      → TestRunAct_ViewerRunning_PostFails_StopsEarly
+// #481 --viewer-url:
+// DONE: --viewer-url 指定時は明示 URL の viewer に POST する                → TestRunAct_ExplicitViewerURL_POSTsToViewer
+// DONE: --viewer-url 指定時は lockfile auto-detect をスキップする           → TestRunAct_ExplicitViewerURL_SkipsLockfile
+// DONE: --viewer-url 指定時は AudioProbe をスキップする                     → TestRunAct_ExplicitViewerURL_SkipsAudioProbe
+// DONE: --viewer-url 指定時に接続失敗 → エラーを返す (no fallback)         → TestRunAct_ExplicitViewerURL_ConnectionError_ReturnsError
 
 // グレースフルシャットダウン テストリスト
 // DONE: actコマンドのcontextにシグナルハンドリングが設定されていることを確認
@@ -589,5 +596,160 @@ func TestRunAct_AudioProbe_FailureCausesError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "audio") {
 		t.Errorf("expected error message to mention 'audio', got: %v", err)
+	}
+}
+
+// --- #481 --viewer-url テスト ---
+
+func TestRunAct_ExplicitViewerURL_POSTsToViewer(t *testing.T) {
+	dir := t.TempDir()
+	scriptFile := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("テストセリフ"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var postCount int
+	var capturedText string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if v, ok := req["text"].(string); ok {
+			capturedText = v
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--viewer-url", srv.URL})
+
+	deps := &ActDeps{
+		Reader:        infra.NewFileReader(),
+		ClientFactory: func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:        &noopPlayer{},
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	if postCount != 1 {
+		t.Errorf("expected 1 POST to /api/play, got %d", postCount)
+	}
+	if capturedText != "テストセリフ" {
+		t.Errorf("expected text=%q, got %q", "テストセリフ", capturedText)
+	}
+}
+
+func TestRunAct_ExplicitViewerURL_SkipsLockfile(t *testing.T) {
+	dir := t.TempDir()
+	scriptFile := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("テスト\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// lockfile に起動中 viewer があっても explicit URL が優先
+	var lockfilePostCount int
+	lockfileMux := http.NewServeMux()
+	lockfileMux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	lockfileMux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		lockfilePostCount++
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	lockPath, _ := setupFakeViewer(t, lockfileMux)
+
+	var explicitPostCount int
+	explicitMux := http.NewServeMux()
+	explicitMux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		explicitPostCount++
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	explicitSrv := httptest.NewServer(explicitMux)
+	defer explicitSrv.Close()
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--viewer-url", explicitSrv.URL})
+
+	deps := &ActDeps{
+		Reader:           infra.NewFileReader(),
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	if lockfilePostCount != 0 {
+		t.Errorf("expected 0 POST to lockfile viewer, got %d", lockfilePostCount)
+	}
+	if explicitPostCount != 1 {
+		t.Errorf("expected 1 POST to explicit viewer, got %d", explicitPostCount)
+	}
+}
+
+func TestRunAct_ExplicitViewerURL_SkipsAudioProbe(t *testing.T) {
+	dir := t.TempDir()
+	scriptFile := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("テスト\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	probeCalled := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--viewer-url", srv.URL})
+
+	deps := &ActDeps{
+		Reader:        infra.NewFileReader(),
+		ClientFactory: func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:        &noopPlayer{},
+		AudioProbe:    func() error { probeCalled = true; return nil },
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	if probeCalled {
+		t.Error("expected AudioProbe to be skipped when --viewer-url is set, but it was called")
+	}
+}
+
+func TestRunAct_ExplicitViewerURL_ConnectionError_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	scriptFile := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("テスト\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	playCalled := false
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--viewer-url", "http://127.0.0.1:1"})
+
+	deps := &ActDeps{
+		Reader:        infra.NewFileReader(),
+		ClientFactory: func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:        &trackingPlayer{playFn: func() { playCalled = true }},
+	}
+
+	err := runAct(cmd, []string{scriptFile}, deps)
+	if err == nil {
+		t.Fatal("expected error when viewer is not reachable, got nil")
+	}
+	if playCalled {
+		t.Error("expected no local playback when --viewer-url fails")
 	}
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -48,6 +48,11 @@ func registerVoiceParamFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("verbose", false, "詳細ログを出力")
 }
 
+// viewerURLDefaultFromEnv は VOX_VIEWER_URL 環境変数からデフォルトの viewer URL を解決する。
+func viewerURLDefaultFromEnv() string {
+	return os.Getenv("VOX_VIEWER_URL")
+}
+
 // registerBaseFlags は dry-run を除く共通フラグを登録する。viewer など dry-run を持たないコマンドで使う。
 func registerBaseFlags(cmd *cobra.Command) {
 	engineURLDefault := "http://localhost:50021"
@@ -59,8 +64,14 @@ func registerBaseFlags(cmd *cobra.Command) {
 	registerVoiceParamFlags(cmd)
 }
 
+// registerViewerURLFlag は --viewer-url フラグを登録する。
+func registerViewerURLFlag(cmd *cobra.Command) {
+	cmd.Flags().String("viewer-url", viewerURLDefaultFromEnv(), "viewer の HTTP エンドポイント URL (例: http://192.168.1.10:8080)。指定時は lockfile auto-detect をスキップして明示 URL の viewer に POST する。")
+}
+
 // registerCommonFlags は各サブコマンド共通のフラグを登録する。
 func registerCommonFlags(cmd *cobra.Command) {
 	registerBaseFlags(cmd)
 	cmd.Flags().Bool("dry-run", false, "VOICEVOX・音声再生を行わず、読み上げ対象をログ出力")
+	registerViewerURLFlag(cmd)
 }

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -136,3 +136,35 @@ func TestRegisterCommonFlags_EngineURL(t *testing.T) {
 		t.Errorf("expected default engine-url 'http://localhost:50021', got: %s", engineURL)
 	}
 }
+
+// #481 --viewer-url フラグ
+
+func TestRegisterCommonFlags_ViewerURL_DefaultEmpty(t *testing.T) {
+	t.Setenv("VOX_VIEWER_URL", "")
+
+	cmd := &cobra.Command{Use: "test"}
+	registerCommonFlags(cmd)
+
+	viewerURL, err := cmd.Flags().GetString("viewer-url")
+	if err != nil {
+		t.Fatalf("expected viewer-url flag to exist, got error: %v", err)
+	}
+	if viewerURL != "" {
+		t.Errorf("expected default viewer-url to be empty, got: %s", viewerURL)
+	}
+}
+
+func TestRegisterCommonFlags_ViewerURL_EnvVar(t *testing.T) {
+	t.Setenv("VOX_VIEWER_URL", "http://remote:8080")
+
+	cmd := &cobra.Command{Use: "test"}
+	registerCommonFlags(cmd)
+
+	viewerURL, err := cmd.Flags().GetString("viewer-url")
+	if err != nil {
+		t.Fatalf("expected viewer-url flag to exist, got error: %v", err)
+	}
+	if viewerURL != "http://remote:8080" {
+		t.Errorf("expected viewer-url 'http://remote:8080', got: %s", viewerURL)
+	}
+}

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -69,12 +69,33 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 	}
 
 	engineURL, _ := cmd.Flags().GetString("engine-url")
+	viewerURL, _ := cmd.Flags().GetString("viewer-url")
 	speakerID, _ := cmd.Flags().GetInt("speaker")
 	speed, _ := cmd.Flags().GetFloat64("speed")
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
 
 	if !dryRun {
+		if viewerURL != "" {
+			// 明示 URL: lockfile スキップ、AudioProbe スキップ、接続失敗時はエラー
+			logger.Info("using explicit viewer URL", "url", viewerURL)
+			vc := infra.NewViewerAPIClientFromURL(viewerURL)
+			resp, err := vc.Play(ctx, infra.ViewerPlayRequest{
+				Text:       args[0],
+				SpeakerID:  speakerID,
+				Speed:      &speed,
+				Pitch:      &pitch,
+				Intonation: &intonation,
+			})
+			if err != nil {
+				return err
+			}
+			if resp.Silent {
+				logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
+			}
+			return nil
+		}
+
 		lockPath, lockErr := resolveSayLockPath(deps)
 		if lockErr != nil {
 			logger.Debug("could not resolve viewer lock path, using local player", "error", lockErr)

--- a/cmd/say_test.go
+++ b/cmd/say_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,6 +32,14 @@ import (
 // DONE: 環境変数VOX_SPEAKERがデフォルト値に反映される
 // DONE: VOX_SPEAKERに不正な値が設定されている場合デフォルト値が使われる
 // DONE: --verboseフラグのデフォルト値がfalse
+// #481 --viewer-url:
+// DONE: --viewer-url フラグがヘルプに含まれる                                   → TestSayCmd_HelpContainsViewerURL
+// DONE: --viewer-url デフォルトは空文字                                          → TestSayCmd_ViewerURL_DefaultEmpty
+// DONE: VOX_VIEWER_URL 環境変数でデフォルト値が設定される                       → TestSayCmd_EnvVarVOXViewerURL
+// DONE: --viewer-url 指定時は明示 URL の viewer に POST する                     → TestRunSay_ExplicitViewerURL_POSTsToViewer
+// DONE: --viewer-url 指定時は lockfile auto-detect をスキップする                → TestRunSay_ExplicitViewerURL_SkipsLockfile
+// DONE: --viewer-url 指定時は AudioProbe をスキップする                          → TestRunSay_ExplicitViewerURL_SkipsAudioProbe
+// DONE: --viewer-url 指定時に接続失敗 → フォールバックせずエラーを返す          → TestRunSay_ExplicitViewerURL_ConnectionError_ReturnsError
 
 // findSayCmd はrootCmdからsayサブコマンドを検索して返すテストヘルパー。
 func findSayCmd(t *testing.T, rootCmd *cobra.Command) *cobra.Command {
@@ -478,5 +487,179 @@ func TestRunSay_AudioProbe_FailureCausesError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "audio") {
 		t.Errorf("expected error message to mention 'audio', got: %v", err)
+	}
+}
+
+// --- #481 --viewer-url テスト ---
+
+func TestSayCmd_HelpContainsViewerURL(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"say", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error for --help, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "--viewer-url") {
+		t.Error("expected help output to contain '--viewer-url'")
+	}
+}
+
+func TestSayCmd_ViewerURL_DefaultEmpty(t *testing.T) {
+	t.Setenv("VOX_VIEWER_URL", "")
+
+	rootCmd := makeRootCmd()
+	sayCmd := findSayCmd(t, rootCmd)
+
+	viewerURL, err := sayCmd.Flags().GetString("viewer-url")
+	if err != nil {
+		t.Fatalf("expected viewer-url flag to exist, got error: %v", err)
+	}
+	if viewerURL != "" {
+		t.Errorf("expected default viewer-url to be empty, got: %s", viewerURL)
+	}
+}
+
+func TestSayCmd_EnvVarVOXViewerURL(t *testing.T) {
+	t.Setenv("VOX_VIEWER_URL", "http://remote:8080")
+
+	rootCmd := makeRootCmd()
+	sayCmd := findSayCmd(t, rootCmd)
+
+	viewerURL, err := sayCmd.Flags().GetString("viewer-url")
+	if err != nil {
+		t.Fatalf("expected viewer-url flag to exist, got error: %v", err)
+	}
+	if viewerURL != "http://remote:8080" {
+		t.Errorf("expected viewer-url 'http://remote:8080', got: %s", viewerURL)
+	}
+}
+
+func TestRunSay_ExplicitViewerURL_POSTsToViewer(t *testing.T) {
+	var postCount int
+	var capturedText string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if v, ok := req["text"].(string); ok {
+			capturedText = v
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--viewer-url", srv.URL})
+
+	deps := &SayDeps{
+		ClientFactory: func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:        &noopPlayer{},
+	}
+
+	if err := runSay(cmd, []string{"リモートテスト"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+	if postCount != 1 {
+		t.Errorf("expected 1 POST to /api/play, got %d", postCount)
+	}
+	if capturedText != "リモートテスト" {
+		t.Errorf("expected text=%q, got %q", "リモートテスト", capturedText)
+	}
+}
+
+func TestRunSay_ExplicitViewerURL_SkipsLockfile(t *testing.T) {
+	// lockfile には起動中の viewer が存在するが、--viewer-url 優先のため lockfile は使われない
+	var lockfilePostCount int
+	lockfileMux := http.NewServeMux()
+	lockfileMux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	lockfileMux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		lockfilePostCount++
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	lockPath, _ := setupFakeViewer(t, lockfileMux)
+
+	// explicit URL 側のサーバー
+	var explicitPostCount int
+	explicitMux := http.NewServeMux()
+	explicitMux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		explicitPostCount++
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	explicitSrv := httptest.NewServer(explicitMux)
+	defer explicitSrv.Close()
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--viewer-url", explicitSrv.URL})
+
+	deps := &SayDeps{
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runSay(cmd, []string{"テスト"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+	if lockfilePostCount != 0 {
+		t.Errorf("expected 0 POST to lockfile viewer, got %d", lockfilePostCount)
+	}
+	if explicitPostCount != 1 {
+		t.Errorf("expected 1 POST to explicit viewer, got %d", explicitPostCount)
+	}
+}
+
+func TestRunSay_ExplicitViewerURL_SkipsAudioProbe(t *testing.T) {
+	probeCalled := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--viewer-url", srv.URL})
+
+	deps := &SayDeps{
+		ClientFactory: func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:        &noopPlayer{},
+		AudioProbe:    func() error { probeCalled = true; return nil },
+	}
+
+	if err := runSay(cmd, []string{"テスト"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+	if probeCalled {
+		t.Error("expected AudioProbe to be skipped when --viewer-url is set, but it was called")
+	}
+}
+
+func TestRunSay_ExplicitViewerURL_ConnectionError_ReturnsError(t *testing.T) {
+	// Not-listening server to simulate connection failure
+	playCalled := false
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{"--viewer-url", "http://127.0.0.1:1"})
+
+	deps := &SayDeps{
+		ClientFactory: func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:        &trackingPlayer{playFn: func() { playCalled = true }},
+	}
+
+	err := runSay(cmd, []string{"テスト"}, deps)
+	if err == nil {
+		t.Fatal("expected error when viewer is not reachable, got nil")
+	}
+	if playCalled {
+		t.Error("expected no local playback when --viewer-url fails")
 	}
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -22,6 +23,9 @@ type WatchDeps struct {
 	// QueuePathResolver は --queue 指定時に監視対象パスを解決する関数。
 	// nil の場合は infra.ResolveQueuePath がデフォルトで使われる。
 	QueuePathResolver func() (string, error)
+	// LockPathResolver は viewer ロックファイルのパスを解決する関数。
+	// nil の場合は infra.ResolveHomeViewerLockPath がデフォルトで使われる。
+	LockPathResolver func() (string, error)
 	// AudioProbe は起動時に音声デバイス可用性を検査する関数。
 	// nil の場合は検査をスキップする。--dry-run 時は呼ばれない。
 	AudioProbe func() error
@@ -59,6 +63,41 @@ func makeWatchCmd(deps *WatchDeps) *cobra.Command {
 	_ = cmd.Flags().MarkHidden("stream-addr")
 
 	return cmd
+}
+
+func resolveWatchLockPath(deps *WatchDeps) (string, error) {
+	if deps != nil {
+		return resolveViewerLockPathWith(deps.LockPathResolver)
+	}
+	return resolveViewerLockPathWith(nil)
+}
+
+// viewerWatchPlayer は watch 時に viewer へ音声再生リクエストを転送するプレイヤー。
+// app.AudioPlayer と textPlayer の両インターフェースを実装する。
+type viewerWatchPlayer struct {
+	vc         *infra.ViewerAPIClient
+	speed      *float64
+	pitch      *float64
+	intonation *float64
+}
+
+func (p *viewerWatchPlayer) Play(ctx context.Context, _ []byte, meta app.PlayMeta) error {
+	return p.playViaViewer(ctx, meta)
+}
+
+func (p *viewerWatchPlayer) PlayText(ctx context.Context, meta app.PlayMeta) error {
+	return p.playViaViewer(ctx, meta)
+}
+
+func (p *viewerWatchPlayer) playViaViewer(ctx context.Context, meta app.PlayMeta) error {
+	_, err := p.vc.Play(ctx, infra.ViewerPlayRequest{
+		Text:       meta.Text,
+		SpeakerID:  meta.SpeakerID,
+		Speed:      p.speed,
+		Pitch:      p.pitch,
+		Intonation: p.intonation,
+	})
+	return err
 }
 
 // resolveWatchPaths は watch の監視対象パスを確定する。
@@ -133,10 +172,6 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 		return fmt.Errorf("watch command dependencies are not initialized")
 	}
 
-	if err := runAudioProbe(deps.AudioProbe, dryRun); err != nil {
-		return err
-	}
-
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -151,6 +186,54 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 	opts := []app.WatchOption{app.WithWatchLogger(logger)}
 	if deleteMode {
 		opts = append(opts, app.WithDeleteMode())
+	}
+
+	// viewer 優先順位: 明示 URL > lockfile auto-detect > ローカル再生
+	var vwPlayer *viewerWatchPlayer
+	if !dryRun {
+		viewerURL, _ := cmd.Flags().GetString("viewer-url")
+		if viewerURL != "" {
+			// 明示 URL: lockfile スキップ、AudioProbe スキップ
+			logger.Info("using explicit viewer URL for watch", "url", viewerURL)
+			vwPlayer = &viewerWatchPlayer{
+				vc:         infra.NewViewerAPIClientFromURL(viewerURL),
+				speed:      &speed,
+				pitch:      &pitch,
+				intonation: &intonation,
+			}
+		} else {
+			// lockfile auto-detect
+			lockPath, lockErr := resolveWatchLockPath(deps)
+			if lockErr != nil {
+				logger.Debug("could not resolve viewer lock path", "error", lockErr)
+			} else if addr, ok := infra.DetectViewer(lockPath); ok {
+				logger.Info("viewer detected, will use viewer for watch playback", "addr", addr)
+				vwPlayer = &viewerWatchPlayer{
+					vc:         infra.NewViewerAPIClient(addr),
+					speed:      &speed,
+					pitch:      &pitch,
+					intonation: &intonation,
+				}
+			}
+		}
+	}
+
+	if vwPlayer != nil {
+		// viewer 使用時: AudioProbe スキップ、WithSilent で VOICEVOX 合成もスキップ
+		opts = append(opts, app.WithSilent())
+		uc := app.NewWatchUsecase(deps.Reader, client, vwPlayer, deps.Mover, watcher, opts...)
+		return uc.Run(ctx, app.WatchParams{
+			Paths:      args,
+			SpeakerID:  speakerID,
+			Speed:      &speed,
+			Pitch:      &pitch,
+			Intonation: &intonation,
+			DryRun:     dryRun,
+		})
+	}
+
+	if err := runAudioProbe(deps.AudioProbe, dryRun); err != nil {
+		return err
 	}
 
 	uc := app.NewWatchUsecase(deps.Reader, client, deps.Player, deps.Mover, watcher, opts...)

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -3,11 +3,16 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/canpok1/vox-actor/internal/app"
 	"github.com/canpok1/vox-actor/internal/domain/entity"
@@ -448,6 +453,15 @@ func TestWatchCmd_HelpContainsQueueFlag(t *testing.T) {
 // DONE: watch で dry-run の場合 AudioProbe がスキップされる           → TestRunWatch_AudioProbe_SkippedOnDryRun
 // DONE: watch で AudioProbe が失敗した場合起動拒否してエラーを返す    → TestRunWatch_AudioProbe_FailureCausesError
 
+// --- #481 --viewer-url / lockfile auto-detect テスト ---
+// DONE: --viewer-url フラグがヘルプに含まれる                                             → TestWatchCmd_HelpContainsViewerURL
+// DONE: --viewer-url デフォルトは空文字                                                   → TestWatchCmd_ViewerURL_DefaultEmpty
+// DONE: VOX_VIEWER_URL 環境変数でデフォルト値が設定される                                 → TestWatchCmd_EnvVarVOXViewerURL
+// DONE: --viewer-url 指定時は AudioProbe をスキップする                                   → TestRunWatch_ExplicitViewerURL_SkipsAudioProbe
+// DONE: lockfile auto-detect で viewer 検知時は AudioProbe をスキップする                 → TestRunWatch_LockfileAutoDetect_SkipsAudioProbe
+// DONE: --viewer-url 指定時にファイル検知 → viewer に POST する                          → TestRunWatch_ExplicitViewerURL_PostsToViewer
+// DONE: lockfile auto-detect で viewer 検知時にファイル検知 → viewer に POST する        → TestRunWatch_LockfileAutoDetect_PostsToViewer
+
 // makeWatchDepsWithProbe は AudioProbe 付きの WatchDeps を組み立てるテストヘルパー。
 func makeWatchDepsWithProbe(probe func() error) *WatchDeps {
 	return &WatchDeps{
@@ -525,5 +539,258 @@ func TestRunWatch_AudioProbe_FailureCausesError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "audio") {
 		t.Errorf("expected error message to mention 'audio', got: %v", err)
+	}
+}
+
+// --- #481 --viewer-url テスト ---
+
+func TestWatchCmd_HelpContainsViewerURL(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"watch", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error for --help, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "--viewer-url") {
+		t.Error("expected help output to contain '--viewer-url'")
+	}
+}
+
+func TestWatchCmd_ViewerURL_DefaultEmpty(t *testing.T) {
+	t.Setenv("VOX_VIEWER_URL", "")
+
+	rootCmd := makeRootCmd()
+	watchCmd := findWatchCmd(t, rootCmd)
+
+	viewerURL, err := watchCmd.Flags().GetString("viewer-url")
+	if err != nil {
+		t.Fatalf("expected viewer-url flag to exist, got error: %v", err)
+	}
+	if viewerURL != "" {
+		t.Errorf("expected default viewer-url to be empty, got: %s", viewerURL)
+	}
+}
+
+func TestWatchCmd_EnvVarVOXViewerURL(t *testing.T) {
+	t.Setenv("VOX_VIEWER_URL", "http://remote:8080")
+
+	rootCmd := makeRootCmd()
+	watchCmd := findWatchCmd(t, rootCmd)
+
+	viewerURL, err := watchCmd.Flags().GetString("viewer-url")
+	if err != nil {
+		t.Fatalf("expected viewer-url flag to exist, got error: %v", err)
+	}
+	if viewerURL != "http://remote:8080" {
+		t.Errorf("expected viewer-url 'http://remote:8080', got: %s", viewerURL)
+	}
+}
+
+func TestRunWatch_ExplicitViewerURL_SkipsAudioProbe(t *testing.T) {
+	probeCalled := false
+	watchDir := t.TempDir()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	cmd.Flags().Bool("delete", false, "")
+	cmd.Flags().Bool("queue", false, "")
+	_ = cmd.ParseFlags([]string{"--viewer-url", srv.URL})
+
+	deps := &WatchDeps{
+		Reader:            stubScriptReader{},
+		ClientFactory:     func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+		Player:            stubAudioPlayer{},
+		Mover:             stubFileMover{},
+		DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
+		AudioProbe:        func() error { probeCalled = true; return nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd.SetContext(ctx)
+
+	_ = runWatch(cmd, []string{watchDir}, deps)
+	if probeCalled {
+		t.Error("expected AudioProbe to be skipped when --viewer-url is set, but it was called")
+	}
+}
+
+func TestRunWatch_LockfileAutoDetect_SkipsAudioProbe(t *testing.T) {
+	probeCalled := false
+	watchDir := t.TempDir()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	cmd.Flags().Bool("delete", false, "")
+	cmd.Flags().Bool("queue", false, "")
+	_ = cmd.ParseFlags([]string{})
+
+	deps := &WatchDeps{
+		Reader:            stubScriptReader{},
+		ClientFactory:     func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+		Player:            stubAudioPlayer{},
+		Mover:             stubFileMover{},
+		DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return stubDirWatcher{} },
+		AudioProbe:        func() error { probeCalled = true; return nil },
+		LockPathResolver:  func() (string, error) { return lockPath, nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd.SetContext(ctx)
+
+	_ = runWatch(cmd, []string{watchDir}, deps)
+	if probeCalled {
+		t.Error("expected AudioProbe to be skipped when viewer is auto-detected, but it was called")
+	}
+}
+
+// oneFileDirWatcher は指定ファイルを1件送信してから待機するスタブ DirWatcher。
+type oneFileDirWatcher struct {
+	filePath string
+}
+
+func (w *oneFileDirWatcher) Watch(ctx context.Context, _ string) (<-chan string, <-chan error) {
+	fileCh := make(chan string, 1)
+	errCh := make(chan error)
+	fileCh <- w.filePath
+	go func() {
+		<-ctx.Done()
+		close(fileCh)
+		close(errCh)
+	}()
+	return fileCh, errCh
+}
+
+func TestRunWatch_ExplicitViewerURL_PostsToViewer(t *testing.T) {
+	watchDir := t.TempDir()
+	scriptFile := filepath.Join(watchDir, "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("ウォッチテスト"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var postCount int
+	var capturedText string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if v, ok := req["text"].(string); ok {
+			capturedText = v
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	cmd.Flags().Bool("delete", false, "")
+	cmd.Flags().Bool("queue", false, "")
+	_ = cmd.ParseFlags([]string{"--viewer-url", srv.URL})
+
+	deps := &WatchDeps{
+		Reader:        infra.NewFileReader(),
+		ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+		Player:        stubAudioPlayer{},
+		Mover:         stubFileMover{},
+		DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher {
+			return &oneFileDirWatcher{filePath: scriptFile}
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runWatch(cmd, []string{watchDir}, deps) }()
+
+	// Wait for the POST to be received
+	for i := 0; i < 100; i++ {
+		if postCount > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if postCount == 0 {
+		t.Error("expected at least 1 POST to /api/play, got 0")
+	}
+	if capturedText != "ウォッチテスト" {
+		t.Errorf("expected text=%q, got %q", "ウォッチテスト", capturedText)
+	}
+}
+
+func TestRunWatch_LockfileAutoDetect_PostsToViewer(t *testing.T) {
+	watchDir := t.TempDir()
+	scriptFile := filepath.Join(watchDir, "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("ロックファイルテスト"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var postCount int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	cmd.Flags().Bool("delete", false, "")
+	cmd.Flags().Bool("queue", false, "")
+	_ = cmd.ParseFlags([]string{})
+
+	deps := &WatchDeps{
+		Reader:        infra.NewFileReader(),
+		ClientFactory: func(_ string) app.VoicevoxClient { return &stubVoicevoxClient{} },
+		Player:        stubAudioPlayer{},
+		Mover:         stubFileMover{},
+		DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher {
+			return &oneFileDirWatcher{filePath: scriptFile}
+		},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runWatch(cmd, []string{watchDir}, deps) }()
+
+	for i := 0; i < 100; i++ {
+		if postCount > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if postCount == 0 {
+		t.Error("expected at least 1 POST to /api/play via lockfile auto-detect, got 0")
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -78,6 +78,7 @@ vox-actor say <text>
 | オプション | 環境変数 | デフォルト値 | 説明 |
 |---|---|---|---|
 | `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
+| `--viewer-url` | `VOX_VIEWER_URL` | (未指定) | viewer の HTTP エンドポイント URL (例: `http://192.168.1.10:8080`)。指定時は lockfile auto-detect をスキップして明示 URL の viewer に POST `/api/play` する。接続失敗時はローカル再生にフォールバックせずエラー終了する。 |
 | `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
 | `--speed` | — | `1.0` | 話速 |
 | `--pitch` | — | `0.0` | 音高 |
@@ -176,6 +177,7 @@ vox-actor act <path>
 | オプション | 環境変数 | デフォルト値 | 説明 |
 |---|---|---|---|
 | `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
+| `--viewer-url` | `VOX_VIEWER_URL` | (未指定) | viewer の HTTP エンドポイント URL (例: `http://192.168.1.10:8080`)。指定時は lockfile auto-detect をスキップして明示 URL の viewer に POST `/api/play` する。接続失敗時はローカル再生にフォールバックせずエラー終了する。 |
 | `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
 | `--speed` | — | `1.0` | 話速 |
 | `--pitch` | — | `0.0` | 音高 |
@@ -202,6 +204,7 @@ vox-actor watch --queue
 | オプション | 環境変数 | デフォルト値 | 説明 |
 |---|---|---|---|
 | `--engine-url` | `VOX_ENGINE_URL` | `http://localhost:50021` | VOICEVOXエンジンのURL |
+| `--viewer-url` | `VOX_VIEWER_URL` | (未指定) | viewer の HTTP エンドポイント URL (例: `http://192.168.1.10:8080`)。指定時は lockfile auto-detect をスキップして明示 URL の viewer に POST `/api/play` する。 |
 | `--speaker` | `VOX_SPEAKER` | `3` | キャラクターID |
 | `--speed` | — | `1.0` | 話速 |
 | `--pitch` | — | `0.0` | 音高 |

--- a/internal/infra/viewer_client.go
+++ b/internal/infra/viewer_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -48,15 +49,24 @@ type ViewerPlayResponse struct {
 
 // ViewerAPIClient is a thin HTTP client for calling viewer's /api/play.
 type ViewerAPIClient struct {
-	addr   string
-	client *http.Client
+	baseURL string // e.g., "http://host:port"
+	client  *http.Client
 }
 
 // NewViewerAPIClient creates a client targeting the viewer at addr (host:port).
 func NewViewerAPIClient(addr string) *ViewerAPIClient {
 	return &ViewerAPIClient{
-		addr:   addr,
-		client: &http.Client{},
+		baseURL: "http://" + addr,
+		client:  &http.Client{},
+	}
+}
+
+// NewViewerAPIClientFromURL creates a client targeting the viewer at the given base URL.
+// Trailing slashes are trimmed.
+func NewViewerAPIClientFromURL(rawURL string) *ViewerAPIClient {
+	return &ViewerAPIClient{
+		baseURL: strings.TrimRight(rawURL, "/"),
+		client:  &http.Client{},
 	}
 }
 
@@ -67,7 +77,7 @@ func (c *ViewerAPIClient) Play(ctx context.Context, req ViewerPlayRequest) (*Vie
 		return nil, fmt.Errorf("marshal play request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+c.addr+"/api/play", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/play", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}

--- a/internal/infra/viewer_client_test.go
+++ b/internal/infra/viewer_client_test.go
@@ -10,6 +10,9 @@ package infra_test
 // - POST /api/play 成功 → ViewerAPIClient.Play が PlayResponse を返す      → TestViewerAPIClient_Play_Success
 // - POST /api/play 無音モード応答 → ViewerAPIClient.Play が silent=true    → TestViewerAPIClient_Play_Silent
 // - POST /api/play で非 200 応答 → ViewerAPIClient.Play がエラーを返す     → TestViewerAPIClient_Play_Error
+// #481 --viewer-url:
+// - NewViewerAPIClientFromURL でフル URL 指定 → POST /api/play が成功する  → TestViewerAPIClientFromURL_Play_Success
+// - NewViewerAPIClientFromURL でフル URL に trailing slash → POST が成功   → TestViewerAPIClientFromURL_Play_TrailingSlash
 
 import (
 	"encoding/json"
@@ -179,5 +182,46 @@ func TestViewerAPIClient_Play_Error(t *testing.T) {
 	_, err := client.Play(t.Context(), infra.ViewerPlayRequest{Text: "test", SpeakerID: 2})
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestViewerAPIClientFromURL_Play_Success(t *testing.T) {
+	t.Parallel()
+	var capturedReq infra.ViewerPlayRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedReq)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	}))
+	defer srv.Close()
+
+	client := infra.NewViewerAPIClientFromURL("http://" + srv.Listener.Addr().String())
+	resp, err := client.Play(t.Context(), infra.ViewerPlayRequest{Text: "テスト", SpeakerID: 3})
+	if err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+	if resp.Silent {
+		t.Errorf("expected silent=false")
+	}
+	if capturedReq.Text != "テスト" {
+		t.Errorf("expected text=%q, got %q", "テスト", capturedReq.Text)
+	}
+}
+
+func TestViewerAPIClientFromURL_Play_TrailingSlash(t *testing.T) {
+	t.Parallel()
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+	}))
+	defer srv.Close()
+
+	client := infra.NewViewerAPIClientFromURL("http://" + srv.Listener.Addr().String() + "/")
+	_, err := client.Play(t.Context(), infra.ViewerPlayRequest{Text: "テスト", SpeakerID: 3})
+	if err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+	if !called {
+		t.Error("expected POST /api/play to be called")
 	}
 }


### PR DESCRIPTION
## Summary

- `say` / `act` / `watch` に `--viewer-url` フラグと `VOX_VIEWER_URL` 環境変数を追加
- `--viewer-url` 指定時は lockfile auto-detect をスキップして明示 URL の viewer に POST `/api/play`
- `--viewer-url` 指定時は `AudioProbe` をスキップ（音声デバイスなし環境からのリモート再生対応）
- `--viewer-url` 指定時に接続失敗 / 非 200 応答の場合はフォールバックせず終了コード 1 で終了
- `watch` に lockfile auto-detect を追加し `say` / `act` と同一の viewer 優先順位に統一
- `infra.NewViewerAPIClientFromURL` を追加してフル URL からクライアントを生成可能に
- `docs/reference/cli.md` と CHANGELOG を更新

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `cmd/flags.go` | `--viewer-url` フラグ定義を共通化 |
| `cmd/say.go` | `--viewer-url` 処理・`AudioProbe` スキップ |
| `cmd/act.go` | `--viewer-url` 処理・`AudioProbe` スキップ |
| `cmd/watch.go` | `--viewer-url` 処理・lockfile auto-detect 追加 |
| `internal/infra/viewer_client.go` | `NewViewerAPIClientFromURL` を追加 |
| `docs/reference/cli.md` | `--viewer-url` / `VOX_VIEWER_URL` を追記 |
| `CHANGELOG.md` | Unreleased セクションに追記 |

## Test plan

- [x] `go test ./...` → 全パス
- [x] `gofmt -l .` → 出力なし
- [x] `golangci-lint run` → 0 issues
- [ ] VOICEVOX + viewer が必要なため、リモート再生の実機確認は手動で実施

Closes #481

---
🤖 Generated with [Claude Code](https://claude.ai/code)
