### PR TITLE
feat(viewer): playback_id 化と /api/play バッチ対応で talk と独り言の混在を解消する (#488-490)

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
 	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
@@ -59,6 +61,46 @@ func makeActCmd(deps *ActDeps) *cobra.Command {
 	return cmd
 }
 
+// actViaViewer は scripts を 1 回の POST にまとめて viewer に送り、playback_id を stdout に出力する。
+func actViaViewer(
+	ctx context.Context,
+	cmd *cobra.Command,
+	vc *infra.ViewerAPIClient,
+	scripts []entity.Script,
+	speakerID int, speed, pitch, intonation float64,
+	logger *slog.Logger,
+) error {
+	var clips []infra.ViewerClip
+	for _, script := range scripts {
+		if script.IsEmpty {
+			continue
+		}
+		clips = append(clips, infra.ViewerClip{
+			Text:       script.Text,
+			SpeakerID:  script.ResolveSpeakerID(speakerID),
+			Speed:      script.ResolveSpeed(&speed),
+			Pitch:      script.ResolvePitch(&pitch),
+			Intonation: script.ResolveIntonation(&intonation),
+		})
+	}
+	if len(clips) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "local_playback")
+		return nil
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+	resp, err := vc.Play(ctx, infra.ViewerPlayRequest{Clips: clips})
+	if err != nil {
+		return fmt.Errorf("act via viewer: %w", err)
+	}
+	if resp.Silent {
+		logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), resp.PlaybackID)
+	return nil
+}
+
 func resolveActLockPath(deps *ActDeps) (string, error) {
 	if deps != nil {
 		return resolveViewerLockPathWith(deps.LockPathResolver)
@@ -104,34 +146,7 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 				return err
 			}
 			vc := infra.NewViewerAPIClientFromURL(viewerURL)
-			for _, script := range scripts {
-				if script.IsEmpty {
-					continue
-				}
-				if ctx.Err() != nil {
-					return nil
-				}
-				effectiveSpeakerID := script.ResolveSpeakerID(speakerID)
-				effectiveSpeed := script.ResolveSpeed(&speed)
-				effectivePitch := script.ResolvePitch(&pitch)
-				effectiveIntonation := script.ResolveIntonation(&intonation)
-				resp, postErr := vc.Play(ctx, infra.ViewerPlayRequest{
-					Clips: []infra.ViewerClip{{
-						Text:       script.Text,
-						SpeakerID:  effectiveSpeakerID,
-						Speed:      effectiveSpeed,
-						Pitch:      effectivePitch,
-						Intonation: effectiveIntonation,
-					}},
-				})
-				if postErr != nil {
-					return fmt.Errorf("act via viewer: %w", postErr)
-				}
-				if resp.Silent {
-					logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
-				}
-			}
-			return nil
+			return actViaViewer(ctx, cmd, vc, scripts, speakerID, speed, pitch, intonation, logger)
 		}
 
 		lockPath, lockErr := resolveActLockPath(deps)
@@ -144,34 +159,7 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 				return err
 			}
 			vc := infra.NewViewerAPIClient(addr)
-			for _, script := range scripts {
-				if script.IsEmpty {
-					continue
-				}
-				if ctx.Err() != nil {
-					return nil
-				}
-				effectiveSpeakerID := script.ResolveSpeakerID(speakerID)
-				effectiveSpeed := script.ResolveSpeed(&speed)
-				effectivePitch := script.ResolvePitch(&pitch)
-				effectiveIntonation := script.ResolveIntonation(&intonation)
-				resp, postErr := vc.Play(ctx, infra.ViewerPlayRequest{
-					Clips: []infra.ViewerClip{{
-						Text:       script.Text,
-						SpeakerID:  effectiveSpeakerID,
-						Speed:      effectiveSpeed,
-						Pitch:      effectivePitch,
-						Intonation: effectiveIntonation,
-					}},
-				})
-				if postErr != nil {
-					return fmt.Errorf("act via viewer: %w", postErr)
-				}
-				if resp.Silent {
-					logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
-				}
-			}
-			return nil
+			return actViaViewer(ctx, cmd, vc, scripts, speakerID, speed, pitch, intonation, logger)
 		} else {
 			logger.Debug("viewer not running, using local player")
 		}
@@ -182,12 +170,16 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 	}
 
 	uc := app.NewActUsecase(deps.Reader, client, deps.Player, app.WithLogger(logger))
-	return uc.Run(ctx, app.ActParams{
+	if err := uc.Run(ctx, app.ActParams{
 		Path:       args[0],
 		SpeakerID:  speakerID,
 		Speed:      &speed,
 		Pitch:      &pitch,
 		Intonation: &intonation,
 		DryRun:     dryRun,
-	})
+	}); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "local_playback")
+	return nil
 }

--- a/cmd/act.go
+++ b/cmd/act.go
@@ -61,7 +61,6 @@ func makeActCmd(deps *ActDeps) *cobra.Command {
 	return cmd
 }
 
-// actViaViewer は scripts を 1 回の POST にまとめて viewer に送り、playback_id を stdout に出力する。
 func actViaViewer(
 	ctx context.Context,
 	cmd *cobra.Command,
@@ -84,7 +83,7 @@ func actViaViewer(
 		})
 	}
 	if len(clips) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "local_playback")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), localPlaybackID)
 		return nil
 	}
 	if ctx.Err() != nil {
@@ -180,6 +179,6 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 	}); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "local_playback")
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), localPlaybackID)
 	return nil
 }

--- a/cmd/act_test.go
+++ b/cmd/act_test.go
@@ -236,7 +236,7 @@ func (s stubScriptReaderForAct) Read(_ string) ([]entity.Script, error) {
 	return s.scripts, nil
 }
 
-func TestRunAct_ViewerRunning_POSTsPerLine(t *testing.T) {
+func TestRunAct_ViewerRunning_BatchesAllClipsInOnePOST(t *testing.T) {
 	var postCount int
 	var capturedTexts []string
 
@@ -246,15 +246,17 @@ func TestRunAct_ViewerRunning_POSTsPerLine(t *testing.T) {
 		postCount++
 		var req map[string]interface{}
 		_ = json.NewDecoder(r.Body).Decode(&req)
-		// clips 形式: {"clips":[{"text":"...","speaker_id":...}]}
-		if clips, ok := req["clips"].([]interface{}); ok && len(clips) > 0 {
-			if clip, ok := clips[0].(map[string]interface{}); ok {
-				if text, ok := clip["text"].(string); ok {
-					capturedTexts = append(capturedTexts, text)
+		// clips 形式: {"clips":[{"text":"...","speaker_id":...}, ...]}
+		if clips, ok := req["clips"].([]interface{}); ok {
+			for _, c := range clips {
+				if clip, ok := c.(map[string]interface{}); ok {
+					if text, ok := clip["text"].(string); ok {
+						capturedTexts = append(capturedTexts, text)
+					}
 				}
 			}
 		}
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"silent": false})
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"playback_id": "abc", "clip_count": 2, "silent": false})
 	})
 	lockPath, _ := setupFakeViewer(t, mux)
 
