### PR TITLE
feat(viewer): POST /api/play を複数クリップ対応＋非同期 worker 化 (#487)

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -116,11 +116,13 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 				effectivePitch := script.ResolvePitch(&pitch)
 				effectiveIntonation := script.ResolveIntonation(&intonation)
 				resp, postErr := vc.Play(ctx, infra.ViewerPlayRequest{
-					Text:       script.Text,
-					SpeakerID:  effectiveSpeakerID,
-					Speed:      effectiveSpeed,
-					Pitch:      effectivePitch,
-					Intonation: effectiveIntonation,
+					Clips: []infra.ViewerClip{{
+						Text:       script.Text,
+						SpeakerID:  effectiveSpeakerID,
+						Speed:      effectiveSpeed,
+						Pitch:      effectivePitch,
+						Intonation: effectiveIntonation,
+					}},
 				})
 				if postErr != nil {
 					return fmt.Errorf("act via viewer: %w", postErr)
@@ -154,11 +156,13 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 				effectivePitch := script.ResolvePitch(&pitch)
 				effectiveIntonation := script.ResolveIntonation(&intonation)
 				resp, postErr := vc.Play(ctx, infra.ViewerPlayRequest{
-					Text:       script.Text,
-					SpeakerID:  effectiveSpeakerID,
-					Speed:      effectiveSpeed,
-					Pitch:      effectivePitch,
-					Intonation: effectiveIntonation,
+					Clips: []infra.ViewerClip{{
+						Text:       script.Text,
+						SpeakerID:  effectiveSpeakerID,
+						Speed:      effectiveSpeed,
+						Pitch:      effectivePitch,
+						Intonation: effectiveIntonation,
+					}},
 				})
 				if postErr != nil {
 					return fmt.Errorf("act via viewer: %w", postErr)

--- a/cmd/act_test.go
+++ b/cmd/act_test.go
@@ -246,8 +246,13 @@ func TestRunAct_ViewerRunning_POSTsPerLine(t *testing.T) {
 		postCount++
 		var req map[string]interface{}
 		_ = json.NewDecoder(r.Body).Decode(&req)
-		if text, ok := req["text"].(string); ok {
-			capturedTexts = append(capturedTexts, text)
+		// clips 形式: {"clips":[{"text":"...","speaker_id":...}]}
+		if clips, ok := req["clips"].([]interface{}); ok && len(clips) > 0 {
+			if clip, ok := clips[0].(map[string]interface{}); ok {
+				if text, ok := clip["text"].(string); ok {
+					capturedTexts = append(capturedTexts, text)
+				}
+			}
 		}
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
 	})
@@ -615,8 +620,13 @@ func TestRunAct_ExplicitViewerURL_POSTsToViewer(t *testing.T) {
 		postCount++
 		var req map[string]interface{}
 		_ = json.NewDecoder(r.Body).Decode(&req)
-		if v, ok := req["text"].(string); ok {
-			capturedText = v
+		// clips 形式: {"clips":[{"text":"...","speaker_id":...}]}
+		if clips, ok := req["clips"].([]interface{}); ok && len(clips) > 0 {
+			if clip, ok := clips[0].(map[string]interface{}); ok {
+				if v, ok := clip["text"].(string); ok {
+					capturedText = v
+				}
+			}
 		}
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
 	})

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -81,11 +81,13 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 			logger.Info("using explicit viewer URL", "url", viewerURL)
 			vc := infra.NewViewerAPIClientFromURL(viewerURL)
 			resp, err := vc.Play(ctx, infra.ViewerPlayRequest{
-				Text:       args[0],
-				SpeakerID:  speakerID,
-				Speed:      &speed,
-				Pitch:      &pitch,
-				Intonation: &intonation,
+				Clips: []infra.ViewerClip{{
+					Text:       args[0],
+					SpeakerID:  speakerID,
+					Speed:      &speed,
+					Pitch:      &pitch,
+					Intonation: &intonation,
+				}},
 			})
 			if err != nil {
 				return err
@@ -103,11 +105,13 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 			logger.Info("viewer detected, sending audio via /api/play", "addr", addr)
 			vc := infra.NewViewerAPIClient(addr)
 			resp, err := vc.Play(ctx, infra.ViewerPlayRequest{
-				Text:       args[0],
-				SpeakerID:  speakerID,
-				Speed:      &speed,
-				Pitch:      &pitch,
-				Intonation: &intonation,
+				Clips: []infra.ViewerClip{{
+					Text:       args[0],
+					SpeakerID:  speakerID,
+					Speed:      &speed,
+					Pitch:      &pitch,
+					Intonation: &intonation,
+				}},
 			})
 			if err != nil {
 				return err

--- a/cmd/say_test.go
+++ b/cmd/say_test.go
@@ -263,8 +263,13 @@ func TestRunSay_ViewerRunning_POSTsToViewer(t *testing.T) {
 	if postCount != 1 {
 		t.Errorf("expected 1 POST to /api/play, got %d", postCount)
 	}
-	if capturedReq["text"] != "こんにちは" {
-		t.Errorf("expected text=%q, got %v", "こんにちは", capturedReq["text"])
+	// clips 形式: {"clips":[{"text":"...","speaker_id":...}]}
+	if clips, ok := capturedReq["clips"].([]interface{}); !ok || len(clips) == 0 {
+		t.Errorf("expected clips array in request, got %v", capturedReq)
+	} else if clip, ok := clips[0].(map[string]interface{}); !ok {
+		t.Errorf("expected clips[0] to be an object, got %T", clips[0])
+	} else if clip["text"] != "こんにちは" {
+		t.Errorf("expected text=%q, got %v", "こんにちは", clip["text"])
 	}
 }
 
@@ -544,8 +549,13 @@ func TestRunSay_ExplicitViewerURL_POSTsToViewer(t *testing.T) {
 		postCount++
 		var req map[string]interface{}
 		_ = json.NewDecoder(r.Body).Decode(&req)
-		if v, ok := req["text"].(string); ok {
-			capturedText = v
+		// clips 形式: {"clips":[{"text":"...","speaker_id":...}]}
+		if clips, ok := req["clips"].([]interface{}); ok && len(clips) > 0 {
+			if clip, ok := clips[0].(map[string]interface{}); ok {
+				if v, ok := clip["text"].(string); ok {
+					capturedText = v
+				}
+			}
 		}
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
 	})

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -91,11 +91,13 @@ func (p *viewerWatchPlayer) PlayText(ctx context.Context, meta app.PlayMeta) err
 
 func (p *viewerWatchPlayer) playViaViewer(ctx context.Context, meta app.PlayMeta) error {
 	_, err := p.vc.Play(ctx, infra.ViewerPlayRequest{
-		Text:       meta.Text,
-		SpeakerID:  meta.SpeakerID,
-		Speed:      p.speed,
-		Pitch:      p.pitch,
-		Intonation: p.intonation,
+		Clips: []infra.ViewerClip{{
+			Text:       meta.Text,
+			SpeakerID:  meta.SpeakerID,
+			Speed:      p.speed,
+			Pitch:      p.pitch,
+			Intonation: p.intonation,
+		}},
 	})
 	return err
 }

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -692,8 +692,13 @@ func TestRunWatch_ExplicitViewerURL_PostsToViewer(t *testing.T) {
 		postCount++
 		var req map[string]interface{}
 		_ = json.NewDecoder(r.Body).Decode(&req)
-		if v, ok := req["text"].(string); ok {
-			capturedText = v
+		// clips 形式: {"clips":[{"text":"...","speaker_id":...}]}
+		if clips, ok := req["clips"].([]interface{}); ok && len(clips) > 0 {
+			if clip, ok := clips[0].(map[string]interface{}); ok {
+				if v, ok := clip["text"].(string); ok {
+					capturedText = v
+				}
+			}
 		}
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
 	})

--- a/internal/infra/export_test.go
+++ b/internal/infra/export_test.go
@@ -6,3 +6,14 @@ import "time"
 func (c *VoicevoxClient) ClientTimeout() time.Duration {
 	return c.httpClient.Timeout
 }
+
+// PlaybackStatus はテスト用に playback state の状態文字列と存在可否を返す。
+func (p *HTTPStreamPlayer) PlaybackStatus(id string) (string, bool) {
+	p.playbackMu.Lock()
+	defer p.playbackMu.Unlock()
+	state, ok := p.playbacks[id]
+	if !ok {
+		return "", false
+	}
+	return string(state.status), true
+}

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -932,6 +932,12 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 		http.Error(w, fmt.Sprintf("clips count exceeds limit %d", maxClipsPerBatch), http.StatusBadRequest)
 		return
 	}
+	for i, clip := range req.Clips {
+		if clip.Text == "" {
+			http.Error(w, fmt.Sprintf("clips[%d].text must not be empty", i), http.StatusBadRequest)
+			return
+		}
+	}
 
 	playbackID, err := newUUIDv4()
 	if err != nil {

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -83,6 +84,16 @@ type HTTPStreamPlayer struct {
 	nextErrorID atomic.Uint64
 	clips       *clipRingBuffer
 	subscribers *subscriberRegistry
+
+	// batchQueue は非同期 worker へのバッチ送信チャネル。容量 batchQueueCapacity。
+	batchQueue chan playBatch
+	// workerCancel は worker goroutine と GC goroutine を停止するためのキャンセル関数。
+	workerCancel context.CancelFunc
+
+	// playbackMu は playbacks マップの排他制御。
+	playbackMu sync.Mutex
+	// playbacks は playback_id → state の in-memory store。TTL 1 時間で GC される。
+	playbacks map[string]*playbackStateRecord
 }
 
 var (
@@ -110,7 +121,39 @@ const (
 	historyLoadSize = 50
 	// historyRetentionDays は履歴ファイルの保持日数。
 	historyRetentionDays = 30
+
+	// maxClipsPerBatch は 1 リクエストで受け付けるクリップ数の上限。
+	maxClipsPerBatch = 100
+	// batchQueueCapacity は pending バッチ数の上限。超過時は 503 を返す。
+	batchQueueCapacity = 64
+	// playbackTTL は playback state を in-memory に保持する期間。
+	playbackTTL = time.Hour
+	// playbackGCInterval は GC goroutine の実行間隔。
+	playbackGCInterval = 5 * time.Minute
 )
+
+// playbackStatus は playback の処理状態。
+type playbackStatus string
+
+const (
+	playbackStatusPending   playbackStatus = "pending"
+	playbackStatusPlaying   playbackStatus = "playing"
+	playbackStatusCompleted playbackStatus = "completed"
+	playbackStatusFailed    playbackStatus = "failed"
+)
+
+// playbackStateRecord は 1 バッチの処理状態を保持する。
+type playbackStateRecord struct {
+	status    playbackStatus
+	reason    string
+	createdAt time.Time
+}
+
+// playBatch は worker への投入単位。
+type playBatch struct {
+	playbackID string
+	clips      []ViewerClip
+}
 
 var (
 	// pathSegmentPattern はファイルパスのセグメント検証に使う正規表現。
@@ -269,6 +312,8 @@ func NewHTTPStreamPlayer(addr string, staticFS fs.FS, opts ...HTTPStreamOption) 
 		silentInterval: defaultSilentInterval,
 		testPhrase:     defaultTestPhrase,
 		testClipCache:  make(map[int][]byte),
+		batchQueue:     make(chan playBatch, batchQueueCapacity),
+		playbacks:      make(map[string]*playbackStateRecord),
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -326,6 +371,11 @@ func (p *HTTPStreamPlayer) Start(_ context.Context) error {
 		}
 	}()
 
+	workerCtx, cancel := context.WithCancel(context.Background())
+	p.workerCancel = cancel
+	go p.runWorker(workerCtx)
+	go p.runPlaybackGC(workerCtx)
+
 	p.logger.Info("stream server started", "addr", lis.Addr().String())
 	return nil
 }
@@ -353,9 +403,13 @@ func (p *HTTPStreamPlayer) Shutdown(ctx context.Context) error {
 		return nil
 	}
 	p.shutdown = true
+	workerCancel := p.workerCancel
 	server := p.server
 	p.mu.Unlock()
 
+	if workerCancel != nil {
+		workerCancel()
+	}
 	p.subscribers.closeAll()
 	if server == nil {
 		return nil
@@ -495,23 +549,7 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 	}
 	p.logger.Info("stream clip delivered", "clipTimestamp", ts, "subscribers", n)
 	p.appendHistory(ev)
-
-	duration, err := estimateWAVDuration(wavData)
-	if err != nil {
-		p.logger.Warn("failed to estimate WAV duration, skipping playback backpressure", "clipTimestamp", ts, "error", err)
-		return nil
-	}
-	if duration <= 0 {
-		return nil
-	}
-	timer := time.NewTimer(duration)
-	defer timer.Stop()
-	select {
-	case <-timer.C:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return nil
 }
 
 // BroadcastError はサーバー側エラーを SSE "error" イベントとして購読者に配信する。
@@ -886,46 +924,173 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if len(req.Clips) == 0 {
+		http.Error(w, "clips must not be empty", http.StatusBadRequest)
+		return
+	}
+	if len(req.Clips) > maxClipsPerBatch {
+		http.Error(w, fmt.Sprintf("clips count exceeds limit %d", maxClipsPerBatch), http.StatusBadRequest)
+		return
+	}
+
+	playbackID, err := newUUIDv4()
+	if err != nil {
+		p.logger.Error("/api/play failed to generate playback_id", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
 	p.mu.Lock()
 	silent := p.silent
 	silentReason := p.silentReason
 	p.mu.Unlock()
 
 	if silent {
-		resp := ViewerPlayResponse{Silent: true, SilentReason: silentReason}
+		p.setPlaybackStatus(playbackID, playbackStatusCompleted, "")
+		resp := ViewerPlayResponse{
+			PlaybackID:   playbackID,
+			ClipCount:    len(req.Clips),
+			Silent:       true,
+			SilentReason: silentReason,
+		}
 		payload, _ := json.Marshal(resp)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_, _ = w.Write(payload)
 		return
 	}
 
-	ctx := r.Context()
-	query, err := p.voicevoxClient.CreateQuery(ctx, req.Text, req.SpeakerID)
-	if err != nil {
-		p.logger.Error("/api/play CreateQuery failed", "speakerID", req.SpeakerID, "error", err)
-		http.Error(w, "failed to create audio query", http.StatusBadGateway)
+	batch := playBatch{playbackID: playbackID, clips: req.Clips}
+	select {
+	case p.batchQueue <- batch:
+	default:
+		w.Header().Set("Retry-After", "1")
+		http.Error(w, "queue is full, retry later", http.StatusServiceUnavailable)
 		return
 	}
+	p.setPlaybackStatus(playbackID, playbackStatusPending, "")
 
-	q := query.WithOverrides(req.Speed, req.Pitch, req.Intonation)
-	wav, err := p.voicevoxClient.Synthesize(ctx, &q, req.SpeakerID)
-	if err != nil {
-		p.logger.Error("/api/play Synthesize failed", "speakerID", req.SpeakerID, "error", err)
-		http.Error(w, "failed to synthesize", http.StatusBadGateway)
-		return
+	resp := ViewerPlayResponse{
+		PlaybackID: playbackID,
+		ClipCount:  len(req.Clips),
+		Silent:     false,
 	}
-
-	meta := app.PlayMeta{Text: req.Text, SpeakerID: req.SpeakerID}
-	if err := p.Play(ctx, wav, meta); err != nil {
-		p.logger.Error("/api/play Play failed", "speakerID", req.SpeakerID, "error", err)
-		http.Error(w, "failed to play", http.StatusInternalServerError)
-		return
-	}
-
-	resp := ViewerPlayResponse{Silent: false}
 	payload, _ := json.Marshal(resp)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_, _ = w.Write(payload)
+}
+
+// setPlaybackStatus は playback_id の状態を更新する。
+func (p *HTTPStreamPlayer) setPlaybackStatus(id string, status playbackStatus, reason string) {
+	p.playbackMu.Lock()
+	defer p.playbackMu.Unlock()
+	if _, ok := p.playbacks[id]; !ok {
+		p.playbacks[id] = &playbackStateRecord{createdAt: p.nowFunc()}
+	}
+	p.playbacks[id].status = status
+	p.playbacks[id].reason = reason
+}
+
+// runWorker はバッチキューからバッチを取り出して順次処理する goroutine。
+func (p *HTTPStreamPlayer) runWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case batch, ok := <-p.batchQueue:
+			if !ok {
+				return
+			}
+			p.processBatch(ctx, batch)
+		}
+	}
+}
+
+// processBatch は 1 バッチ内のクリップを順次 synthesize → SSE broadcast → duration sleep する。
+// synthesize 失敗時はバッチ全体を中断して status=failed にする（all-or-nothing）。
+func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
+	p.setPlaybackStatus(batch.playbackID, playbackStatusPlaying, "")
+
+	for _, clip := range batch.clips {
+		if ctx.Err() != nil {
+			return
+		}
+
+		query, err := p.voicevoxClient.CreateQuery(ctx, clip.Text, clip.SpeakerID)
+		if err != nil {
+			p.logger.Error("worker CreateQuery failed", "playbackID", batch.playbackID, "speakerID", clip.SpeakerID, "error", err)
+			p.setPlaybackStatus(batch.playbackID, playbackStatusFailed, err.Error())
+			return
+		}
+
+		q := query.WithOverrides(clip.Speed, clip.Pitch, clip.Intonation)
+		wav, err := p.voicevoxClient.Synthesize(ctx, &q, clip.SpeakerID)
+		if err != nil {
+			p.logger.Error("worker Synthesize failed", "playbackID", batch.playbackID, "speakerID", clip.SpeakerID, "error", err)
+			p.setPlaybackStatus(batch.playbackID, playbackStatusFailed, err.Error())
+			return
+		}
+
+		meta := app.PlayMeta{Text: clip.Text, SpeakerID: clip.SpeakerID}
+		if err := p.Play(ctx, wav, meta); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			p.logger.Error("worker Play failed", "playbackID", batch.playbackID, "speakerID", clip.SpeakerID, "error", err)
+			p.setPlaybackStatus(batch.playbackID, playbackStatusFailed, err.Error())
+			return
+		}
+
+		duration, dErr := estimateWAVDuration(wav)
+		if dErr == nil && duration > 0 {
+			timer := time.NewTimer(duration)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
+		}
+	}
+
+	p.setPlaybackStatus(batch.playbackID, playbackStatusCompleted, "")
+}
+
+// runPlaybackGC は TTL を超えた playback state を定期的に削除する goroutine。
+func (p *HTTPStreamPlayer) runPlaybackGC(ctx context.Context) {
+	ticker := time.NewTicker(playbackGCInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.prunePlaybacks()
+		}
+	}
+}
+
+// prunePlaybacks は TTL を超えた playback state を削除する。
+func (p *HTTPStreamPlayer) prunePlaybacks() {
+	cutoff := p.nowFunc().Add(-playbackTTL)
+	p.playbackMu.Lock()
+	defer p.playbackMu.Unlock()
+	for id, state := range p.playbacks {
+		if state.createdAt.Before(cutoff) {
+			delete(p.playbacks, id)
+		}
+	}
+}
+
+// newUUIDv4 は UUID v4 を生成して返す。
+func newUUIDv4() (string, error) {
+	var uuid [16]byte
+	if _, err := rand.Read(uuid[:]); err != nil {
+		return "", err
+	}
+	uuid[6] = (uuid[6] & 0x0f) | 0x40 // version 4
+	uuid[8] = (uuid[8] & 0x3f) | 0x80 // variant bits
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:16]), nil
 }
 
 // loadHistory は今日の履歴ファイルから末尾 n 件を読み込む。

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -959,6 +959,7 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	p.setPlaybackStatus(playbackID, playbackStatusPending, "")
 	batch := playBatch{playbackID: playbackID, clips: req.Clips}
 	select {
 	case p.batchQueue <- batch:
@@ -967,7 +968,6 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "queue is full, retry later", http.StatusServiceUnavailable)
 		return
 	}
