### PR TITLE
feat(talk): play-script.sh のバックグラウンド実行を禁止する制約を追加

### DIFF
--- a/plugins/vox-actor-plugin/skills/talk/SKILL.md
+++ b/plugins/vox-actor-plugin/skills/talk/SKILL.md
@@ -37,3 +37,4 @@ allowed-tools: Bash(vox-actor *) Bash(scripts/play-script.sh *)
 - ファイルパス・URL・UUID 等の長い文字列はセリフに含めない
 - セリフ内のダブルクォート・バックスラッシュは JSON / JSONL 仕様でエスケープ
 - 利用可能なキャラクターが存在しない場合は、 `--speaker` を省略してデフォルト声でセリフ生成する
+- `scripts/play-script.sh` は必ず **foreground で実行**すること（`run_in_background: true` や `&` によるバックグラウンド実行は禁止）。バックグラウンド実行すると再生完了時の `task-notification` が新しいターンとして扱われ、Stop hook の `stop_hook_active` フラグがリセットされ独り言生成の無限ループを引き起こす。


### PR DESCRIPTION
## 概要

`vox-actor-plugin:talk` スキルの SKILL.md に `scripts/play-script.sh` のバックグラウンド実行禁止制約を追加する。

## 変更内容

- `plugins/vox-actor-plugin/skills/talk/SKILL.md` の「制約」セクションに以下を追記
  - `scripts/play-script.sh` は必ず foreground で実行すること（`run_in_background: true` や `&` によるバックグラウンド実行は禁止）
  - 理由: バックグラウンド実行すると再生完了時の `task-notification` が新しいターンとして扱われ、Stop hook の `stop_hook_active` フラグがリセットされ独り言生成の無限ループを引き起こす

## テスト計画

- [ ] talk スキルを実行した際、Claude が foreground でのみ再生コマンドを発行することを手動確認
- [ ] auto-monologue-plugin の Stop hook と組み合わせて連続実行しても、独り言生成ループが発生しないことを確認

Closes #484

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