@@ -266,6 +268,7 @@ func TestRunAct_ViewerRunning_POSTsPerLine(t *testing.T) {
 	cmd := newCmdWithContext(t)
 	registerCommonFlags(cmd)
 	_ = cmd.ParseFlags([]string{})
+	cmd.SetOut(new(bytes.Buffer))
 
 	deps := &ActDeps{
 		Reader:           stubScriptReaderForAct{scripts: []entity.Script{{Text: "line1"}, {Text: "line2"}}},
@@ -277,8 +280,8 @@ func TestRunAct_ViewerRunning_POSTsPerLine(t *testing.T) {
 	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
 		t.Fatalf("runAct: %v", err)
 	}
-	if postCount != 2 {
-		t.Errorf("expected 2 POSTs, got %d", postCount)
+	if postCount != 1 {
+		t.Errorf("expected 1 batch POST, got %d", postCount)
 	}
 	if len(capturedTexts) != 2 || capturedTexts[0] != "line1" || capturedTexts[1] != "line2" {
 		t.Errorf("expected texts [line1, line2], got %v", capturedTexts)
@@ -761,5 +764,133 @@ func TestRunAct_ExplicitViewerURL_ConnectionError_ReturnsError(t *testing.T) {
 	}
 	if playCalled {
 		t.Error("expected no local playback when --viewer-url fails")
+	}
+}
+
+// --- #489 say/act が viewer モードで playback_id を stdout 出力 ---
+
+func TestRunAct_ViewerMode_PrintsPlaybackIDToStdout(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"playback_id": "11111111-1111-4111-8111-111111111111",
+			"clip_count":  2,
+			"silent":      false,
+		})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	scriptFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("line1\nline2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	deps := &ActDeps{
+		Reader:           stubScriptReaderForAct{scripts: []entity.Script{{Text: "line1"}, {Text: "line2"}}},
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	got := strings.TrimSpace(stdout.String())
+	if got != "11111111-1111-4111-8111-111111111111" {
+		t.Errorf("expected stdout=playback_id, got %q", got)
+	}
+}
+
+func TestRunAct_ViewerMode_BatchesAllClipsInSinglePOST(t *testing.T) {
+	t.Parallel()
+	var postCount int
+	var capturedClips []map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		postCount++
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if clips, ok := req["clips"].([]interface{}); ok {
+			for _, c := range clips {
+				if m, ok := c.(map[string]interface{}); ok {
+					capturedClips = append(capturedClips, m)
+				}
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"playback_id": "abc", "clip_count": 2, "silent": false})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	scriptFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("line1\nline2\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+	cmd.SetOut(new(bytes.Buffer))
+
+	deps := &ActDeps{
+		Reader:           stubScriptReaderForAct{scripts: []entity.Script{{Text: "line1"}, {Text: "line2"}}},
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	if postCount != 1 {
+		t.Errorf("expected 1 batch POST, got %d", postCount)
+	}
+	if len(capturedClips) != 2 {
+		t.Errorf("expected 2 clips in batch, got %d", len(capturedClips))
+	}
+}
+
+func TestRunAct_LocalMode_PrintsLocalPlaybackToStdout(t *testing.T) {
+	t.Parallel()
+	player := &trackingPlayer{playFn: func() {}}
+	client := &mockSayClient{}
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+
+	scriptFile := filepath.Join(t.TempDir(), "test.txt")
+	if err := os.WriteFile(scriptFile, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	deps := &ActDeps{
+		Reader:           stubScriptReaderForAct{scripts: []entity.Script{{Text: "hello"}}},
+		ClientFactory:    func(_ string) app.VoicevoxClient { return client },
+		Player:           player,
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runAct(cmd, []string{scriptFile}, deps); err != nil {
+		t.Fatalf("runAct: %v", err)
+	}
+	got := strings.TrimSpace(stdout.String())
+	if got != "local_playback" {
+		t.Errorf("expected stdout=local_playback, got %q", got)
 	}
 }

--- a/cmd/playback.go
+++ b/cmd/playback.go
@@ -55,6 +55,9 @@ func makePlaybackWaitCmd(deps *PlaybackWaitDeps) *cobra.Command {
 
 func runPlaybackWait(cmd *cobra.Command, args []string, deps *PlaybackWaitDeps) error {
 	id := args[0]
+	if id == "" {
+		return fmt.Errorf("%w: id must not be empty", ErrUsage)
+	}
 	if id == localPlaybackID {
 		return nil
 	}

--- a/cmd/playback.go
+++ b/cmd/playback.go
@@ -9,7 +9,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// PlaybackWaitDeps は playback wait コマンドの依存を保持する。
+// localPlaybackID はローカル再生モード時の playback_id 文字列。
+const localPlaybackID = "local_playback"
+
 type PlaybackWaitDeps struct {
 	LockPathResolver func() (string, error)
 }
@@ -53,7 +55,7 @@ func makePlaybackWaitCmd(deps *PlaybackWaitDeps) *cobra.Command {
 
 func runPlaybackWait(cmd *cobra.Command, args []string, deps *PlaybackWaitDeps) error {
 	id := args[0]
-	if id == "local_playback" {
+	if id == localPlaybackID {
 		return nil
 	}
 

--- a/cmd/playback.go
+++ b/cmd/playback.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canpok1/vox-actor/internal/infra"
+	"github.com/spf13/cobra"
+)
+
+// PlaybackWaitDeps は playback wait コマンドの依存を保持する。
+type PlaybackWaitDeps struct {
+	LockPathResolver func() (string, error)
+}
+
+func resolvePlaybackWaitLockPath(deps *PlaybackWaitDeps) (string, error) {
+	if deps != nil {
+		return resolveViewerLockPathWith(deps.LockPathResolver)
+	}
+	return resolveViewerLockPathWith(nil)
+}
+
+func makePlaybackCmd(deps *PlaybackWaitDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "playback",
+		Short: "再生状態を管理する",
+	}
+	cmd.SilenceUsage = true
+	cmd.AddCommand(makePlaybackWaitCmd(deps))
+	return cmd
+}
+
+func makePlaybackWaitCmd(deps *PlaybackWaitDeps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "wait <id>",
+		Short: "再生が完了するまで待機する",
+		Long:  "playback_id を指定して再生が完了するまでポーリングする。local_playback を渡すと即時終了する。",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return fmt.Errorf("%w: %s", ErrUsage, err)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPlaybackWait(cmd, args, deps)
+		},
+	}
+	registerViewerURLFlag(cmd)
+	cmd.Flags().Duration("server-down-timeout", 30*time.Second, "サーバー接続失敗を fail 扱いにするまでの連続失敗時間")
+	return cmd
+}
+
+func runPlaybackWait(cmd *cobra.Command, args []string, deps *PlaybackWaitDeps) error {
+	id := args[0]
+	if id == "local_playback" {
+		return nil
+	}
+
+	viewerURL, _ := cmd.Flags().GetString("viewer-url")
+	serverDownTimeout, _ := cmd.Flags().GetDuration("server-down-timeout")
+
+	var vc *infra.ViewerAPIClient
+	if viewerURL != "" {
+		vc = infra.NewViewerAPIClientFromURL(viewerURL)
+	} else {
+		lockPath, lockErr := resolvePlaybackWaitLockPath(deps)
+		if lockErr == nil {
+			if addr, ok := infra.DetectViewer(lockPath); ok {
+				vc = infra.NewViewerAPIClient(addr)
+			}
+		}
+	}
+
+	if vc == nil {
+		return fmt.Errorf("viewer not found: specify --viewer-url or start viewer")
+	}
+
+	return pollPlaybackCompletion(cmd.Context(), cmd, vc, id, serverDownTimeout)
+}
+
+func pollPlaybackCompletion(ctx context.Context, cmd *cobra.Command, vc *infra.ViewerAPIClient, id string, serverDownTimeout time.Duration) error {
+	const (
+		initialInterval = 200 * time.Millisecond
+		maxInterval     = 2 * time.Second
+	)
+
+	interval := initialInterval
+	var serverDownStart *time.Time
+
+	for {
+		resp, err := vc.GetPlayback(ctx, id)
+		if err != nil {
+			now := time.Now()
+			if serverDownStart == nil {
+				serverDownStart = &now
+			} else if now.Sub(*serverDownStart) >= serverDownTimeout {
+				return fmt.Errorf("server unreachable for %v: %w", serverDownTimeout, err)
+			}
+		} else {
+			serverDownStart = nil
+			switch resp.Status {
+			case "completed":
+				return nil
+			case "failed":
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), resp.FailedReason)
+				return fmt.Errorf("playback failed: %s", resp.FailedReason)
+			case "unknown":
+				return fmt.Errorf("playback not found: %s", id)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+
+		if interval < maxInterval {
+			interval *= 2
+			if interval > maxInterval {
+				interval = maxInterval
+			}
+		}
+	}
+}

--- a/cmd/playback_test.go
+++ b/cmd/playback_test.go
@@ -154,7 +154,33 @@ func TestRunPlaybackWait_ServerDown_Timeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error after server-down timeout, got nil")
 	}
+	if !strings.Contains(err.Error(), "server unreachable") {
+		t.Errorf("expected error to contain 'server unreachable', got: %v", err)
+	}
 	if elapsed > 3*time.Second {
 		t.Errorf("expected to fail within 3s, took %v", elapsed)
+	}
+}
+
+func TestRunPlaybackWait_ViewerNotFound_ReturnsError(t *testing.T) {
+	t.Parallel()
+	id := "77777777-7777-4777-8777-777777777777"
+
+	// no --viewer-url, no viewer lock file → viewer not found
+	cmd := newPlaybackWaitCmd(t)
+	cmd.Flags().String("viewer-url", "", "")
+	cmd.Flags().Duration("server-down-timeout", 5*time.Second, "")
+	_ = cmd.ParseFlags([]string{})
+
+	deps := &PlaybackWaitDeps{
+		LockPathResolver: func() (string, error) { return "/nonexistent/path/viewer.lock", nil },
+	}
+
+	err := runPlaybackWait(cmd, []string{id}, deps)
+	if err == nil {
+		t.Fatal("expected error when viewer not found, got nil")
+	}
+	if !strings.Contains(err.Error(), "viewer not found") {
+		t.Errorf("expected error to contain 'viewer not found', got: %v", err)
 	}
 }

--- a/cmd/playback_test.go
+++ b/cmd/playback_test.go
@@ -1,0 +1,160 @@
+package cmd
+
+// playback wait コマンド テストリスト (#490)
+//
+// DONE: local_playback を渡すと即 exit 0                          → TestRunPlaybackWait_LocalPlayback_ImmediateSuccess
+// DONE: completed で exit 0                                       → TestRunPlaybackWait_Completed_Success
+// DONE: failed で exit≠0 かつ stderr に reason                    → TestRunPlaybackWait_Failed_ReturnsError
+// DONE: unknown で exit≠0                                         → TestRunPlaybackWait_Unknown_ReturnsError
+// DONE: 30 秒連続接続失敗で exit≠0                                → TestRunPlaybackWait_ServerDown_Timeout
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newPlaybackWaitCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+func TestRunPlaybackWait_LocalPlayback_ImmediateSuccess(t *testing.T) {
+	t.Parallel()
+	cmd := newPlaybackWaitCmd(t)
+	cmd.Flags().String("viewer-url", "", "")
+	cmd.Flags().Duration("server-down-timeout", 30*time.Second, "")
+	_ = cmd.ParseFlags([]string{})
+
+	deps := &PlaybackWaitDeps{
+		LockPathResolver: func() (string, error) { return "", nil },
+	}
+
+	err := runPlaybackWait(cmd, []string{"local_playback"}, deps)
+	if err != nil {
+		t.Errorf("expected nil error for local_playback, got: %v", err)
+	}
+}
+
+func TestRunPlaybackWait_Completed_Success(t *testing.T) {
+	t.Parallel()
+	id := "33333333-3333-4333-8333-333333333333"
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		var status string
+		if n < 3 {
+			status = "playing"
+		} else {
+			status = "completed"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":              id,
+			"status":          status,
+			"clip_count":      1,
+			"completed_clips": 0,
+		})
+	}))
+	defer srv.Close()
+
+	cmd := newPlaybackWaitCmd(t)
+	cmd.Flags().String("viewer-url", srv.URL, "")
+	cmd.Flags().Duration("server-down-timeout", 5*time.Second, "")
+	_ = cmd.ParseFlags([]string{"--viewer-url", srv.URL})
+
+	deps := &PlaybackWaitDeps{}
+
+	err := runPlaybackWait(cmd, []string{id}, deps)
+	if err != nil {
+		t.Errorf("expected nil error for completed, got: %v", err)
+	}
+}
+
+func TestRunPlaybackWait_Failed_ReturnsError(t *testing.T) {
+	t.Parallel()
+	id := "44444444-4444-4444-8444-444444444444"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":            id,
+			"status":        "failed",
+			"clip_count":    1,
+			"failed_reason": "synthesis error",
+		})
+	}))
+	defer srv.Close()
+
+	var stderr bytes.Buffer
+	cmd := newPlaybackWaitCmd(t)
+	cmd.Flags().String("viewer-url", srv.URL, "")
+	cmd.Flags().Duration("server-down-timeout", 5*time.Second, "")
+	_ = cmd.ParseFlags([]string{"--viewer-url", srv.URL})
+	cmd.SetErr(&stderr)
+
+	deps := &PlaybackWaitDeps{}
+
+	err := runPlaybackWait(cmd, []string{id}, deps)
+	if err == nil {
+		t.Fatal("expected error for failed status, got nil")
+	}
+	if !strings.Contains(stderr.String(), "synthesis error") {
+		t.Errorf("expected stderr to contain reason, got: %q", stderr.String())
+	}
+}
+
+func TestRunPlaybackWait_Unknown_ReturnsError(t *testing.T) {
+	t.Parallel()
+	id := "55555555-5555-4555-8555-555555555555"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":     id,
+			"status": "unknown",
+		})
+	}))
+	defer srv.Close()
+
+	cmd := newPlaybackWaitCmd(t)
+	cmd.Flags().String("viewer-url", srv.URL, "")
+	cmd.Flags().Duration("server-down-timeout", 5*time.Second, "")
+	_ = cmd.ParseFlags([]string{"--viewer-url", srv.URL})
+
+	deps := &PlaybackWaitDeps{}
+
+	err := runPlaybackWait(cmd, []string{id}, deps)
+	if err == nil {
+		t.Fatal("expected error for unknown status, got nil")
+	}
+}
+
+func TestRunPlaybackWait_ServerDown_Timeout(t *testing.T) {
+	t.Parallel()
+	id := "66666666-6666-4666-8666-666666666666"
+
+	// Do not start a server, so connection will fail
+	cmd := newPlaybackWaitCmd(t)
+	cmd.Flags().String("viewer-url", "http://127.0.0.1:1", "")
+	cmd.Flags().Duration("server-down-timeout", 100*time.Millisecond, "")
+	_ = cmd.ParseFlags([]string{"--viewer-url", "http://127.0.0.1:1", "--server-down-timeout", "100ms"})
+
+	deps := &PlaybackWaitDeps{}
+
+	start := time.Now()
+	err := runPlaybackWait(cmd, []string{id}, deps)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error after server-down timeout, got nil")
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("expected to fail within 3s, took %v", elapsed)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ type Deps struct {
 	Viewer       *ViewerDeps
 	Assets       *AssetsDownloadDeps
 	Speakers     *SpeakersDeps
+	Playback     *PlaybackWaitDeps
 }
 
 func makeRootCmd(deps ...*Deps) *cobra.Command {
@@ -64,6 +65,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	var viewerCheckDeps *ViewerCheckDeps
 	var assetsDeps *AssetsDownloadDeps
 	var speakersDeps *SpeakersDeps
+	var playbackDeps *PlaybackWaitDeps
 	if d != nil {
 		actDeps = d.Act
 		watchDeps = d.Watch
@@ -74,6 +76,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 		viewerCheckDeps = d.ViewerCheck
 		assetsDeps = d.Assets
 		speakersDeps = d.Speakers
+		playbackDeps = d.Playback
 	}
 	var viewerDeps *ViewerDeps
 	if d != nil {
@@ -89,6 +92,7 @@ func makeRootCmd(deps ...*Deps) *cobra.Command {
 	cmd.AddCommand(makeViewerCmd(viewerDeps))
 	cmd.AddCommand(makeAssetsCmd(assetsDeps))
 	cmd.AddCommand(makeSpeakersCmd(speakersDeps))
+	cmd.AddCommand(makePlaybackCmd(playbackDeps))
 
 	return cmd
 }

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -45,11 +45,10 @@ func makeSayCmd(deps *SayDeps) *cobra.Command {
 	return cmd
 }
 
-// sayViaViewer は clip を viewer に送り、playback_id を stdout に出力する。
 func sayViaViewer(ctx context.Context, cmd *cobra.Command, vc *infra.ViewerAPIClient, clip infra.ViewerClip, logger *slog.Logger) error {
 	resp, err := vc.Play(ctx, infra.ViewerPlayRequest{Clips: []infra.ViewerClip{clip}})
 	if err != nil {
-		return err
+		return fmt.Errorf("say via viewer: %w", err)
 	}
 	if resp.Silent {
 		logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
@@ -139,6 +138,6 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 	if err := uc.Run(ctx, params); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "local_playback")
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), localPlaybackID)
 	return nil
 }

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -44,6 +45,19 @@ func makeSayCmd(deps *SayDeps) *cobra.Command {
 	return cmd
 }
 
+// sayViaViewer は clip を viewer に送り、playback_id を stdout に出力する。
+func sayViaViewer(ctx context.Context, cmd *cobra.Command, vc *infra.ViewerAPIClient, clip infra.ViewerClip, logger *slog.Logger) error {
+	resp, err := vc.Play(ctx, infra.ViewerPlayRequest{Clips: []infra.ViewerClip{clip}})
+	if err != nil {
+		return err
+	}
+	if resp.Silent {
+		logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), resp.PlaybackID)
+	return nil
+}
+
 func resolveSayLockPath(deps *SayDeps) (string, error) {
 	if deps != nil {
 		return resolveViewerLockPathWith(deps.LockPathResolver)
@@ -75,27 +89,20 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
 
+	clip := infra.ViewerClip{
+		Text:       args[0],
+		SpeakerID:  speakerID,
+		Speed:      &speed,
+		Pitch:      &pitch,
+		Intonation: &intonation,
+	}
+
 	if !dryRun {
 		if viewerURL != "" {
 			// 明示 URL: lockfile スキップ、AudioProbe スキップ、接続失敗時はエラー
 			logger.Info("using explicit viewer URL", "url", viewerURL)
 			vc := infra.NewViewerAPIClientFromURL(viewerURL)
-			resp, err := vc.Play(ctx, infra.ViewerPlayRequest{
-				Clips: []infra.ViewerClip{{
-					Text:       args[0],
-					SpeakerID:  speakerID,
-					Speed:      &speed,
-					Pitch:      &pitch,
-					Intonation: &intonation,
-				}},
-			})
-			if err != nil {
-				return err
-			}
-			if resp.Silent {
-				logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
-			}
-			return nil
+			return sayViaViewer(ctx, cmd, vc, clip, logger)
 		}
 
 		lockPath, lockErr := resolveSayLockPath(deps)
@@ -104,22 +111,7 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 		} else if addr, ok := infra.DetectViewer(lockPath); ok {
 			logger.Info("viewer detected, sending audio via /api/play", "addr", addr)
 			vc := infra.NewViewerAPIClient(addr)
-			resp, err := vc.Play(ctx, infra.ViewerPlayRequest{
-				Clips: []infra.ViewerClip{{
-					Text:       args[0],
-					SpeakerID:  speakerID,
-					Speed:      &speed,
-					Pitch:      &pitch,
-					Intonation: &intonation,
-				}},
-			})
-			if err != nil {
-				return err
-			}
-			if resp.Silent {
-				logger.Warn("viewer is in silent mode", "reason", resp.SilentReason)
-			}
-			return nil
+			return sayViaViewer(ctx, cmd, vc, clip, logger)
 		} else {
 			logger.Debug("viewer not running, using local player")
 		}
@@ -144,5 +136,9 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 	}
 
 	uc := app.NewSayUsecase(client, deps.Player, app.WithSayLogger(logger))
-	return uc.Run(ctx, params)
+	if err := uc.Run(ctx, params); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "local_playback")
+	return nil
 }

