### PR TITLE
feat(viewer): クリップ先読みキュー導入でクリップ間の無音ギャップを縮める

### DIFF
--- a/frontend/src/hooks/usePlaybackQueue.test.ts
+++ b/frontend/src/hooks/usePlaybackQueue.test.ts
@@ -13,11 +13,22 @@ function makeClip(n: number): ClipEvent {
   };
 }
 
+function makeFetchMock() {
+  return vi.fn((url: string | URL | Request) => {
+    const blobData = new Blob([`audio:${String(url)}`], { type: "audio/wav" });
+    // jsdom では new Response(blob) が blob.stream() を呼び失敗するため
+    // 実装が使う .blob() のみを持つ最小限のオブジェクトを返す
+    return Promise.resolve({ blob: () => Promise.resolve(blobData) } as Response);
+  });
+}
+
 describe("usePlaybackQueue", () => {
   let audio: HTMLAudioElement;
   let audioRef: { current: HTMLAudioElement };
   let mockPlay: ReturnType<typeof vi.spyOn>;
   let mockPause: ReturnType<typeof vi.spyOn>;
+  let mockCreateObjectURL: ReturnType<typeof vi.fn>;
+  let urlCounter: number;
 
   beforeEach(() => {
     audio = document.createElement("audio");
@@ -29,10 +40,17 @@ describe("usePlaybackQueue", () => {
       .spyOn(HTMLMediaElement.prototype, "pause")
       .mockImplementation(() => {});
     vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+    urlCounter = 0;
+    // jsdom では URL.createObjectURL / revokeObjectURL が未実装のため直接定義する
+    mockCreateObjectURL = vi.fn(() => `blob:mock-${++urlCounter}`);
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = vi.fn();
+    vi.stubGlobal("fetch", makeFetchMock());
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("enqueue で audio.play が呼ばれ playingClipTimestamp が更新される", async () => {
@@ -43,6 +61,19 @@ describe("usePlaybackQueue", () => {
     });
     expect(mockPlay).toHaveBeenCalled();
     expect(result.current.playingClipTimestamp).toBe(1000);
+  });
+
+  it("enqueue で fetch が呼ばれ audio.src に blob URL が設定される", async () => {
+    const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+    });
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      "http://example.com/clip/1.wav",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+    expect(audio.src).toMatch(/^blob:/);
   });
 
   it("ended イベント発火で次クリップが再生されキューが空なら null", async () => {
@@ -60,6 +91,23 @@ describe("usePlaybackQueue", () => {
       audio.dispatchEvent(new Event("ended"));
     });
     expect(result.current.playingClipTimestamp).toBeNull();
+  });
+
+  it("ended イベント発火時に先読み済みクリップが即再生される", async () => {
+    const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+      result.current.enqueue(makeClip(2));
+    });
+    // clip1 再生中、clip2 が先読み済み
+    expect(result.current.playingClipTimestamp).toBe(1000);
+    const playCallsBefore = mockPlay.mock.calls.length;
+    await act(async () => {
+      audio.dispatchEvent(new Event("ended"));
+    });
+    // ended 直後に fetch を待たず即 play() が追加呼び出しされる
+    expect(mockPlay.mock.calls.length).toBeGreaterThan(playCallsBefore);
+    expect(result.current.playingClipTimestamp).toBe(2000);
   });
 
   it("active=false への遷移で pause とキュー破棄と playingClipTimestamp=null になる", async () => {
@@ -98,6 +146,46 @@ describe("usePlaybackQueue", () => {
       result.current.enqueue(makeClip(2));
     });
     expect(result.current.playingClipTimestamp).toBe(2000);
+  });
+
+  it("先読みエラー時は次クリップへスキップされる", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockImplementation(makeFetchMock());
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+      result.current.enqueue(makeClip(2));
+    });
+    // clip1 の先読みが失敗し clip2 が再生される
+    expect(result.current.playingClipTimestamp).toBe(2000);
+  });
+
+  it("active=false 遷移で進行中の先読み fetch がキャンセルされる", async () => {
+    let capturedSignal: AbortSignal | null = null;
+    const slowFetch = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      capturedSignal = init?.signal ?? null;
+      return new Promise<Response>(() => {}); // 解決しない
+    });
+    vi.stubGlobal("fetch", slowFetch);
+
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) => usePlaybackQueue(audioRef, active),
+      { initialProps: { active: true } },
+    );
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+    });
+    expect(capturedSignal).not.toBeNull();
+    expect((capturedSignal as unknown as AbortSignal).aborted).toBe(false);
+
+    await act(async () => {
+      rerender({ active: false });
+    });
+    expect((capturedSignal as unknown as AbortSignal).aborted).toBe(true);
   });
 
   it("アンマウントで ended リスナーが解除される", () => {

--- a/frontend/src/hooks/usePlaybackQueue.ts
+++ b/frontend/src/hooks/usePlaybackQueue.ts
@@ -12,43 +12,107 @@ interface PlaybackQueue {
   enqueue: (clip: ClipEvent) => void;
 }
 
+interface ReadyClip {
+  clip: ClipEvent;
+  objectUrl: string;
+}
+
 // active=false の間は enqueue してもキューに積まれず、既存の再生は停止される。
 export function usePlaybackQueue(
   audioRef: RefObject<HTMLAudioElement>,
   active: boolean,
 ): PlaybackQueue {
-  const queueRef = useRef<ClipEvent[]>([]);
-  const [playingClipTimestamp, setPlayingClipTimestamp] = useState<number | null>(null);
+  const waitingRef = useRef<ClipEvent[]>([]);
+  const prefetchedRef = useRef<ReadyClip | null>(null);
+  const prefetchingAbortRef = useRef<AbortController | null>(null);
+  const playingObjUrlRef = useRef<string | null>(null);
+  const [playingClipTimestamp, setPlayingClipTimestamp] = useState<
+    number | null
+  >(null);
   const playingClipTimestampRef = useRef<number | null>(null);
   playingClipTimestampRef.current = playingClipTimestamp;
   const activeRef = useRef(active);
   activeRef.current = active;
 
-  const playNext = useCallback((): void => {
+  // startPrefetch は startNext から呼ばれ、完了後に startNext を呼ぶ。
+  // 互いに依存する循環呼び出しを ref で解決する。
+  const startNextRef = useRef<() => void>(() => {});
+  const startPrefetchRef = useRef<() => void>(() => {});
+
+  const startNext = useCallback((): void => {
     if (!activeRef.current) return;
     if (playingClipTimestampRef.current !== null) return;
     const audio = audioRef.current;
     if (!audio) return;
-    const next = queueRef.current.shift();
-    if (!next) return;
-    playingClipTimestampRef.current = next.timestamp;
-    setPlayingClipTimestamp(next.timestamp);
-    audio.src = next.url;
-    audio.play().catch((err: unknown) => {
-      console.error("play failed", err);
-      playingClipTimestampRef.current = null;
-      setPlayingClipTimestamp(null);
-      playNext();
-    });
+
+    const ready = prefetchedRef.current;
+    if (ready) {
+      prefetchedRef.current = null;
+      const oldUrl = playingObjUrlRef.current;
+      if (oldUrl) URL.revokeObjectURL(oldUrl);
+      playingObjUrlRef.current = ready.objectUrl;
+      playingClipTimestampRef.current = ready.clip.timestamp;
+      setPlayingClipTimestamp(ready.clip.timestamp);
+      audio.src = ready.objectUrl;
+      audio.play().catch((err: unknown) => {
+        console.error("play failed", err);
+        URL.revokeObjectURL(ready.objectUrl);
+        if (playingObjUrlRef.current === ready.objectUrl) {
+          playingObjUrlRef.current = null;
+        }
+        playingClipTimestampRef.current = null;
+        setPlayingClipTimestamp(null);
+        startNextRef.current();
+      });
+      startPrefetchRef.current();
+      return;
+    }
+
+    startPrefetchRef.current();
   }, [audioRef]);
+
+  const startPrefetch = useCallback((): void => {
+    if (prefetchedRef.current) return;
+    if (prefetchingAbortRef.current) return;
+    const next = waitingRef.current.shift();
+    if (!next) return;
+
+    const abort = new AbortController();
+    prefetchingAbortRef.current = abort;
+
+    fetch(next.url, { signal: abort.signal })
+      .then((res) => res.blob())
+      .then((blob) => {
+        prefetchingAbortRef.current = null;
+        if (!activeRef.current) {
+          return;
+        }
+        prefetchedRef.current = {
+          clip: next,
+          objectUrl: URL.createObjectURL(blob),
+        };
+        if (playingClipTimestampRef.current === null) {
+          startNextRef.current();
+        }
+      })
+      .catch((err: unknown) => {
+        prefetchingAbortRef.current = null;
+        if ((err as { name?: string }).name === "AbortError") return;
+        console.error("prefetch failed", err);
+        startPrefetchRef.current();
+      });
+  }, []);
+
+  startNextRef.current = startNext;
+  startPrefetchRef.current = startPrefetch;
 
   const enqueue = useCallback(
     (clip: ClipEvent): void => {
       if (!activeRef.current) return;
-      queueRef.current.push(clip);
-      playNext();
+      waitingRef.current.push(clip);
+      startNext();
     },
-    [playNext],
+    [startNext],
   );
 
   const stop = useCallback((): void => {
@@ -58,7 +122,19 @@ export function usePlaybackQueue(
       audio.removeAttribute("src");
       audio.load();
     }
-    queueRef.current = [];
+    if (prefetchingAbortRef.current) {
+      prefetchingAbortRef.current.abort();
+      prefetchingAbortRef.current = null;
+    }
+    if (prefetchedRef.current) {
+      URL.revokeObjectURL(prefetchedRef.current.objectUrl);
+      prefetchedRef.current = null;
+    }
+    if (playingObjUrlRef.current) {
+      URL.revokeObjectURL(playingObjUrlRef.current);
+      playingObjUrlRef.current = null;
+    }
+    waitingRef.current = [];
     playingClipTimestampRef.current = null;
     setPlayingClipTimestamp(null);
   }, [audioRef]);
@@ -70,18 +146,28 @@ export function usePlaybackQueue(
   }, [active, stop]);
 
   useEffect(() => {
+    return () => {
+      stop();
+    };
+  }, [stop]);
+
+  useEffect(() => {
     const audio = audioRef.current;
     if (!audio) return;
     const onEnded = (): void => {
+      if (playingObjUrlRef.current) {
+        URL.revokeObjectURL(playingObjUrlRef.current);
+        playingObjUrlRef.current = null;
+      }
       playingClipTimestampRef.current = null;
       setPlayingClipTimestamp(null);
-      playNext();
+      startNextRef.current();
     };
     audio.addEventListener("ended", onEnded);
     return () => {
       audio.removeEventListener("ended", onEnded);
     };
-  }, [audioRef, playNext]);
+  }, [audioRef]);
 
   return { playingClipTimestamp, enqueue };
 }

--- a/frontend/test/e2e/playback-queue.spec.ts
+++ b/frontend/test/e2e/playback-queue.spec.ts
@@ -125,10 +125,11 @@ test.describe("再生キュー", () => {
 
     await requestPromise;
 
-    // audio.src に clip の URL が設定されている
-    await expect(page.locator("audio")).toHaveJSProperty(
-      "src",
-      new URL(clipUrl, page.url()).toString(),
+    // 先読みにより fetch が完了し audio.src に blob URL が設定されている
+    const audioSrc = await page.locator("audio").evaluate(
+      (el: HTMLAudioElement) => el.src,
     );
+    expect(audioSrc).toMatch(/^blob:/);
+
   });
 });


