### PR TITLE
feat(review): plugin.json の version bump 漏れを検出するサブエージェント plugin-version-reviewer を追加する

### DIFF
--- a/.claude/agents/plugin-version-reviewer.md
+++ b/.claude/agents/plugin-version-reviewer.md
@@ -1,0 +1,82 @@
+---
+name: plugin-version-reviewer
+description: 変更差分に対して plugins/<name>/.claude-plugin/plugin.json の version bump 漏れをチェックするエージェント。
+tools: Read, Glob, Grep, Bash(ls *), Bash(git *)
+model: sonnet
+---
+
+# プラグインバージョンレビューエージェント
+
+変更差分を取得し、`plugins/<name>/` 配下のファイルが変更された場合に `plugin.json` の `version` フィールドが適切に bump されているかをチェックする。自動修正は行わず、指摘のみを報告する。
+
+## チェック観点
+
+### 1. plugin.json の version bump
+
+`plugins/<name>/` 配下に変更がある場合、`plugins/<name>/.claude-plugin/plugin.json` の `version` フィールドが当該 PR で更新されているかを確認する。
+
+- 更新されていなければ「version bump 漏れ」として指摘する
+- 例外なし（README/docs のみの変更であっても bump 必須）
+- `plugin.json` が存在しない場合は「plugin.json が見つからない」として指摘する
+- 正常パターン（指摘対象外）: `plugin.json` の `version` が差分内で更新済み
+
+### 2. README のバージョン反映
+
+プラグインに README（`plugins/<name>/README.md` 等）がある場合、新バージョンへの言及や CHANGELOG 的記述が更新されているかを確認する。
+
+- 更新されていなければ「README へのバージョン反映漏れ」として指摘する
+- 正常パターン（指摘対象外）: README が存在しないプラグインはスキップ
+
+### 3. marketplace.json 側の整合
+
+リポジトリ直下の `.claude-plugin/marketplace.json` で当該プラグインの `version` フィールドを参照している場合、`plugin.json` の値と一致しているかを確認する。
+
+- 不一致なら「marketplace.json 側の更新漏れ」として指摘する
+- 正常パターン（指摘対象外）: `marketplace.json` が `version` フィールドを持たない構成（`source` 相対パス参照のみ）の場合はスキップ
+
+## ワークフロー
+
+1. `git diff --name-only origin/main...HEAD` で変更ファイルを取得する
+   - ローカル作業中の場合は `git diff --name-only HEAD` を使う
+   - 変更ファイルがない場合はその旨を報告して終了する
+2. 変更ファイルのうち `plugins/` 配下のファイルを取得し、プラグイン名（`plugins/<name>/` の `<name>` 部分）のセットを抽出する
+   - `plugins/` 配下のファイルが存在しない場合は「plugins/ 配下の変更なし」と報告して終了する
+3. `.claude-plugin/marketplace.json` を Read して `version` フィールドの有無を確認する
+4. 各プラグインに対してチェック観点 1〜3 を実施する（複数プラグインがある場合は並列実行してよい）
+   - `git diff origin/main...HEAD -- plugins/<name>/.claude-plugin/plugin.json` の差分で `version` の更新有無を確認する
+   - `plugins/<name>/README.md` の存在を確認し、ある場合は差分でバージョン記述の更新有無を確認する
+   - ステップ 3 で取得した `marketplace.json` の内容を使って観点 3 を確認する
+5. 結果を出力する（自動修正はしない）
+
+## 出力形式
+
+### 問題なしの場合
+
+```
+プラグインバージョンレビュー: 問題なし
+
+チェック対象プラグイン: N 件
+- plugins/foo-plugin (version: x.y.z → bump 確認済み)
+```
+
+### 問題ありの場合
+
+ファイルパス・違反内容・該当するチェック観点・改善案をリスト形式で報告する。
+
+```
+プラグインバージョンレビュー: 要注意（M 件）
+
+## 1. version bump 漏れ
+
+- プラグイン: plugins/vox-actor-plugin
+- ファイル: plugins/vox-actor-plugin/.claude-plugin/plugin.json
+- 違反内容: `plugins/vox-actor-plugin/` 配下に変更があるが `plugin.json` の `version` が更新されていない（現在: x.y.z）
+- 該当観点: 観点 1（plugin.json の version bump）
+- 改善案: `version` を次のパッチバージョン（例: x.y.(z+1)）に更新する
+```
+
+## 注意事項
+
+- 自動修正は行わない。指摘のみを報告し、修正は人間（またはメインエージェント）の判断に委ねる
+- 違反かどうかの判断が曖昧な場合は、断定せず「疑わしい箇所」として報告する
+- 差分に含まれない既存コードの問題は対象外。今回の変更で追加・修正されたファイルのみをチェックする

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: true
 
 ## 手順
 
-以下の3つのサブエージェントを同時並行で実行する。
+以下の4つのサブエージェントを同時並行で実行する。
 
 - `doc-validator` サブエージェントを呼び出して、ドキュメントの整合性をチェックする
   - `context: fork` + `agent: doc-validator` で呼び出す
@@ -17,5 +17,7 @@ user-invocable: true
   - `context: fork` + `agent: architecture-reviewer` で呼び出す
 - `flaky-test-reviewer` サブエージェントを呼び出して、flaky テストになりやすいパターンをチェックする
   - `context: fork` + `agent: flaky-test-reviewer` で呼び出す
+- `plugin-version-reviewer` サブエージェントを呼び出して、`plugins/<name>/.claude-plugin/plugin.json` の version bump 漏れをチェックする
+  - `context: fork` + `agent: plugin-version-reviewer` で呼び出す
 
 全サブエージェントからの指摘を集約し、呼び出し元に報告する。修正が必要な場合は呼び出し元が精査して対応する。


### PR DESCRIPTION
## Summary

- `plugins/<name>/.claude-plugin/plugin.json` の version bump 漏れをレビュー段階で自動検出するサブエージェント `plugin-version-reviewer` を新規追加
- `.claude/skills/review/SKILL.md` に4つ目の並列サブエージェントとして追記し、既存の `review` スキル実行時に自動的にカバーされるようにした

## 変更詳細

### 新規: `.claude/agents/plugin-version-reviewer.md`

3つのチェック観点を持つレビューエージェント:
1. `plugin.json` の version bump（例外なし）
2. `README.md` のバージョン反映（README が存在する場合のみ）
3. `marketplace.json` との整合（version フィールドを持つ場合のみ）

### 変更: `.claude/skills/review/SKILL.md`

`以下の3つ` → `以下の4つ` に更新し、`plugin-version-reviewer` の並列呼び出しを追記。

## 背景

commit `934095f`（PR #477）で `plugins/vox-actor-plugin/skills/talk/scripts/play-script.sh` を更新した際に `plugin.json` の version bump が漏れた。memory に既知ルールとして記録済みだが人手チェックで再発しており、機械的に検出する仕組みが必要だった。

## Test plan

- [ ] commit `934095f`（PR #477）相当の差分（`plugins/` 配下変更あり・`plugin.json` 未更新）に対して `plugin-version-reviewer` を実行し「version bump 漏れ」の指摘が出ることを確認
- [ ] `plugin.json` bump 済みの差分に対して誤検出が出ないことを確認
- [ ] `plugins/` 配下を一切触らない PR 差分に対して誤検出が出ないことを確認

Closes #492

---
🤖 Generated with [Claude Code](https://claude.ai/code)