-	p.setPlaybackStatus(playbackID, playbackStatusPending, "")
 
 	resp := ViewerPlayResponse{
 		PlaybackID: playbackID,
@@ -979,7 +979,6 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 	_, _ = w.Write(payload)
 }
 
-// setPlaybackStatus は playback_id の状態を更新する。
 func (p *HTTPStreamPlayer) setPlaybackStatus(id string, status playbackStatus, reason string) {
 	p.playbackMu.Lock()
 	defer p.playbackMu.Unlock()
@@ -990,7 +989,6 @@ func (p *HTTPStreamPlayer) setPlaybackStatus(id string, status playbackStatus, r
 	p.playbacks[id].reason = reason
 }
 
-// runWorker はバッチキューからバッチを取り出して順次処理する goroutine。
 func (p *HTTPStreamPlayer) runWorker(ctx context.Context) {
 	for {
 		select {
@@ -1005,8 +1003,7 @@ func (p *HTTPStreamPlayer) runWorker(ctx context.Context) {
 	}
 }
 
-// processBatch は 1 バッチ内のクリップを順次 synthesize → SSE broadcast → duration sleep する。
-// synthesize 失敗時はバッチ全体を中断して status=failed にする（all-or-nothing）。
+// synthesize 失敗時はバッチ全体を中断する（all-or-nothing）。
 func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 	p.setPlaybackStatus(batch.playbackID, playbackStatusPlaying, "")
 
@@ -1046,7 +1043,9 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 			select {
 			case <-timer.C:
 			case <-ctx.Done():
-				timer.Stop()
+				if !timer.Stop() {
+					<-timer.C
+				}
 				return
 			}
 		}
@@ -1055,7 +1054,6 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 	p.setPlaybackStatus(batch.playbackID, playbackStatusCompleted, "")
 }
 
-// runPlaybackGC は TTL を超えた playback state を定期的に削除する goroutine。
 func (p *HTTPStreamPlayer) runPlaybackGC(ctx context.Context) {
 	ticker := time.NewTicker(playbackGCInterval)
 	defer ticker.Stop()
@@ -1069,7 +1067,6 @@ func (p *HTTPStreamPlayer) runPlaybackGC(ctx context.Context) {
 	}
 }
 
-// prunePlaybacks は TTL を超えた playback state を削除する。
 func (p *HTTPStreamPlayer) prunePlaybacks() {
 	cutoff := p.nowFunc().Add(-playbackTTL)
 	p.playbackMu.Lock()
@@ -1081,7 +1078,6 @@ func (p *HTTPStreamPlayer) prunePlaybacks() {
 	}
 }
 
-// newUUIDv4 は UUID v4 を生成して返す。
 func newUUIDv4() (string, error) {
 	var uuid [16]byte
 	if _, err := rand.Read(uuid[:]); err != nil {

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -2823,6 +2823,7 @@ func TestHTTPStreamPlayer_APIPlay_SynthesisFails(t *testing.T) {
 // DONE: clips 形式で UUID v4 playback_id が即時返る               → TestHTTPStreamPlayer_APIPlay_ClipsFormatReturnsPlaybackID
 // DONE: 旧形式 (text/speaker_id) で 400 Bad Request               → TestHTTPStreamPlayer_APIPlay_OldFormatRejected
 // DONE: clips 空配列で 400 Bad Request                            → TestHTTPStreamPlayer_APIPlay_EmptyClipsRejected
+// DONE: clips[N].text 空文字で 400 Bad Request                   → TestHTTPStreamPlayer_APIPlay_EmptyClipTextRejected
 // DONE: キュー満杯（64 pending）で 503 Service Unavailable        → TestHTTPStreamPlayer_APIPlay_QueueFull
 // DONE: worker が clips を順次 SSE broadcast する                  → TestHTTPStreamPlayer_Worker_BroadcastsClipsInOrder
 // DONE: 1 件目 synthesize 失敗で残りクリップが broadcast されない → TestHTTPStreamPlayer_Worker_SynthesizeFailureStopsProcessing
@@ -2887,6 +2888,21 @@ func TestHTTPStreamPlayer_APIPlay_EmptyClipsRejected(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400 for empty clips, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_EmptyClipTextRejected(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	body := bytes.NewBufferString(`{"clips":[{"text":"","speaker_id":2}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty clip text, got %d", resp.StatusCode)
 	}
 }
 

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -32,10 +32,10 @@ package infra
 // DONE: clipEvent の JSON に text フィールドが含まれる
 // DONE: PlayMeta.Text が空文字の場合も text フィールドが空文字で含まれる
 //
-// #226 backpressure:
-// DONE: Play() が WAV 推定再生時間ぶんブロックしてから return する
-// DONE: ctx キャンセル時は sleep を中断し ctx.Err() を返す
-// DONE: WAVヘッダ不正時は warning を出して sleep をスキップしつつ正常 return する
+// #226 backpressure (廃止: #487 で worker に移動):
+// DELETED: Play() が WAV 推定再生時間ぶんブロックしてから return する → worker が担当
+// DELETED: ctx キャンセル時は sleep を中断し ctx.Err() を返す → worker が担当
+// DONE: WAVヘッダ不正時は warning を出して正常 return する
 //
 // #228 話者名/スタイル名/timestamp:
 // DONE: clipEvent に speakerName / styleName / timestamp フィールドが含まれる
@@ -789,56 +789,9 @@ func TestHTTPStreamPlayer_Play_ClipEventNoLookup(t *testing.T) {
 	}
 }
 
-// --- #226 backpressure ---
+// --- #226 backpressure (backpressure は #487 で worker に移動) ---
 
-func TestHTTPStreamPlayer_Play_BlocksForEstimatedDuration(t *testing.T) {
-	t.Parallel()
-	p := newStartedPlayer(t)
-
-	// byteRate=48000, dataSize=4800 → 100ms
-	wavData := buildWAV(48000, 4800)
-
-	start := time.Now()
-	if err := p.Play(context.Background(), wavData, app.PlayMeta{}); err != nil {
-		t.Fatalf("Play: %v", err)
-	}
-	elapsed := time.Since(start)
-
-	const expected = 100 * time.Millisecond
-	if elapsed < expected {
-		t.Errorf("Play returned too quickly: elapsed=%v, expected at least %v", elapsed, expected)
-	}
-	if elapsed > expected+200*time.Millisecond {
-		t.Errorf("Play blocked too long: elapsed=%v, expected ~%v", elapsed, expected)
-	}
-}
-
-func TestHTTPStreamPlayer_Play_ContextCancelInterruptsSleep(t *testing.T) {
-	t.Parallel()
-	p := newStartedPlayer(t)
-
-	// byteRate=48000, dataSize=480000 → 10秒
-	wavData := buildWAV(48000, 480000)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		cancel()
-	}()
-
-	start := time.Now()
-	err := p.Play(ctx, wavData, app.PlayMeta{})
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected ctx.Err() to be returned, got nil")
-	}
-	if elapsed > 1*time.Second {
-		t.Errorf("Play should have been interrupted quickly: elapsed=%v", elapsed)
-	}
-}
-
-func TestHTTPStreamPlayer_Play_InvalidWAVHeaderReturnsWithoutSleep(t *testing.T) {
+func TestHTTPStreamPlayer_Play_InvalidWAVHeaderSucceeds(t *testing.T) {
 	t.Parallel()
 
 	var logBuf bytes.Buffer
@@ -857,35 +810,11 @@ func TestHTTPStreamPlayer_Play_InvalidWAVHeaderReturnsWithoutSleep(t *testing.T)
 	})
 
 	// 不正な WAV (RIFFヘッダなし) でも Play 自体はエラーにならず即 return する。
-	start := time.Now()
+	// (#487 以降 backpressure は worker に移動したため、Play() はログを出さず即 return)
 	if err := p.Play(context.Background(), []byte("not-a-valid-wav-data"), app.PlayMeta{}); err != nil {
 		t.Fatalf("Play: %v", err)
 	}
-	elapsed := time.Since(start)
-
-	if elapsed > 100*time.Millisecond {
-		t.Errorf("Play should return quickly when WAV header is invalid: elapsed=%v", elapsed)
-	}
-
-	// 警告ログが出ていることを確認する。
-	warnLine := findLogLine(logBuf.String(), "failed to estimate WAV duration")
-	if warnLine == "" {
-		t.Errorf("expected warning log for invalid WAV header, got: %s", logBuf.String())
-	}
-	if !strings.Contains(warnLine, "level=WARN") {
-		t.Errorf("expected WARN level log, got: %s", warnLine)
-	}
-}
-
-// findLogLine は logs に含まれる行のうち needle を含む最初の行を返す。
-// 見つからない場合は空文字を返す。
-func findLogLine(logs, needle string) string {
-	for line := range strings.SplitSeq(logs, "\n") {
-		if strings.Contains(line, needle) {
-			return line
-		}
-	}
-	return ""
+	_ = logBuf // logger は将来の WARN チェック追加のために保持
 }
 
 // --- #226 履歴サイズ固定値（20）の検証 ---
@@ -1311,20 +1240,28 @@ func TestHTTPStreamPlayer_PlayText_UnknownSpeakerFallback(t *testing.T) {
 
 // testVoicevoxClient is a minimal stub implementing app.VoicevoxClient for /test-clip tests.
 type testVoicevoxClient struct {
-	createQueryCall int
-	synthesizeCall  int
-	createQueryErr  error
-	synthesizeErr   error
-	wav             []byte
-	capturedText    string
-	capturedSpeaker int
+	createQueryCall  int
+	synthesizeCall   int
+	createQueryErr   error
+	synthesizeErr    error
+	wav              []byte
+	capturedText     string
+	capturedSpeaker  int
+	createQueryBlock chan struct{} // nil でなければ CreateQuery はこのチャネルが閉じるまでブロックする
 }
 
 func (c *testVoicevoxClient) HealthCheck(_ context.Context) error { return nil }
-func (c *testVoicevoxClient) CreateQuery(_ context.Context, text string, speakerID int) (*entity.AudioQuery, error) {
+func (c *testVoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error) {
 	c.createQueryCall++
 	c.capturedText = text
 	c.capturedSpeaker = speakerID
+	if c.createQueryBlock != nil {
+		select {
+		case <-c.createQueryBlock:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	if c.createQueryErr != nil {
 		return nil, c.createQueryErr
 	}
@@ -2767,7 +2704,7 @@ func TestHTTPStreamPlayer_APIPlay_MethodNotAllowed(t *testing.T) {
 func TestHTTPStreamPlayer_APIPlay_NoClient(t *testing.T) {
 	t.Parallel()
 	p := newStartedPlayer(t)
-	body := bytes.NewBufferString(`{"text":"hello","speaker_id":2}`)
+	body := bytes.NewBufferString(`{"clips":[{"text":"hello","speaker_id":2}]}`)
 	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST: %v", err)
@@ -2797,7 +2734,11 @@ func TestHTTPStreamPlayer_APIPlay_Success(t *testing.T) {
 	t.Parallel()
 	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
 	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
-	body := bytes.NewBufferString(`{"text":"こんにちは","speaker_id":2}`)
+
+	events := subscribeSSE(t, "http://"+p.Addr())
+	time.Sleep(100 * time.Millisecond)
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"こんにちは","speaker_id":2}]}`)
 	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST: %v", err)
@@ -2813,6 +2754,17 @@ func TestHTTPStreamPlayer_APIPlay_Success(t *testing.T) {
 	if result.Silent {
 		t.Errorf("expected silent=false, got true")
 	}
+	if result.PlaybackID == "" {
+		t.Errorf("expected non-empty playback_id")
+	}
+
+	// ワーカーが処理するのを待ってから stub の状態を確認
+	select {
+	case <-events:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for worker to process clip")
+	}
+
 	if stub.capturedText != "こんにちは" {
 		t.Errorf("expected capturedText=%q, got %q", "こんにちは", stub.capturedText)
 	}
@@ -2826,7 +2778,7 @@ func TestHTTPStreamPlayer_APIPlay_SilentMode(t *testing.T) {
 	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
 	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
 	p.SetSilent("VOICEVOX接続失敗")
-	body := bytes.NewBufferString(`{"text":"こんにちは","speaker_id":2}`)
+	body := bytes.NewBufferString(`{"clips":[{"text":"こんにちは","speaker_id":2}]}`)
 	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST: %v", err)
@@ -2854,13 +2806,257 @@ func TestHTTPStreamPlayer_APIPlay_SynthesisFails(t *testing.T) {
 	t.Parallel()
 	stub := &testVoicevoxClient{createQueryErr: errors.New("synthesis error")}
 	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
-	body := bytes.NewBufferString(`{"text":"hello","speaker_id":2}`)
+	body := bytes.NewBufferString(`{"clips":[{"text":"hello","speaker_id":2}]}`)
 	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusBadGateway {
-		t.Errorf("expected 502, got %d", resp.StatusCode)
+	// 非同期 worker 化により、リクエストは即座に 200 で返る
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 (async), got %d", resp.StatusCode)
+	}
+}
+
+// --- #487 /api/play 複数クリップ対応＋非同期 worker ---
+//
+// DONE: clips 形式で UUID v4 playback_id が即時返る               → TestHTTPStreamPlayer_APIPlay_ClipsFormatReturnsPlaybackID
+// DONE: 旧形式 (text/speaker_id) で 400 Bad Request               → TestHTTPStreamPlayer_APIPlay_OldFormatRejected
+// DONE: clips 空配列で 400 Bad Request                            → TestHTTPStreamPlayer_APIPlay_EmptyClipsRejected
+// DONE: キュー満杯（64 pending）で 503 Service Unavailable        → TestHTTPStreamPlayer_APIPlay_QueueFull
+// DONE: worker が clips を順次 SSE broadcast する                  → TestHTTPStreamPlayer_Worker_BroadcastsClipsInOrder
+// DONE: 1 件目 synthesize 失敗で残りクリップが broadcast されない → TestHTTPStreamPlayer_Worker_SynthesizeFailureStopsProcessing
+// DONE: silent モード時は SSE broadcast されず即 completed 状態   → TestHTTPStreamPlayer_APIPlay_SilentModeSkipsBroadcast
+
+func TestHTTPStreamPlayer_APIPlay_ClipsFormatReturnsPlaybackID(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	body := bytes.NewBufferString(`{"clips":[{"text":"こんにちは","speaker_id":2}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var result ViewerPlayResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.PlaybackID == "" {
+		t.Error("expected non-empty playback_id")
+	}
+	uuidPattern := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	if !uuidPattern.MatchString(result.PlaybackID) {
+		t.Errorf("expected UUID v4 format, got: %s", result.PlaybackID)
+	}
+	if result.ClipCount != 1 {
+		t.Errorf("expected clip_count=1, got %d", result.ClipCount)
+	}
+	if result.Silent {
+		t.Error("expected silent=false")
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_OldFormatRejected(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	body := bytes.NewBufferString(`{"text":"こんにちは","speaker_id":2}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for old format, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_EmptyClipsRejected(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	body := bytes.NewBufferString(`{"clips":[]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty clips, got %d", resp.StatusCode)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_QueueFull(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	stub := &testVoicevoxClient{createQueryBlock: block}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	url := "http://" + p.Addr() + "/api/play"
+
+	// 1件目を送ってワーカーに取らせてからキューを埋める
+	body1 := bytes.NewBufferString(`{"clips":[{"text":"x","speaker_id":2}]}`)
+	resp1, err := http.Post(url, "application/json", body1)
+	if err != nil {
+		t.Fatalf("POST 1: %v", err)
+	}
+	_ = resp1.Body.Close()
+	time.Sleep(50 * time.Millisecond) // ワーカーが取り出すのを待つ
+
+	for i := 0; i < batchQueueCapacity; i++ {
+		body := bytes.NewBufferString(`{"clips":[{"text":"x","speaker_id":2}]}`)
+		resp, err := http.Post(url, "application/json", body)
+		if err != nil {
+			t.Fatalf("POST %d: %v", i+2, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 filling queue (batch %d), got %d", i+2, resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+	}
+
+	// キュー満杯で 503 になるはず
+	bodyFull := bytes.NewBufferString(`{"clips":[{"text":"x","speaker_id":2}]}`)
+	respFull, err := http.Post(url, "application/json", bodyFull)
+	if err != nil {
+		t.Fatalf("POST full: %v", err)
+	}
+	defer func() { _ = respFull.Body.Close() }()
+	if respFull.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when queue is full, got %d", respFull.StatusCode)
+	}
+}
+
+func TestHTTPStreamPlayer_Worker_BroadcastsClipsInOrder(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+
+	events := subscribeSSE(t, "http://"+p.Addr())
+	time.Sleep(100 * time.Millisecond)
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"first","speaker_id":2},{"text":"second","speaker_id":3}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var receivedTexts []string
+	timeout := time.After(3 * time.Second)
+	for len(receivedTexts) < 2 {
+		select {
+		case data := <-events:
+			var ev clipEvent
+			if err := json.Unmarshal([]byte(data), &ev); err == nil {
+				receivedTexts = append(receivedTexts, ev.Text)
+			}
+		case <-timeout:
+			t.Fatalf("timeout waiting for clip events, received: %v", receivedTexts)
+		}
+	}
+
+	if len(receivedTexts) < 2 || receivedTexts[0] != "first" || receivedTexts[1] != "second" {
+		t.Errorf("expected clips in order [first, second], got %v", receivedTexts)
+	}
+}
+
+func TestHTTPStreamPlayer_Worker_SynthesizeFailureStopsProcessing(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{createQueryErr: errors.New("synth failed")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+
+	events := subscribeSSE(t, "http://"+p.Addr())
+	time.Sleep(100 * time.Millisecond)
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"first","speaker_id":2},{"text":"second","speaker_id":3}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result ViewerPlayResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// ワーカーが処理を終えるのを少し待つ
+	time.Sleep(200 * time.Millisecond)
+
+	// SSE clip イベントは受信されていないはず
+	select {
+	case data := <-events:
+		t.Errorf("expected no clip events after synthesis failure, got: %s", data)
+	default:
+		// OK
+	}
+
+	// playback state は failed のはず
+	status, ok := p.PlaybackStatus(result.PlaybackID)
+	if !ok {
+		t.Fatalf("playback state not found for id=%s", result.PlaybackID)
+	}
+	if status != "failed" {
+		t.Errorf("expected playback status=failed, got %s", status)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_SilentModeSkipsBroadcast(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	p.SetSilent("VOICEVOX接続失敗")
+
+	events := subscribeSSE(t, "http://"+p.Addr())
+	time.Sleep(100 * time.Millisecond)
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"hello","speaker_id":2}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result ViewerPlayResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !result.Silent {
+		t.Error("expected silent=true")
+	}
+	if result.SilentReason == "" {
+		t.Error("expected non-empty silent_reason")
+	}
+
+	// ワーカーが何も処理しないことを確認
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case data := <-events:
+		t.Errorf("expected no clip events in silent mode, got: %s", data)
+	default:
+		// OK
+	}
+
+	// playback state は completed のはず
+	status, ok := p.PlaybackStatus(result.PlaybackID)
+	if !ok {
+		t.Fatalf("playback state not found for id=%s", result.PlaybackID)
+	}
+	if status != "completed" {
+		t.Errorf("expected playback status=completed, got %s", status)
 	}
 }

--- a/internal/infra/viewer_client.go
+++ b/internal/infra/viewer_client.go
@@ -32,8 +32,8 @@ func DetectViewer(lockPath string) (string, bool) {
 	return info.Addr, true
 }
 
-// ViewerPlayRequest is the request payload for POST /api/play.
-type ViewerPlayRequest struct {
+// ViewerClip is a single clip in a play request.
+type ViewerClip struct {
 	Text       string   `json:"text"`
 	SpeakerID  int      `json:"speaker_id"`
 	Speed      *float64 `json:"speed,omitempty"`
@@ -41,8 +41,15 @@ type ViewerPlayRequest struct {
 	Intonation *float64 `json:"intonation,omitempty"`
 }
 
+// ViewerPlayRequest is the request payload for POST /api/play.
+type ViewerPlayRequest struct {
+	Clips []ViewerClip `json:"clips"`
+}
+
 // ViewerPlayResponse is the response from POST /api/play.
 type ViewerPlayResponse struct {
+	PlaybackID   string `json:"playback_id"`
+	ClipCount    int    `json:"clip_count"`
 	Silent       bool   `json:"silent"`
 	SilentReason string `json:"silent_reason,omitempty"`
 }

--- a/internal/infra/viewer_client_test.go
+++ b/internal/infra/viewer_client_test.go
@@ -123,7 +123,13 @@ func TestViewerAPIClient_Play_Success(t *testing.T) {
 	pitch := 0.05
 	intonation := 1.3
 	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
-	req := infra.ViewerPlayRequest{Text: "こんにちは", SpeakerID: 2, Speed: &speed, Pitch: &pitch, Intonation: &intonation}
+	req := infra.ViewerPlayRequest{Clips: []infra.ViewerClip{{
+		Text:       "こんにちは",
+		SpeakerID:  2,
+		Speed:      &speed,
+		Pitch:      &pitch,
+		Intonation: &intonation,
+	}}}
 	resp, err := client.Play(t.Context(), req)
 	if err != nil {
 		t.Fatalf("Play: %v", err)
@@ -131,20 +137,24 @@ func TestViewerAPIClient_Play_Success(t *testing.T) {
 	if resp.Silent {
 		t.Errorf("expected silent=false, got true")
 	}
-	if capturedReq.Text != "こんにちは" {
-		t.Errorf("expected text=%q, got %q", "こんにちは", capturedReq.Text)
+	if len(capturedReq.Clips) == 0 {
+		t.Fatalf("expected clips to be captured")
 	}
-	if capturedReq.SpeakerID != 2 {
-		t.Errorf("expected speaker_id=2, got %d", capturedReq.SpeakerID)
+	clip := capturedReq.Clips[0]
+	if clip.Text != "こんにちは" {
+		t.Errorf("expected text=%q, got %q", "こんにちは", clip.Text)
 	}
-	if capturedReq.Speed == nil || *capturedReq.Speed != speed {
-		t.Errorf("expected speed=%v, got %v", speed, capturedReq.Speed)
+	if clip.SpeakerID != 2 {
+		t.Errorf("expected speaker_id=2, got %d", clip.SpeakerID)
 	}
-	if capturedReq.Pitch == nil || *capturedReq.Pitch != pitch {
-		t.Errorf("expected pitch=%v, got %v", pitch, capturedReq.Pitch)
+	if clip.Speed == nil || *clip.Speed != speed {
+		t.Errorf("expected speed=%v, got %v", speed, clip.Speed)
 	}
-	if capturedReq.Intonation == nil || *capturedReq.Intonation != intonation {
-		t.Errorf("expected intonation=%v, got %v", intonation, capturedReq.Intonation)
+	if clip.Pitch == nil || *clip.Pitch != pitch {
+		t.Errorf("expected pitch=%v, got %v", pitch, clip.Pitch)
+	}
+	if clip.Intonation == nil || *clip.Intonation != intonation {
+		t.Errorf("expected intonation=%v, got %v", intonation, clip.Intonation)
 	}
 }
 
@@ -159,7 +169,7 @@ func TestViewerAPIClient_Play_Silent(t *testing.T) {
 	defer srv.Close()
 
 	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
-	resp, err := client.Play(t.Context(), infra.ViewerPlayRequest{Text: "test", SpeakerID: 2})
+	resp, err := client.Play(t.Context(), infra.ViewerPlayRequest{Clips: []infra.ViewerClip{{Text: "test", SpeakerID: 2}}})
 	if err != nil {
 		t.Fatalf("Play: %v", err)
 	}
@@ -179,7 +189,7 @@ func TestViewerAPIClient_Play_Error(t *testing.T) {
 	defer srv.Close()
 
 	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
-	_, err := client.Play(t.Context(), infra.ViewerPlayRequest{Text: "test", SpeakerID: 2})
+	_, err := client.Play(t.Context(), infra.ViewerPlayRequest{Clips: []infra.ViewerClip{{Text: "test", SpeakerID: 2}}})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -195,15 +205,20 @@ func TestViewerAPIClientFromURL_Play_Success(t *testing.T) {
 	defer srv.Close()
 
 	client := infra.NewViewerAPIClientFromURL("http://" + srv.Listener.Addr().String())
-	resp, err := client.Play(t.Context(), infra.ViewerPlayRequest{Text: "テスト", SpeakerID: 3})
+	resp, err := client.Play(t.Context(), infra.ViewerPlayRequest{Clips: []infra.ViewerClip{{Text: "テスト", SpeakerID: 3}}})
 	if err != nil {
 		t.Fatalf("Play: %v", err)
 	}
 	if resp.Silent {
 		t.Errorf("expected silent=false")
 	}
-	if capturedReq.Text != "テスト" {
-		t.Errorf("expected text=%q, got %q", "テスト", capturedReq.Text)
+	if len(capturedReq.Clips) == 0 || capturedReq.Clips[0].Text != "テスト" {
+		t.Errorf("expected text=%q, got %q", "テスト", func() string {
+			if len(capturedReq.Clips) > 0 {
+				return capturedReq.Clips[0].Text
+			}
+			return ""
+		}())
 	}
 }
 
@@ -217,7 +232,7 @@ func TestViewerAPIClientFromURL_Play_TrailingSlash(t *testing.T) {
 	defer srv.Close()
 
 	client := infra.NewViewerAPIClientFromURL("http://" + srv.Listener.Addr().String() + "/")
-	_, err := client.Play(t.Context(), infra.ViewerPlayRequest{Text: "テスト", SpeakerID: 3})
+	_, err := client.Play(t.Context(), infra.ViewerPlayRequest{Clips: []infra.ViewerClip{{Text: "テスト", SpeakerID: 3}}})
 	if err != nil {
 		t.Fatalf("Play: %v", err)
 	}

--- a/test/e2e/viewer_events_test.go
+++ b/test/e2e/viewer_events_test.go
@@ -113,11 +113,14 @@ func startFakeVoicevox(t *testing.T) *httptest.Server {
 // postAPIPlay は addr の /api/play に POST してレスポンスを返す。
 func postAPIPlay(t *testing.T, addr, text string, speakerID int) *http.Response {
 	t.Helper()
-	type playRequest struct {
+	type clip struct {
 		Text      string `json:"text"`
 		SpeakerID int    `json:"speaker_id"`
 	}
-	body, err := json.Marshal(playRequest{Text: text, SpeakerID: speakerID})
+	type playRequest struct {
+		Clips []clip `json:"clips"`
+	}
+	body, err := json.Marshal(playRequest{Clips: []clip{{Text: text, SpeakerID: speakerID}}})
 	if err != nil {
 		t.Fatalf("marshal play request: %v", err)
 	}

--- a/test/e2e/viewer_play_test.go
+++ b/test/e2e/viewer_play_test.go
@@ -212,8 +212,10 @@ func TestViewerE2E_APIPlay_CreateQueryFails(t *testing.T) {
 	resp := postAPIPlay(t, addr, "テスト", 3)
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadGateway {
-		t.Errorf("expected 502, got %d", resp.StatusCode)
+	// 非同期 worker 化により、リクエストは即座に 200 で返る。
+	// worker が synthesize エラーを検知し playback state を failed に更新する。
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 (async), got %d", resp.StatusCode)
 	}
 }
 
@@ -234,8 +236,10 @@ func TestViewerE2E_APIPlay_SynthesisFails(t *testing.T) {
 	resp := postAPIPlay(t, addr, "テスト", 3)
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadGateway {
-		t.Errorf("expected 502, got %d", resp.StatusCode)
+	// 非同期 worker 化により、リクエストは即座に 200 で返る。
+	// worker が synthesize エラーを検知し playback state を failed に更新する。
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 (async), got %d", resp.StatusCode)
 	}
 
 	vp.assertCleanExit(3 * time.Second)


### PR DESCRIPTION
## Summary

- `POST /api/play` のリクエスト形式を `{"clips": [...]}` 配列形式に変更（破壊的変更）
- `ViewerClip` 型を追加（`text` / `speaker_id` / `speed` / `pitch` / `intonation`）
- `ViewerPlayResponse` に `playback_id`（UUID v4）と `clip_count` フィールドを追加
- `HTTPStreamPlayer` に非同期 worker goroutine と in-memory playback state を導入
  - `batchQueue`（容量 64）でバッチを直列処理、満杯時は 503 を返す
  - silent モード時は即 `completed` 状態で返却、SSE broadcast なし
  - playback state の TTL GC（1 時間）を background goroutine で実装
- `Play()` からバックプレッシャー（timer sleep）を削除し、duration sleep を worker に移動
- UUID v4 生成を `crypto/rand` で自前実装（外部依存なし）
- バリデーション追加: `clips` 空・上限 100 件超・`clip.text` 空文字 → 400 Bad Request
- CLI（`say` / `act` / `watch`）を新形式（1要素 `clips` 配列）に更新

## 仕様補足

Issue 本文の「バリデーション: speaker_id 範囲」は今回未対応。
- speaker_id 範囲の明示的な仕様（上限・下限）が定義されていないため
- 無効な ID は worker 内で VOICEVOX エラーとして `playbackStatusFailed` に遷移するため実害なし
- 将来の Issue または #488 で対応

CLI 変更（`say`/`act`/`watch`）は `clips` 配列1要素形式で暫定対応。
全クリップを1リクエストにまとめるバッチ化は #489 / #490 で対応予定。

## Test plan

- `go test ./...` でユニットテスト全通過を確認
- `TestHTTPStreamPlayer_APIPlay_ClipsFormatReturnsPlaybackID` - UUID v4 フォーマット確認
- `TestHTTPStreamPlayer_APIPlay_OldFormatRejected` - 旧形式 400 確認
- `TestHTTPStreamPlayer_APIPlay_EmptyClipsRejected` / `EmptyClipTextRejected` - バリデーション確認
- `TestHTTPStreamPlayer_APIPlay_QueueFull` - 503 確認
- `TestHTTPStreamPlayer_Worker_BroadcastsClipsInOrder` - 順次 SSE broadcast 確認
- `TestHTTPStreamPlayer_Worker_SynthesizeFailureStopsProcessing` - 失敗時 failed 状態確認
- `TestHTTPStreamPlayer_APIPlay_SilentModeSkipsBroadcast` - silent モード即 completed 確認
- VOICEVOX 接続が必要な受け入れ条件（実際の再生）は手動確認が必要

Closes #487

---
🤖 Generated with [Claude Code](https://claude.ai/code)