### PR DESCRIPTION
## Summary

- `usePlaybackQueue` に `fetch` → `Blob` → `URL.createObjectURL` による先読みキューを導入
- `ended` 発火時は先読み済み objectUrl を即 `play()` し、クリップ間のロード待ちを排除
- `stop()` / unmount 時に進行中の fetch を abort し、objectUrl を解放してメモリリークを防止
- 先読み or 再生エラー時は当該クリップを破棄して次へ進む（既存フォールバックと整合）
- e2e の `audio.src` アサーションを `blob:` URL 対応に更新

## 実装方針

```
キューの状態:
  waiting (ClipEvent[])  ←→  prefetched (ReadyClip)  ←→  playing (objectUrl)
```

- `enqueue` → `startNext()` → 先読み済みがあれば即 play、なければ `startPrefetch()` を起動
- `startPrefetch()` → fetch 完了後 `createObjectURL` → 再生中でなければ `startNext()` を呼ぶ
- 循環呼び出し（`startNext` ↔ `startPrefetch`）は `useRef` 経由で解決

## Test plan

- [ ] `npm run test:unit` がグリーン（153件）
- [ ] `npm run typecheck` がエラーなし
- [ ] (手動) 連続クリップ再生時の体感ギャップが現状より明らかに短いこと
  - VOICEVOX 接続が必要なため CI 外での手動確認が必要

Closes #497

---
🤖 Generated with [Claude Code](https://claude.ai/code)
