### PR TITLE
feat(viewer): 次クリップを並行 Synthesize して SSE を前倒し broadcast する (#498)

### DIFF
--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -1122,7 +1122,6 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 
 		var wav []byte
 		if prefetchedWAV != nil {
-			// 前イテレーションで既に Play() 済み。WAV だけ再利用する。
 			wav = prefetchedWAV
 			prefetchedWAV = nil
 		} else {
@@ -1214,7 +1213,6 @@ func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID str
 // タイムアウトで broadcast スキップ）。エラー時は playback を failed に遷移させて error を返す。
 // goroutine leak を防ぐため nextSynthCh は buffered channel (cap=1) であること。
 func (p *HTTPStreamPlayer) prefetchSleep(ctx context.Context, playbackID string, duration time.Duration, nextSynthCh chan synthResult, nextClip ViewerClip) ([]byte, error) {
-	// (duration - prefetchLeadTime) 待機後、前倒し broadcast を試みる。
 	timer1 := time.NewTimer(duration - p.prefetchLeadTime)
 	select {
 	case <-timer1.C:
@@ -1251,7 +1249,6 @@ func (p *HTTPStreamPlayer) prefetchSleep(ctx context.Context, playbackID string,
 			p.setPlaybackStatus(playbackID, playbackStatusFailed, pErr.Error())
 			return nil, pErr
 		}
-		// 残り time を消化してから次クリップへ進む。
 		select {
 		case <-remainTimer.C:
 		case <-ctx.Done():

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -90,6 +90,10 @@ type HTTPStreamPlayer struct {
 	// workerCancel は worker goroutine と GC goroutine を停止するためのキャンセル関数。
 	workerCancel context.CancelFunc
 
+	// prefetchLeadTime は次クリップを前倒し broadcast するリードタイム。
+	// 現クリップの推定再生時間残り prefetchLeadTime の段階で次クリップの clipEvent を送信する。
+	prefetchLeadTime time.Duration
+
 	// playbackMu は playbacks マップの排他制御。
 	playbackMu sync.Mutex
 	// playbacks は playback_id → state の in-memory store。TTL 1 時間で GC される。
@@ -126,6 +130,8 @@ const (
 	maxClipsPerBatch = 100
 	// batchQueueCapacity は pending バッチ数の上限。超過時は 503 を返す。
 	batchQueueCapacity = 64
+	// defaultPrefetchLeadTime は次クリップの前倒し broadcast タイミング（現クリップ残り時間）の既定値。
+	defaultPrefetchLeadTime = 500 * time.Millisecond
 	// playbackTTL は playback state を in-memory に保持する期間。
 	playbackTTL = time.Hour
 	// playbackGCInterval は GC goroutine の実行間隔。
@@ -289,6 +295,17 @@ func WithHistoryDir(dir string) HTTPStreamOption {
 	}
 }
 
+// WithPrefetchLeadTime は次クリップを前倒し broadcast するリードタイムを設定するオプション。
+// 現クリップの推定再生時間が leadTime より長い場合、残り leadTime の段階で
+// 次クリップの Synthesize 結果を broadcast する（テスト用・チューニング用）。
+func WithPrefetchLeadTime(leadTime time.Duration) HTTPStreamOption {
+	return func(p *HTTPStreamPlayer) {
+		if leadTime > 0 {
+			p.prefetchLeadTime = leadTime
+		}
+	}
+}
+
 // withNowFunc は clipEvent の timestamp 取得に使う関数を設定する（テスト用）。
 func withNowFunc(now func() time.Time) HTTPStreamOption {
 	return func(p *HTTPStreamPlayer) {
@@ -310,16 +327,17 @@ func NewHTTPStreamPlayer(addr string, staticFS fs.FS, opts ...HTTPStreamOption) 
 		return nil, fmt.Errorf("stream staticFS must not be nil")
 	}
 	p := &HTTPStreamPlayer{
-		addr:           addr,
-		logger:         slog.New(slog.DiscardHandler),
-		staticFS:       staticFS,
-		subscribers:    newSubscriberRegistry(),
-		nowFunc:        time.Now,
-		silentInterval: defaultSilentInterval,
-		testPhrase:     defaultTestPhrase,
-		testClipCache:  make(map[int][]byte),
-		batchQueue:     make(chan playBatch, batchQueueCapacity),
-		playbacks:      make(map[string]*playbackStateRecord),
+		addr:             addr,
+		logger:           slog.New(slog.DiscardHandler),
+		staticFS:         staticFS,
+		subscribers:      newSubscriberRegistry(),
+		nowFunc:          time.Now,
+		silentInterval:   defaultSilentInterval,
+		testPhrase:       defaultTestPhrase,
+		testClipCache:    make(map[int][]byte),
+		batchQueue:       make(chan playBatch, batchQueueCapacity),
+		playbacks:        make(map[string]*playbackStateRecord),
+		prefetchLeadTime: defaultPrefetchLeadTime,
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -1081,50 +1099,77 @@ func (p *HTTPStreamPlayer) runWorker(ctx context.Context) {
 	}
 }
 
+// synthResult は並行 Synthesize goroutine の結果を格納する。
+type synthResult struct {
+	wav []byte
+	err error
+}
+
 // synthesize 失敗時はバッチ全体を中断する（all-or-nothing）。
+// 現クリップの再生中に次クリップを並行 Synthesize し、残り prefetchLeadTime の
+// タイミングで前倒し broadcast する。
+// メモリ増加: 最大 1 本分の追加 WAV バッファを保持する（VOICEVOX 負荷も +1 並列）。
 func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 	p.setPlaybackStatus(batch.playbackID, playbackStatusPlaying, "")
 
-	for _, clip := range batch.clips {
+	// 前のイテレーションで前倒し broadcast 済みの WAV（nil なら通常合成）。
+	var prefetchedWAV []byte
+
+	for i, clip := range batch.clips {
 		if ctx.Err() != nil {
 			return
 		}
 
-		query, err := p.voicevoxClient.CreateQuery(ctx, clip.Text, clip.SpeakerID)
-		if err != nil {
-			p.logger.Error("worker CreateQuery failed", "playbackID", batch.playbackID, "speakerID", clip.SpeakerID, "error", err)
-			p.setPlaybackStatus(batch.playbackID, playbackStatusFailed, err.Error())
-			return
-		}
-
-		q := query.WithOverrides(clip.Speed, clip.Pitch, clip.Intonation)
-		wav, err := p.voicevoxClient.Synthesize(ctx, &q, clip.SpeakerID)
-		if err != nil {
-			p.logger.Error("worker Synthesize failed", "playbackID", batch.playbackID, "speakerID", clip.SpeakerID, "error", err)
-			p.setPlaybackStatus(batch.playbackID, playbackStatusFailed, err.Error())
-			return
-		}
-
-		meta := app.PlayMeta{Text: clip.Text, SpeakerID: clip.SpeakerID}
-		if err := p.Play(ctx, wav, meta); err != nil {
-			if ctx.Err() != nil {
+		var wav []byte
+		if prefetchedWAV != nil {
+			// 前イテレーションで既に Play() 済み。WAV だけ再利用する。
+			wav = prefetchedWAV
+			prefetchedWAV = nil
+		} else {
+			var err error
+			wav, err = p.synthesizeAndPlay(ctx, batch.playbackID, clip)
+			if err != nil {
 				return
 			}
-			p.logger.Error("worker Play failed", "playbackID", batch.playbackID, "speakerID", clip.SpeakerID, "error", err)
-			p.setPlaybackStatus(batch.playbackID, playbackStatusFailed, err.Error())
-			return
 		}
 
 		duration, dErr := estimateWAVDuration(wav)
-		if dErr == nil && duration > 0 {
-			timer := time.NewTimer(duration)
-			select {
-			case <-timer.C:
-			case <-ctx.Done():
-				if !timer.Stop() {
-					<-timer.C
+
+		// 次クリップが存在し、再生時間が prefetchLeadTime より長い場合に並行 Synthesize を開始。
+		// buffered channel (cap=1) を使うため goroutine は送信後にブロックしない。
+		var nextSynthCh chan synthResult
+		if i+1 < len(batch.clips) && dErr == nil && duration > p.prefetchLeadTime {
+			nextClip := batch.clips[i+1]
+			nextSynthCh = make(chan synthResult, 1)
+			go func() {
+				q2, err := p.voicevoxClient.CreateQuery(ctx, nextClip.Text, nextClip.SpeakerID)
+				if err != nil {
+					nextSynthCh <- synthResult{err: err}
+					return
 				}
-				return
+				q2o := q2.WithOverrides(nextClip.Speed, nextClip.Pitch, nextClip.Intonation)
+				w, err := p.voicevoxClient.Synthesize(ctx, &q2o, nextClip.SpeakerID)
+				nextSynthCh <- synthResult{wav: w, err: err}
+			}()
+		}
+
+		if dErr == nil && duration > 0 {
+			if nextSynthCh != nil {
+				var err error
+				prefetchedWAV, err = p.prefetchSleep(ctx, batch.playbackID, duration, nextSynthCh, batch.clips[i+1])
+				if err != nil {
+					return
+				}
+			} else {
+				timer := time.NewTimer(duration)
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+					if !timer.Stop() {
+						<-timer.C
+					}
+					return
+				}
 			}
 		}
 
@@ -1132,6 +1177,99 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 	}
 
 	p.setPlaybackStatus(batch.playbackID, playbackStatusCompleted, "")
+}
+
+// synthesizeAndPlay は clip を合成して Play() でブロードキャストする。
+// エラー時は playback を failed に遷移させて error を返す。
+func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID string, clip ViewerClip) ([]byte, error) {
+	query, err := p.voicevoxClient.CreateQuery(ctx, clip.Text, clip.SpeakerID)
+	if err != nil {
+		p.logger.Error("worker CreateQuery failed", "playbackID", playbackID, "speakerID", clip.SpeakerID, "error", err)
+		p.setPlaybackStatus(playbackID, playbackStatusFailed, err.Error())
+		return nil, err
+	}
+
+	q := query.WithOverrides(clip.Speed, clip.Pitch, clip.Intonation)
+	wav, err := p.voicevoxClient.Synthesize(ctx, &q, clip.SpeakerID)
+	if err != nil {
+		p.logger.Error("worker Synthesize failed", "playbackID", playbackID, "speakerID", clip.SpeakerID, "error", err)
+		p.setPlaybackStatus(playbackID, playbackStatusFailed, err.Error())
+		return nil, err
+	}
+
+	meta := app.PlayMeta{Text: clip.Text, SpeakerID: clip.SpeakerID}
+	if pErr := p.Play(ctx, wav, meta); pErr != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		p.logger.Error("worker Play failed", "playbackID", playbackID, "speakerID", clip.SpeakerID, "error", pErr)
+		p.setPlaybackStatus(playbackID, playbackStatusFailed, pErr.Error())
+		return nil, pErr
+	}
+	return wav, nil
+}
+
+// prefetchSleep は duration の残り prefetchLeadTime 前に nextSynthCh から合成結果を受け取り
+// nextClip を前倒し broadcast する。broadcast に成功した場合は nextClip の WAV を返す（nil なら
+// タイムアウトで broadcast スキップ）。エラー時は playback を failed に遷移させて error を返す。
+// goroutine leak を防ぐため nextSynthCh は buffered channel (cap=1) であること。
+func (p *HTTPStreamPlayer) prefetchSleep(ctx context.Context, playbackID string, duration time.Duration, nextSynthCh chan synthResult, nextClip ViewerClip) ([]byte, error) {
+	// (duration - prefetchLeadTime) 待機後、前倒し broadcast を試みる。
+	timer1 := time.NewTimer(duration - p.prefetchLeadTime)
+	select {
+	case <-timer1.C:
+	case <-ctx.Done():
+		if !timer1.Stop() {
+			<-timer1.C
+		}
+		return nil, ctx.Err()
+	}
+
+	// 残り prefetchLeadTime 以内に合成が終わればそのまま broadcast する。
+	// タイムアウト時は goroutine の結果を破棄し、次イテレーションで通常合成にフォールバックする
+	// （buffered channel のため goroutine leak なし）。
+	remainTimer := time.NewTimer(p.prefetchLeadTime)
+	select {
+	case result := <-nextSynthCh:
+		if result.err != nil {
+			if !remainTimer.Stop() {
+				<-remainTimer.C
+			}
+			p.logger.Error("worker prefetch Synthesize failed", "playbackID", playbackID, "error", result.err)
+			p.setPlaybackStatus(playbackID, playbackStatusFailed, result.err.Error())
+			return nil, result.err
+		}
+		nextMeta := app.PlayMeta{Text: nextClip.Text, SpeakerID: nextClip.SpeakerID}
+		if pErr := p.Play(ctx, result.wav, nextMeta); pErr != nil {
+			if !remainTimer.Stop() {
+				<-remainTimer.C
+			}
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			p.logger.Error("worker prefetch Play failed", "playbackID", playbackID, "error", pErr)
+			p.setPlaybackStatus(playbackID, playbackStatusFailed, pErr.Error())
+			return nil, pErr
+		}
+		// 残り time を消化してから次クリップへ進む。
+		select {
+		case <-remainTimer.C:
+		case <-ctx.Done():
+			if !remainTimer.Stop() {
+				<-remainTimer.C
+			}
+			return result.wav, ctx.Err()
+		}
+		return result.wav, nil
+	case <-remainTimer.C:
+		// 合成がリードタイム内に完了しなかった。次イテレーションで通常合成する。
+		return nil, nil
+	case <-ctx.Done():
+		if !remainTimer.Stop() {
+			<-remainTimer.C
+		}
+		return nil, ctx.Err()
+	}
 }
 
 func (p *HTTPStreamPlayer) runPlaybackGC(ctx context.Context) {

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -104,6 +104,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -1240,39 +1241,55 @@ func TestHTTPStreamPlayer_PlayText_UnknownSpeakerFallback(t *testing.T) {
 
 // testVoicevoxClient is a minimal stub implementing app.VoicevoxClient for /test-clip tests.
 type testVoicevoxClient struct {
-	createQueryCall  int
-	synthesizeCall   int
-	createQueryErr   error
-	synthesizeErr    error
-	wav              []byte
-	capturedText     string
-	capturedSpeaker  int
-	createQueryBlock chan struct{} // nil でなければ CreateQuery はこのチャネルが閉じるまでブロックする
+	mu              sync.Mutex
+	createQueryCall int
+	synthesizeCall  int
+	createQueryErr  error
+	synthesizeErr   error
+	// synthesizeErrOnNthCall が 0 の場合は全呼び出しで synthesizeErr を返す。
+	// N > 0 の場合は N 回目の呼び出しのみ synthesizeErr を返す。
+	synthesizeErrOnNthCall int
+	wav                    []byte
+	capturedText           string
+	capturedSpeaker        int
+	createQueryBlock       chan struct{} // nil でなければ CreateQuery はこのチャネルが閉じるまでブロックする
 }
 
 func (c *testVoicevoxClient) HealthCheck(_ context.Context) error { return nil }
 func (c *testVoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error) {
+	c.mu.Lock()
 	c.createQueryCall++
 	c.capturedText = text
 	c.capturedSpeaker = speakerID
-	if c.createQueryBlock != nil {
+	block := c.createQueryBlock
+	c.mu.Unlock()
+	if block != nil {
 		select {
-		case <-c.createQueryBlock:
+		case <-block:
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
 	}
-	if c.createQueryErr != nil {
-		return nil, c.createQueryErr
+	c.mu.Lock()
+	err := c.createQueryErr
+	c.mu.Unlock()
+	if err != nil {
+		return nil, err
 	}
 	return &entity.AudioQuery{}, nil
 }
 func (c *testVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+	c.mu.Lock()
 	c.synthesizeCall++
-	if c.synthesizeErr != nil {
-		return nil, c.synthesizeErr
+	n := c.synthesizeCall
+	errOnN := c.synthesizeErrOnNthCall
+	synthErr := c.synthesizeErr
+	wav := c.wav
+	c.mu.Unlock()
+	if synthErr != nil && (errOnN == 0 || n == errOnN) {
+		return nil, synthErr
 	}
-	return c.wav, nil
+	return wav, nil
 }
 func (c *testVoicevoxClient) GetSpeakers(_ context.Context) ([]entity.Speaker, error) {
 	return nil, nil
@@ -3299,6 +3316,98 @@ func TestHTTPStreamPlayer_APIPlayback_CompletedClips(t *testing.T) {
 	}
 	if result.ClipCount != 2 {
 		t.Errorf("expected clip_count=2, got %d", result.ClipCount)
+	}
+}
+
+// --- #498 次クリップ事前 broadcast ---
+//
+// DONE: 現クリップ sleep 中に次クリップを並行 Synthesize して前倒し broadcast する → TestHTTPStreamPlayer_Prefetch_NextClipBroadcastedBeforeCurrentEnds
+// DONE: 前倒し Synthesize 失敗でバッチ全体が failed になる                         → TestHTTPStreamPlayer_Prefetch_SynthesizeFailureDuringPrefetchFails
+
+func TestHTTPStreamPlayer_Prefetch_NextClipBroadcastedBeforeCurrentEnds(t *testing.T) {
+	t.Parallel()
+	// byteRate=8000, dataSize=4800 → duration=600ms
+	wav := buildWAV(8000, 4800)
+	stub := &testVoicevoxClient{wav: wav}
+
+	leadTime := 200 * time.Millisecond
+	p := newStartedPlayerWithOpts(t,
+		WithVoicevoxClient(stub),
+		WithPrefetchLeadTime(leadTime),
+	)
+
+	events := subscribeSSE(t, "http://"+p.Addr())
+	time.Sleep(100 * time.Millisecond)
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"first","speaker_id":2},{"text":"second","speaker_id":3}]}`)
+	_, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+
+	receivedAt := map[string]time.Time{}
+	timeout := time.After(5 * time.Second)
+	for len(receivedAt) < 2 {
+		select {
+		case data := <-events:
+			var ev clipEvent
+			if err := json.Unmarshal([]byte(data), &ev); err == nil {
+				if _, seen := receivedAt[ev.Text]; !seen {
+					receivedAt[ev.Text] = time.Now()
+				}
+			}
+		case <-timeout:
+			t.Fatalf("timeout: received clips %v", receivedAt)
+		}
+	}
+
+	// 前倒しで broadcast されるため、第2クリップのSSEは第1クリップの推定再生時間(600ms)内に届く。
+	gap := receivedAt["second"].Sub(receivedAt["first"])
+	if gap >= 600*time.Millisecond {
+		t.Errorf("second clip arrived too late (gap=%v), expected < 600ms (prefetch not working)", gap)
+	}
+}
+
+func TestHTTPStreamPlayer_Prefetch_SynthesizeFailureDuringPrefetchFails(t *testing.T) {
+	t.Parallel()
+	// byteRate=8000, dataSize=4800 → duration=600ms (プリフェッチが走る十分な長さ)
+	wav := buildWAV(8000, 4800)
+	stub := &testVoicevoxClient{
+		wav:                    wav,
+		synthesizeErr:          errors.New("prefetch synth failed"),
+		synthesizeErrOnNthCall: 2, // 2回目の Synthesize だけ失敗
+	}
+
+	p := newStartedPlayerWithOpts(t,
+		WithVoicevoxClient(stub),
+		WithPrefetchLeadTime(200*time.Millisecond),
+	)
+
+	body := bytes.NewBufferString(`{"clips":[{"text":"first","speaker_id":2},{"text":"second","speaker_id":3}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var result ViewerPlayResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// プリフェッチエラーは現クリップの sleep 中 (600ms-200ms=400ms) に検出される。
+	// 600ms 経過前（500ms時点）で "failed" になっていることを確認する。
+	// ※実装なしの場合は 600ms 後に直列で失敗するため、500ms 時点では "playing" のままになる。
+	time.Sleep(500 * time.Millisecond)
+
+	status, ok := p.PlaybackStatus(result.PlaybackID)
+	if !ok {
+		t.Fatalf("playback state not found for id=%s", result.PlaybackID)
+	}
+	if status != "failed" {
+		t.Errorf("expected prefetch error to fail batch within 500ms, got status=%s (prefetch not implemented?)", status)
 	}
 }
 

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -3340,10 +3340,11 @@ func TestHTTPStreamPlayer_Prefetch_NextClipBroadcastedBeforeCurrentEnds(t *testi
 	time.Sleep(100 * time.Millisecond)
 
 	body := bytes.NewBufferString(`{"clips":[{"text":"first","speaker_id":2},{"text":"second","speaker_id":3}]}`)
-	_, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}
+	defer func() { _ = resp.Body.Close() }()
 
 	receivedAt := map[string]time.Time{}
 	timeout := time.After(5 * time.Second)


### PR DESCRIPTION
## Summary

- `processBatch` で「1 本後ろ」のクリップを goroutine で並行 Synthesize し、現クリップの残り `prefetchLeadTime`（デフォルト 500ms）のタイミングで clipEvent SSE を前倒し broadcast する
- 前倒し broadcast 済みのクリップは次イテレーションで合成・broadcast をスキップし、WAV のみ再利用する
- 並行合成エラーは既存の all-or-nothing バッチ挙動と整合し、バッチ全体を `failed` に遷移させる
- 合成がリードタイム内に完了しない場合は通常合成にフォールバックする（goroutine は buffered channel (cap=1) で leak なし）
- `WithPrefetchLeadTime(d)` オプションでリードタイムを調整可能（テスト・チューニング用）
- 複雑度低減のため `synthesizeAndPlay` / `prefetchSleep` ヘルパーに分割

## Test plan

- [x] `TestHTTPStreamPlayer_Prefetch_NextClipBroadcastedBeforeCurrentEnds` — 第2クリップの SSE が第1クリップの推定再生時間（600ms）内に到着することを確認
- [x] `TestHTTPStreamPlayer_Prefetch_SynthesizeFailureDuringPrefetchFails` — プリフェッチ中の合成エラーがバッチ全体を 500ms 以内に `failed` にすることを確認
- [x] 既存 e2e (`test/e2e/`) グリーン確認（CI で確認）
- [ ] VOICEVOX 接続環境での手動確認（CI 自動検証不可のため PR test plan に記載）

## 実装メモ

- メモリ増加: 最大 1 本分の追加 WAV バッファ + VOICEVOX への並列リクエスト 1 本
- `estimateWAVDuration` が失敗する（無効 WAV ヘッダ等）場合はプリフェッチをスキップし、既存挙動を維持

Closes #498

---
🤖 Generated with [Claude Code](https://claude.ai/code)