--- a/cmd/say_test.go
+++ b/cmd/say_test.go
@@ -673,3 +673,67 @@ func TestRunSay_ExplicitViewerURL_ConnectionError_ReturnsError(t *testing.T) {
 		t.Error("expected no local playback when --viewer-url fails")
 	}
 }
+
+// --- #489 say が viewer モードで playback_id を stdout 出力 ---
+
+func TestRunSay_ViewerMode_PrintsPlaybackIDToStdout(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"playback_id": "22222222-2222-4222-8222-222222222222",
+			"clip_count":  1,
+			"silent":      false,
+		})
+	})
+	lockPath, _ := setupFakeViewer(t, mux)
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	deps := &SayDeps{
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &noopClient{} },
+		Player:           &noopPlayer{},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runSay(cmd, []string{"こんにちは"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+	got := strings.TrimSpace(stdout.String())
+	if got != "22222222-2222-4222-8222-222222222222" {
+		t.Errorf("expected stdout=playback_id, got %q", got)
+	}
+}
+
+func TestRunSay_LocalMode_PrintsLocalPlaybackToStdout(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	_ = cmd.ParseFlags([]string{})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	deps := &SayDeps{
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &mockSayClient{} },
+		Player:           &trackingPlayer{playFn: func() {}},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runSay(cmd, []string{"こんにちは"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+	got := strings.TrimSpace(stdout.String())
+	if got != "local_playback" {
+		t.Errorf("expected stdout=local_playback, got %q", got)
+	}
+}

--- a/internal/infra/export_test.go
+++ b/internal/infra/export_test.go
@@ -17,3 +17,8 @@ func (p *HTTPStreamPlayer) PlaybackStatus(id string) (string, bool) {
 	}
 	return string(state.status), true
 }
+
+// PrunePlaybacks はテスト用に TTL 切れの playback state を削除する。
+func (p *HTTPStreamPlayer) PrunePlaybacks() {
+	p.prunePlaybacks()
+}

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -144,9 +144,24 @@ const (
 
 // playbackStateRecord は 1 バッチの処理状態を保持する。
 type playbackStateRecord struct {
-	status    playbackStatus
-	reason    string
-	createdAt time.Time
+	status         playbackStatus
+	reason         string
+	createdAt      time.Time
+	clipCount      int
+	completedClips int
+	startedAt      *int64 // Unix milliseconds
+	finishedAt     *int64 // Unix milliseconds
+}
+
+// apiPlaybackResponse は GET /api/playback/{id} のレスポンスペイロード。
+type apiPlaybackResponse struct {
+	ID             string `json:"id"`
+	Status         string `json:"status"`
+	ClipCount      int    `json:"clip_count"`
+	CompletedClips int    `json:"completed_clips"`
+	StartedAt      *int64 `json:"started_at"`
+	FinishedAt     *int64 `json:"finished_at"`
+	FailedReason   string `json:"failed_reason"`
 }
 
 // playBatch は worker への投入単位。
@@ -158,6 +173,8 @@ type playBatch struct {
 var (
 	// pathSegmentPattern はファイルパスのセグメント検証に使う正規表現。
 	pathSegmentPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	// uuidV4Pattern は UUID v4 形式の検証に使う正規表現。
+	uuidV4Pattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 )
 
 // historyRecord は履歴ファイル（YYYY-MM-DD.jsonl）の 1 行スキーマ。
@@ -353,6 +370,7 @@ func (p *HTTPStreamPlayer) Start(_ context.Context) error {
 	mux.HandleFunc("/api/status", p.handleAPIStatus)
 	mux.HandleFunc("/api/history", p.handleAPIHistory)
 	mux.HandleFunc("/api/play", p.handleAPIPlay)
+	mux.HandleFunc("/api/playback/", p.handleAPIPlayback)
 	mux.HandleFunc("/api/characters", p.handleAPICharacters)
 	mux.HandleFunc("/assets/images/", p.handleCharacterImage)
 	mux.HandleFunc("/test-clip", p.handleTestClip)
@@ -951,11 +969,14 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 	silentReason := p.silentReason
 	p.mu.Unlock()
 
+	clipCount := len(req.Clips)
+	p.initPlayback(playbackID, clipCount)
+
 	if silent {
 		p.setPlaybackStatus(playbackID, playbackStatusCompleted, "")
 		resp := ViewerPlayResponse{
 			PlaybackID:   playbackID,
-			ClipCount:    len(req.Clips),
+			ClipCount:    clipCount,
 			Silent:       true,
 			SilentReason: silentReason,
 		}
@@ -964,8 +985,6 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 		_, _ = w.Write(payload)
 		return
 	}
-
-	p.setPlaybackStatus(playbackID, playbackStatusPending, "")
 	batch := playBatch{playbackID: playbackID, clips: req.Clips}
 	select {
 	case p.batchQueue <- batch:
@@ -977,12 +996,22 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 
 	resp := ViewerPlayResponse{
 		PlaybackID: playbackID,
-		ClipCount:  len(req.Clips),
+		ClipCount:  clipCount,
 		Silent:     false,
 	}
 	payload, _ := json.Marshal(resp)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_, _ = w.Write(payload)
+}
+
+func (p *HTTPStreamPlayer) initPlayback(id string, clipCount int) {
+	p.playbackMu.Lock()
+	defer p.playbackMu.Unlock()
+	p.playbacks[id] = &playbackStateRecord{
+		createdAt: p.nowFunc(),
+		clipCount: clipCount,
+		status:    playbackStatusPending,
+	}
 }
 
 func (p *HTTPStreamPlayer) setPlaybackStatus(id string, status playbackStatus, reason string) {
@@ -991,8 +1020,62 @@ func (p *HTTPStreamPlayer) setPlaybackStatus(id string, status playbackStatus, r
 	if _, ok := p.playbacks[id]; !ok {
 		p.playbacks[id] = &playbackStateRecord{createdAt: p.nowFunc()}
 	}
-	p.playbacks[id].status = status
-	p.playbacks[id].reason = reason
+	state := p.playbacks[id]
+	state.status = status
+	state.reason = reason
+	now := p.nowFunc().UnixMilli()
+	if status == playbackStatusPlaying && state.startedAt == nil {
+		state.startedAt = &now
+	}
+	if (status == playbackStatusCompleted || status == playbackStatusFailed) && state.finishedAt == nil {
+		state.finishedAt = &now
+	}
+}
+
+func (p *HTTPStreamPlayer) incrementCompletedClips(id string) {
+	p.playbackMu.Lock()
+	defer p.playbackMu.Unlock()
+	if state, ok := p.playbacks[id]; ok {
+		state.completedClips++
+	}
+}
+
+func (p *HTTPStreamPlayer) handleAPIPlayback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := strings.TrimPrefix(r.URL.Path, "/api/playback/")
+	if !uuidV4Pattern.MatchString(id) {
+		http.Error(w, "invalid playback id", http.StatusBadRequest)
+		return
+	}
+
+	p.playbackMu.Lock()
+	state, ok := p.playbacks[id]
+	var resp apiPlaybackResponse
+	if !ok {
+		resp = apiPlaybackResponse{
+			ID:     id,
+			Status: "unknown",
+		}
+	} else {
+		resp = apiPlaybackResponse{
+			ID:             id,
+			Status:         string(state.status),
+			ClipCount:      state.clipCount,
+			CompletedClips: state.completedClips,
+			StartedAt:      state.startedAt,
+			FinishedAt:     state.finishedAt,
+			FailedReason:   state.reason,
+		}
+	}
+	p.playbackMu.Unlock()
+
+	payload, _ := json.Marshal(resp)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_, _ = w.Write(payload)
 }
 
 func (p *HTTPStreamPlayer) runWorker(ctx context.Context) {
@@ -1055,6 +1138,8 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 				return
 			}
 		}
+
+		p.incrementCompletedClips(batch.playbackID)
 	}
 
 	p.setPlaybackStatus(batch.playbackID, playbackStatusCompleted, "")

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -153,17 +153,6 @@ type playbackStateRecord struct {
 	finishedAt     *int64 // Unix milliseconds
 }
 
-// apiPlaybackResponse は GET /api/playback/{id} のレスポンスペイロード。
-type apiPlaybackResponse struct {
-	ID             string `json:"id"`
-	Status         string `json:"status"`
-	ClipCount      int    `json:"clip_count"`
-	CompletedClips int    `json:"completed_clips"`
-	StartedAt      *int64 `json:"started_at"`
-	FinishedAt     *int64 `json:"finished_at"`
-	FailedReason   string `json:"failed_reason"`
-}
-
 // playBatch は worker への投入単位。
 type playBatch struct {
 	playbackID string
@@ -1054,14 +1043,14 @@ func (p *HTTPStreamPlayer) handleAPIPlayback(w http.ResponseWriter, r *http.Requ
 
 	p.playbackMu.Lock()
 	state, ok := p.playbacks[id]
-	var resp apiPlaybackResponse
+	var resp ViewerPlaybackResponse
 	if !ok {
-		resp = apiPlaybackResponse{
+		resp = ViewerPlaybackResponse{
 			ID:     id,
 			Status: "unknown",
 		}
 	} else {
-		resp = apiPlaybackResponse{
+		resp = ViewerPlaybackResponse{
 			ID:             id,
 			Status:         string(state.status),
 			ClipCount:      state.clipCount,

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -3076,3 +3076,268 @@ func TestHTTPStreamPlayer_APIPlay_SilentModeSkipsBroadcast(t *testing.T) {
 		t.Errorf("expected playback status=completed, got %s", status)
 	}
 }
+
+// --- #488 GET /api/playback/{id} エンドポイント ---
+//
+// TODO: 未知 ID で unknown を返す                         → TestHTTPStreamPlayer_APIPlayback_UnknownID
+// TODO: UUID v4 でない id で 400 を返す                  → TestHTTPStreamPlayer_APIPlayback_InvalidUUID
+// TODO: pending 状態を返す                               → TestHTTPStreamPlayer_APIPlayback_PendingStatus
+// TODO: completed 状態を返す                             → TestHTTPStreamPlayer_APIPlayback_CompletedStatus
+// TODO: failed 状態と failed_reason を返す               → TestHTTPStreamPlayer_APIPlayback_FailedStatus
+// TODO: completed_clips が全クリップ完了後に clip_count と一致する → TestHTTPStreamPlayer_APIPlayback_CompletedClips
+// TODO: TTL 切れ後の ID は unknown を返す                → TestHTTPStreamPlayer_APIPlayback_TTLExpiry
+
+func TestHTTPStreamPlayer_APIPlayback_UnknownID(t *testing.T) {
+	t.Parallel()
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(&testVoicevoxClient{wav: []byte("RIFFx")}))
+	unknownID := "00000000-0000-4000-8000-000000000000"
+	resp, err := http.Get("http://" + p.Addr() + "/api/playback/" + unknownID)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	var result apiPlaybackResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Status != "unknown" {
+		t.Errorf("expected status=unknown, got %q", result.Status)
+	}
+	if result.ID != unknownID {
+		t.Errorf("expected id=%s, got %q", unknownID, result.ID)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlayback_InvalidUUID(t *testing.T) {
+	t.Parallel()
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(&testVoicevoxClient{wav: []byte("RIFFx")}))
+	for _, badID := range []string{"notauuid", "12345", "", "00000000-0000-0000-0000-000000000000"} {
+		resp, err := http.Get("http://" + p.Addr() + "/api/playback/" + badID)
+		if err != nil {
+			t.Fatalf("GET %q: %v", badID, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("id=%q: expected 400, got %d", badID, resp.StatusCode)
+		}
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlayback_PendingStatus(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	stub := &testVoicevoxClient{createQueryBlock: block}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"test","speaker_id":2}]}`)
+	postResp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	var playResult ViewerPlayResponse
+	if err := json.NewDecoder(postResp.Body).Decode(&playResult); err != nil {
+		t.Fatalf("decode POST response: %v", err)
+	}
+	_ = postResp.Body.Close()
+
+	// worker がバッチを取り出す前（pending）に確認するため少し早めに polling
+	var foundPending bool
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://" + p.Addr() + "/api/playback/" + playResult.PlaybackID)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		var result apiPlaybackResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			_ = resp.Body.Close()
+			t.Fatalf("decode GET response: %v", err)
+		}
+		_ = resp.Body.Close()
+		if result.Status == "pending" || result.Status == "playing" {
+			foundPending = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !foundPending {
+		t.Error("expected to observe pending or playing status")
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlayback_CompletedStatus(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+
+	events := subscribeSSE(t, "http://"+p.Addr())
+	time.Sleep(100 * time.Millisecond)
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"test","speaker_id":2}]}`)
+	postResp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	var playResult ViewerPlayResponse
+	if err := json.NewDecoder(postResp.Body).Decode(&playResult); err != nil {
+		t.Fatalf("decode POST response: %v", err)
+	}
+	_ = postResp.Body.Close()
+
+	select {
+	case <-events:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for clip event")
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/playback/" + playResult.PlaybackID)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	var result apiPlaybackResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Errorf("expected status=completed, got %q", result.Status)
+	}
+	if result.ClipCount != 1 {
+		t.Errorf("expected clip_count=1, got %d", result.ClipCount)
+	}
+	if result.FinishedAt == nil {
+		t.Error("expected non-nil finished_at")
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlayback_FailedStatus(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{createQueryErr: errors.New("synth error")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"test","speaker_id":2}]}`)
+	postResp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	var playResult ViewerPlayResponse
+	if err := json.NewDecoder(postResp.Body).Decode(&playResult); err != nil {
+		t.Fatalf("decode POST response: %v", err)
+	}
+	_ = postResp.Body.Close()
+
+	time.Sleep(200 * time.Millisecond)
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/playback/" + playResult.PlaybackID)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result apiPlaybackResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Status != "failed" {
+		t.Errorf("expected status=failed, got %q", result.Status)
+	}
+	if result.FailedReason == "" {
+		t.Error("expected non-empty failed_reason for failed status")
+	}
+	if result.FinishedAt == nil {
+		t.Error("expected non-nil finished_at on failure")
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlayback_CompletedClips(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+
+	events := subscribeSSE(t, "http://"+p.Addr())
+	time.Sleep(100 * time.Millisecond)
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"first","speaker_id":2},{"text":"second","speaker_id":2}]}`)
+	postResp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	var playResult ViewerPlayResponse
+	if err := json.NewDecoder(postResp.Body).Decode(&playResult); err != nil {
+		t.Fatalf("decode POST response: %v", err)
+	}
+	_ = postResp.Body.Close()
+
+	// 2つのクリップイベントを待つ
+	for i := 0; i < 2; i++ {
+		select {
+		case <-events:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timeout waiting for clip %d event", i+1)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/playback/" + playResult.PlaybackID)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result apiPlaybackResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.CompletedClips != 2 {
+		t.Errorf("expected completed_clips=2, got %d", result.CompletedClips)
+	}
+	if result.ClipCount != 2 {
+		t.Errorf("expected clip_count=2, got %d", result.ClipCount)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlayback_TTLExpiry(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	// initPlayback 時の時刻を 2 時間前に固定（TTL=1h を超えるため GC で削除される）
+	createdAt := time.Now().Add(-2 * time.Hour)
+	fixedTime := createdAt
+	p := newStartedPlayerWithOpts(t,
+		WithVoicevoxClient(stub),
+		withNowFunc(func() time.Time { return fixedTime }),
+	)
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"test","speaker_id":2}]}`)
+	postResp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	var playResult ViewerPlayResponse
+	if err := json.NewDecoder(postResp.Body).Decode(&playResult); err != nil {
+		t.Fatalf("decode POST response: %v", err)
+	}
+	_ = postResp.Body.Close()
+
+	// 現在時刻を "今" に進め、GC を走らせる（createdAt = 2h前 < cutoff = now - 1h）
+	fixedTime = time.Now()
+	p.PrunePlaybacks()
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/playback/" + playResult.PlaybackID)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var result apiPlaybackResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Status != "unknown" {
+		t.Errorf("expected status=unknown after TTL expiry, got %q", result.Status)
+	}
+}

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -3099,7 +3099,7 @@ func TestHTTPStreamPlayer_APIPlayback_UnknownID(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
-	var result apiPlaybackResponse
+	var result ViewerPlaybackResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -3152,7 +3152,7 @@ func TestHTTPStreamPlayer_APIPlayback_PendingStatus(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GET: %v", err)
 		}
-		var result apiPlaybackResponse
+		var result ViewerPlaybackResponse
 		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 			_ = resp.Body.Close()
 			t.Fatalf("decode GET response: %v", err)
@@ -3203,7 +3203,7 @@ func TestHTTPStreamPlayer_APIPlayback_CompletedStatus(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
-	var result apiPlaybackResponse
+	var result ViewerPlaybackResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -3241,7 +3241,7 @@ func TestHTTPStreamPlayer_APIPlayback_FailedStatus(t *testing.T) {
 		t.Fatalf("GET: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	var result apiPlaybackResponse
+	var result ViewerPlaybackResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -3290,7 +3290,7 @@ func TestHTTPStreamPlayer_APIPlayback_CompletedClips(t *testing.T) {
 		t.Fatalf("GET: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	var result apiPlaybackResponse
+	var result ViewerPlaybackResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -3333,7 +3333,7 @@ func TestHTTPStreamPlayer_APIPlayback_TTLExpiry(t *testing.T) {
 		t.Fatalf("GET: %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	var result apiPlaybackResponse
+	var result ViewerPlaybackResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}

--- a/internal/infra/viewer_client.go
+++ b/internal/infra/viewer_client.go
@@ -77,6 +77,41 @@ func NewViewerAPIClientFromURL(rawURL string) *ViewerAPIClient {
 	}
 }
 
+// ViewerPlaybackResponse is the response from GET /api/playback/{id}.
+type ViewerPlaybackResponse struct {
+	ID             string `json:"id"`
+	Status         string `json:"status"`
+	ClipCount      int    `json:"clip_count"`
+	CompletedClips int    `json:"completed_clips"`
+	StartedAt      *int64 `json:"started_at"`
+	FinishedAt     *int64 `json:"finished_at"`
+	FailedReason   string `json:"failed_reason"`
+}
+
+// GetPlayback sends a GET /api/playback/{id} request and returns the playback state.
+func (c *ViewerAPIClient) GetPlayback(ctx context.Context, id string) (*ViewerPlaybackResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/playback/"+id, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET /api/playback/%s: %w", id, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET /api/playback/%s returned %d", id, resp.StatusCode)
+	}
+
+	var result ViewerPlaybackResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode playback response: %w", err)
+	}
+	return &result, nil
+}
+
 // Play sends a POST /api/play request to the viewer and returns the response.
 func (c *ViewerAPIClient) Play(ctx context.Context, req ViewerPlayRequest) (*ViewerPlayResponse, error) {
 	body, err := json.Marshal(req)

--- a/internal/infra/viewer_client_test.go
+++ b/internal/infra/viewer_client_test.go
@@ -240,3 +240,56 @@ func TestViewerAPIClientFromURL_Play_TrailingSlash(t *testing.T) {
 		t.Error("expected POST /api/play to be called")
 	}
 }
+func TestViewerAPIClient_GetPlayback_Success(t *testing.T) {
+	t.Parallel()
+	id := "00000000-0000-4000-8000-000000000001"
+	startedAt := int64(1000000000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/playback/"+id {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":              id,
+			"status":          "completed",
+			"clip_count":      2,
+			"completed_clips": 2,
+			"started_at":      startedAt,
+			"finished_at":     startedAt + 5000,
+			"failed_reason":   "",
+		})
+	}))
+	defer srv.Close()
+
+	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
+	resp, err := client.GetPlayback(t.Context(), id)
+	if err != nil {
+		t.Fatalf("GetPlayback: %v", err)
+	}
+	if resp.Status != "completed" {
+		t.Errorf("expected status=completed, got %q", resp.Status)
+	}
+	if resp.ClipCount != 2 {
+		t.Errorf("expected clip_count=2, got %d", resp.ClipCount)
+	}
+	if resp.CompletedClips != 2 {
+		t.Errorf("expected completed_clips=2, got %d", resp.CompletedClips)
+	}
+	if resp.StartedAt == nil || *resp.StartedAt != startedAt {
+		t.Errorf("expected started_at=%d, got %v", startedAt, resp.StartedAt)
+	}
+}
+
+func TestViewerAPIClient_GetPlayback_Error(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
+	_, err := client.GetPlayback(t.Context(), "00000000-0000-4000-8000-000000000001")
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func main() {
 			},
 		},
 		ViewerCheck: cmd.NewViewerCheckDeps(),
+		Playback:    &cmd.PlaybackWaitDeps{},
 	}
 
 	if err := cmd.Execute(deps); err != nil {

--- a/plugins/vox-actor-plugin/skills/talk/scripts/play-script.sh
+++ b/plugins/vox-actor-plugin/skills/talk/scripts/play-script.sh
@@ -30,22 +30,22 @@ case "$MODE" in
     mkdir -p "$WORKSPACE_DIR"
     ERROR_LOG="${WORKSPACE_DIR}/play-script-errors.log"
     MAX_LOG_LINES=200
-    OUTPUT=$(vox-actor act "$JSONL_PATH" 2>&1)
+    ID=$(vox-actor act "$JSONL_PATH" 2>>"$ERROR_LOG")
     STATUS=$?
     if [ "$STATUS" -ne 0 ]; then
       TS=$(date '+%Y-%m-%d %H:%M:%S')
-      {
-        echo "[$TS] exit=$STATUS path=$JSONL_PATH"
-        printf '%s\n' "$OUTPUT" | sed 's/^/  /'
-      } >> "$ERROR_LOG"
+      echo "[$TS] act exit=$STATUS path=$JSONL_PATH" >> "$ERROR_LOG"
       LINES=$(wc -l < "$ERROR_LOG")
       if [ "$LINES" -gt "$MAX_LOG_LINES" ]; then
         TMP_LOG=$(mktemp "${ERROR_LOG}.XXXXXX")
         tail -n "$MAX_LOG_LINES" "$ERROR_LOG" > "$TMP_LOG"
         mv "$TMP_LOG" "$ERROR_LOG"
       fi
+      rm -f "$JSONL_PATH"
+      exit "$STATUS"
     fi
     rm -f "$JSONL_PATH"
+    vox-actor playback wait "$ID" 2>>"$ERROR_LOG"
     ;;
   file)
     mkdir -p "$QUEUE_DIR"

--- a/test/e2e/act_comm_test.go
+++ b/test/e2e/act_comm_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -111,8 +110,9 @@ func TestActE2E_Viewer_POSTsAndExitsZero(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("expected exit 0 with viewer running, got %d\nstderr:\n%s", exitCode, stderr)
 	}
-	if *calls != 3 {
-		t.Errorf("expected 3 POSTs to /api/play (one per script line), got %d\nstderr:\n%s", *calls, stderr)
+	// 全クリップを 1 回のバッチ POST にまとめて送信する
+	if *calls != 1 {
+		t.Errorf("expected 1 batch POST to /api/play, got %d\nstderr:\n%s", *calls, stderr)
 	}
 }
 
@@ -126,19 +126,13 @@ func TestActE2E_Viewer_POSTFailure_EarlyExit(t *testing.T) {
 `
 	path := writeTempFile(t, dir, "script.jsonl", content)
 
-	var callCount atomic.Int32
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/status", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 	mux.HandleFunc("/api/play", func(w http.ResponseWriter, _ *http.Request) {
-		n := callCount.Add(1)
-		if n >= 2 {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"silent":false}`))
+		// 全クリップを 1 回の POST で送るため、常に失敗させる
+		w.WriteHeader(http.StatusInternalServerError)
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)


### PR DESCRIPTION
## Summary

Epic #486 の残り子 Issue (#488, #489, #490) をまとめて実装します。

### #488 `GET /api/playback/{id}` エンドポイント新設

- `playbackStateRecord` に `clipCount`/`completedClips`/`startedAt`/`finishedAt` を追加
- `processBatch` で各クリップ完了後に `completedClips` をインクリメント
- `setPlaybackStatus` で `playing` 時に `startedAt`、`completed`/`failed` 時に `finishedAt` を設定
- UUID v4 以外の `id` は `400`、未知 ID は `status=unknown` を返す
- `ViewerAPIClient.GetPlayback` メソッドを追加

### #489 `vox-actor say/act` が viewer モードで `playback_id` を stdout 出力

- viewer モードで全クリップを 1 回の `POST /api/play` にまとめて送信し、`playback_id` を stdout に 1 行出力
- ローカル再生モードでは再生完了後に `local_playback` を stdout に出力
- `actViaViewer` / `sayViaViewer` ヘルパーで共通化

### #490 `vox-actor playback wait` サブコマンド新設＋talk スクリプト改修

- `cmd/playback.go` を新設: `vox-actor playback wait <id>` を実装
  - `local_playback` を渡すと即 exit 0（ローカル再生モードの no-op）
  - UUID v4 は `GET /api/playback/{id}` をポーリング（200ms → 指数増加 → 上限 2s）
  - `completed` で exit 0、`failed` で exit≠0 + stderr、`unknown` で exit≠0
  - `--server-down-timeout`（デフォルト 30s）超の連続接続失敗で exit≠0
- `play-script.sh` の direct モードを `act → playback wait` の 2 段階に変更
  - `wait` が return するまでスクリプトが終了しないため Stop hook 割り込みを根本解消

## 仕様補足

- ローカル再生で全スクリプトが空（`IsEmpty`）の場合でも `local_playback` を stdout 出力して正常終了する
- viewer モードで空クリップのみのバッチは POST を送らず `local_playback` を返す（viewer に空バッチを送るとエラーになるため）

## Test plan

- [x] `go test ./...` でユニットテスト全通過（環境依存の `TestRunWatch_AudioProbe_*` を除く）
- [ ] VOICEVOX サーバー起動 + `vox-actor viewer` 起動後、`vox-actor act <jsonl>` で UUID が stdout に出力されることを手動確認
- [ ] `vox-actor playback wait <UUID>` が再生完了まで block することを手動確認
- [ ] talk スクリプト経由で長めのセリフ再生中に Stop hook が発火しても割り込みが起きないことを手動確認（VOICEVOX 必須）

Closes #488
Closes #489
Closes #490

---
🤖 Generated with [Claude Code](https://claude.ai/code)
