### PR TITLE
feat(docs): test/e2e/ の受け入れ条件を Gherkin .feature として整備する (#503)

### DIFF
--- a/docs/acceptance/cli/act.feature
+++ b/docs/acceptance/cli/act.feature
@@ -1,0 +1,252 @@
+Feature: vox-actor act コマンド
+
+  # ===== ドライラン基本動作 =====
+
+  Scenario: .txt ファイルをドライランで実行するとファイル全体が1スクリプトとして処理される
+    Given テンポラリディレクトリに "script.txt" を作成し、複数行テキストを書く
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コード 0 で完了する
+    And stderr に "[dry run] playback completed" が1回だけ出力される
+    # test: test/e2e/act_test.go::TestActE2E_TxtFile_DryRun
+
+  Scenario: .json ファイルをドライランで実行するとパラメータがログに反映される
+    Given テンポラリディレクトリに JSON ファイル '{"text":"こんにちは","speaker":11,"speed":1.2,"pitch":0.1,"intonation":1.5}' を書く
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コード 0 で完了する
+    And "[dry run] playback completed" の行に "text=こんにちは", "speaker=11", "speed=1.2", "pitch=0.1", "intonation=1.5" が含まれる
+    # test: test/e2e/act_test.go::TestActE2E_JsonFile_DryRun_OverrideParams
+
+  Scenario: .jsonl ファイルをドライランで実行すると各行が独立したスクリプトとして処理される
+    Given テンポラリディレクトリに 3 行の .jsonl ファイルを書く
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コード 0 で完了する
+    And stderr に "playback completed" が3回出力される
+    And テキストの出力順が "いちぎょうめ → にぎょうめ → さんぎょうめ" の順である
+    # test: test/e2e/act_test.go::TestActE2E_JsonlFile_DryRun_MultipleScripts
+
+  Scenario: ディレクトリをドライランで実行するとファイルが辞書順に処理される
+    Given テンポラリディレクトリに "a.txt", "b.json", "c.jsonl" を作成する
+    When "vox-actor act --dry-run <dir>" を実行する
+    Then 終了コード 0 で完了する
+    And stderr に "playback completed" が4回出力される（a.txt=1, b.json=1, c.jsonl=2）
+    And テキストの出力順が "エーのテキスト → ビーのテキスト → シー1 → シー2" の順である
+    # test: test/e2e/act_test.go::TestActE2E_Directory_DryRun_LexOrder
+
+  # ===== エラーハンドリング =====
+
+  Scenario: 存在しないパスを指定すると非ゼロ終了コードと stderr が出力される
+    Given 存在しないファイルパスを用意する
+    When "vox-actor act --dry-run <missing_path>" を実行する
+    Then 終了コードが非ゼロである
+    And stderr が空でない
+    # test: test/e2e/act_test.go::TestActE2E_NonexistentPath_NonZeroWithStderr
+
+  Scenario: 壊れた JSON ファイルを指定すると非ゼロ終了コードと stderr が出力される
+    Given テンポラリディレクトリに不正な JSON ファイル "{" を書く
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コードが非ゼロである
+    And stderr が空でない
+    # test: test/e2e/act_test.go::TestActE2E_BrokenJSON_NonZero
+
+  Scenario: 引数なしで実行すると終了コード 2 が返る
+    When "vox-actor act" を引数なしで実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/act_test.go::TestActE2E_NoArgs_ExitCode2
+
+  Scenario: text フィールドがない JSON ファイルを指定すると非ゼロ終了コードと stderr が出力される
+    Given テンポラリディレクトリに "{}" を書いた .json ファイルを用意する
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コードが非ゼロである
+    And stderr が空でない
+    # test: test/e2e/act_test.go::TestActE2E_EmptyJson_NoTextField_NonZero
+
+  # ===== フラグとパラメータの反映 =====
+
+  Scenario: --speaker および --speed フラグの値がログに反映される
+    Given テンポラリディレクトリに .txt ファイルを作成する
+    When "vox-actor act --dry-run --speaker 8 --speed 1.2 <path>" を実行する
+    Then 終了コード 0 で完了する
+    And "[dry run] playback completed" の行に "text=フラグテスト", "speaker=8", "speed=1.2" が含まれる
+    # test: test/e2e/act_test.go::TestActE2E_TxtFile_FlagsReflectedInLog
+
+  Scenario: JSON ファイルでパラメータを省略した場合は CLI フラグのデフォルト値が使用される
+    Given テンポラリディレクトリに '{"text":"きほん"}' を書いた .json ファイルを用意する
+    When "vox-actor act --dry-run --speaker 5 --speed 1.3 <path>" を実行する
+    Then 終了コード 0 で完了する
+    And "[dry run] playback completed" の行に "text=きほん", "speaker=5", "speed=1.3" が含まれる
+    # test: test/e2e/act_test.go::TestActE2E_JsonFile_OmittedParams_UsesCLIFlagDefaults
+
+  Scenario: .jsonl ファイルの各行パラメータがプレイバックログに反映される
+    Given テンポラリディレクトリに2行の .jsonl ファイル（各行にパラメータを指定）を作成する
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コード 0 で完了する
+    And 1行目の "playback completed" に "speaker=11", "speed=1.2", "pitch=0.05", "intonation=1.3" が含まれる
+    And 2行目の "playback completed" に "speaker=7" が含まれる
+    # test: test/e2e/act_test.go::TestActE2E_JsonlFile_PerLineParams_Reflected
+
+  # ===== 廃止フラグ =====
+
+  Scenario: 廃止済み --watch フラグを指定すると終了コード 2 が返る
+    Given テンポラリディレクトリを用意する
+    When "vox-actor act --watch <dir>" を実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/act_test.go::TestActE2E_WatchFlag_ExitCode2
+
+  Scenario: 廃止済み --watch-delete フラグを指定すると終了コード 2 が返る
+    Given テンポラリディレクトリを用意する
+    When "vox-actor act --watch-delete <dir>" を実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/act_test.go::TestActE2E_WatchDeleteFlag_ExitCode2
+
+  # ===== ヘルプ =====
+
+  Scenario: --help フラグで終了コード 0 かつ全フラグが表示される
+    When "vox-actor act --help" を実行する
+    Then 終了コード 0 で完了する
+    And stdout に "--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run" が含まれる
+    # test: test/e2e/act_test.go::TestActE2E_Help_ExitZeroWithAllFlags
+
+  # ===== 空ファイル・特殊ケース =====
+
+  Scenario: 空の .txt ファイルを指定すると終了コード 0 が返る
+    Given テンポラリディレクトリに空の "empty.txt" を作成する
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コード 0 で完了する
+    # test: test/e2e/act_test.go::TestActE2E_EmptyFile_Txt_ExitsZero
+
+  Scenario: 空の .jsonl ファイルを指定すると終了コード 0 が返る
+    Given テンポラリディレクトリに空の "empty.jsonl" を作成する
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コード 0 で完了する
+    # test: test/e2e/act_test.go::TestActE2E_EmptyFile_Jsonl_ExitsZero
+
+  Scenario: サポート外の拡張子（.md）はプレーンテキストとして処理され終了コード 0 が返る
+    Given テンポラリディレクトリに "note.md" を作成する
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コード 0 で完了する
+    # test: test/e2e/act_test.go::TestActE2E_UnsupportedExtension_ExitsZero
+
+  Scenario: .jsonl ファイルの空行はスキップされる
+    Given テンポラリディレクトリに空行を含む .jsonl ファイル（有効行2行）を作成する
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コード 0 で完了する
+    And stderr に "playback completed" が2回出力される
+    # test: test/e2e/act_test.go::TestActE2E_JsonlFile_EmptyLines_Skipped
+
+  # ===== 詳細ログ =====
+
+  Scenario: --verbose フラグでデバッグログが出力される
+    Given テンポラリディレクトリに .txt ファイルを作成する
+    When "vox-actor act --dry-run --verbose <path>" を実行する
+    Then 終了コード 0 で完了する
+    And stderr の "act starting" 行に "path=" が含まれる
+    # test: test/e2e/act_test.go::TestActE2E_Verbose_ShowsDebugLogs
+
+  Scenario: ディレクトリを指定すると "scripts loaded" ログが出力される
+    Given テンポラリディレクトリに2つの .txt ファイルを作成する
+    When "vox-actor act --dry-run <dir>" を実行する
+    Then 終了コード 0 で完了する
+    And stderr に "scripts loaded" が含まれる
+    # test: test/e2e/act_test.go::TestActE2E_Dir_ScriptsLoadedLog
+
+  # ===== VOICEVOX 実通信エラー =====
+
+  Scenario: VOICEVOX が 5xx を返すと非ゼロ終了コードと stderr が出力される
+    Given VOICEVOX のスタブサーバーが常に 500 を返す
+    When "vox-actor act <path>" を VOX_ENGINE_URL に向けて実行する
+    Then 終了コードが非ゼロである
+    And stderr が空でない
+    # test: test/e2e/act_comm_test.go::TestActE2E_RealComm_Voicevox5xx_NonZeroExit
+
+  Scenario: VOICEVOX への接続が失敗すると非ゼロ終了コードと stderr が出力される
+    Given VOX_ENGINE_URL に到達不能なアドレス "http://127.0.0.1:1" を設定する
+    When "vox-actor act <path>" を実行する
+    Then 終了コードが非ゼロである
+    And stderr が空でない
+    # test: test/e2e/act_comm_test.go::TestActE2E_RealComm_VoicevoxConnFailed_NonZeroExit
+
+  Scenario: VOICEVOX がレスポンスボディに不正 JSON を返すと非ゼロ終了コードと stderr が出力される
+    Given /audio_query が "not-json" を返すスタブサーバーを用意する
+    When "vox-actor act <path>" を VOX_ENGINE_URL に向けて実行する
+    Then 終了コードが非ゼロである
+    And stderr が空でない
+    # test: test/e2e/act_comm_test.go::TestActE2E_RealComm_VoicevoxBadBody_NonZeroExit
+
+  # ===== viewer 連携 =====
+
+  Scenario: viewer が起動中の場合、全クリップを1回のバッチ POST で送信し終了コード 0 が返る
+    Given フェイク viewer サーバーが起動しロックファイルが書き込まれている
+    And テンポラリディレクトリに3行の .jsonl スクリプトを作成する
+    When "vox-actor act <path>" を HOME に向けて実行する
+    Then 終了コード 0 で完了する
+    And /api/play への POST が1回だけ呼ばれる
+    # test: test/e2e/act_comm_test.go::TestActE2E_Viewer_POSTsAndExitsZero
+
+  Scenario: viewer の /api/play が失敗すると非ゼロ終了コードが返る
+    Given /api/play が常に 500 を返すスタブ viewer が起動している
+    And テンポラリディレクトリに3行の .jsonl スクリプトを作成する
+    When "vox-actor act <path>" を HOME に向けて実行する
+    Then 終了コードが非ゼロである
+    # test: test/e2e/act_comm_test.go::TestActE2E_Viewer_POSTFailure_EarlyExit
+
+  Scenario: viewer がサイレントモードの場合、終了コード 0 かつ WARN ログが出力される
+    Given フェイク viewer がサイレントモード（理由: "test-reason"）で起動している
+    When "vox-actor act <path>" を HOME に向けて実行する
+    Then 終了コード 0 で完了する
+    And stderr の "viewer is in silent mode" 行が WARN レベルプレフィックス "!" で始まる
+    # test: test/e2e/act_comm_test.go::TestActE2E_Viewer_SilentMode_Warns
+
+  Scenario: viewer に到達できず VOICEVOX も到達不能な場合、非ゼロ終了コードと "viewer not running" ログが出力される
+    Given ロックファイルが到達不能アドレス "127.0.0.1:1" を指している
+    And VOX_ENGINE_URL も "http://127.0.0.1:1" に設定する
+    When "vox-actor act --verbose <path>" を実行する
+    Then 終了コードが非ゼロである
+    And stderr に "viewer not running" が含まれる
+    # test: test/e2e/act_comm_test.go::TestActE2E_Viewer_Unreachable_FallbackFails
+
+  Scenario: --dry-run 時は viewer への POST を行わない
+    Given フェイク viewer サーバーが起動している
+    When "vox-actor act --dry-run <path>" を HOME に向けて実行する
+    Then 終了コード 0 で完了する
+    And /api/play への POST が0回である
+    # test: test/e2e/act_comm_test.go::TestActE2E_Viewer_DryRun_NoPOST
+
+  Scenario: viewer 起動中は "viewer detected" ログが出力される
+    Given フェイク viewer サーバーが起動している
+    When "vox-actor act <path>" を HOME に向けて実行する
+    Then 終了コード 0 で完了する
+    And stderr に "viewer detected" が含まれる
+    # test: test/e2e/act_comm_test.go::TestActE2E_Viewer_Detected_LogMessage
+
+  # ===== 環境変数とフラグの優先順位 =====
+
+  Scenario: --speaker フラグが VOX_SPEAKER 環境変数より優先される
+    Given 環境変数 VOX_SPEAKER=10 が設定されている
+    When "vox-actor act --dry-run --speaker 5 <path>" を実行する
+    Then 終了コード 0 で完了する
+    And "playback completed" 行に "speaker=5" が含まれる
+    # test: test/e2e/act_comm_test.go::TestActE2E_Flag_SpeakerOverridesEnv
+
+  Scenario: --engine-url フラグが VOX_ENGINE_URL 環境変数より優先される
+    Given 環境変数 VOX_ENGINE_URL に到達不能アドレスを設定する
+    And --engine-url に 5xx を返すスタブサーバーの URL を指定する
+    When "vox-actor act --engine-url <stub_url> <path>" を実行する
+    Then 終了コードが非ゼロである
+    And stderr に "500" または "audio" が含まれる
+    # test: test/e2e/act_comm_test.go::TestActE2E_Flag_EngineURLOverridesEnv
+
+  Scenario: VOX_SPEAKER に不正な値を設定するとデフォルト値（speaker=3）にフォールバックする
+    Given 環境変数 VOX_SPEAKER=not-a-number が設定されている
+    When "vox-actor act --dry-run <path>" を実行する
+    Then 終了コード 0 で完了する
+    And "playback completed" 行に "speaker=3" が含まれる
+    # test: test/e2e/act_comm_test.go::TestActE2E_Env_VOXSpeakerInvalid_DefaultFallback
+
+  # ===== シグナル処理 =====
+
+  Scenario: VOICEVOX 処理中に SIGINT を送ると 5 秒以内にプロセスが終了する
+    Given ハングするスタブ VOICEVOX サーバーを起動する
+    And "vox-actor act --engine-url <stub_url> <path>" をバックグラウンドで起動する
+    When 150ms 後に SIGINT を送る
+    Then 5 秒以内にプロセスが終了する
+    # test: test/e2e/act_comm_test.go::TestActE2E_SIGINT_DuringVoicevox_Exits

--- a/docs/acceptance/cli/assets.feature
+++ b/docs/acceptance/cli/assets.feature
@@ -1,0 +1,147 @@
+Feature: vox-actor assets コマンド
+
+  # ─────────────────────────────────────────
+  # A. 親コマンド / ヘルプ / 引数バリデーション
+  # ─────────────────────────────────────────
+
+  Scenario: "assets" のみ実行するとヘルプに "download" が含まれる
+    When "vox-actor assets" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "assets" と "download" が含まれる
+    # test: test/e2e/assets_test.go::TestAssetsE2E_NoSubcmd_ShowsHelp
+
+  Scenario: "assets download --help" で "--speaker"、"--force"、"--scope" が表示される
+    When "vox-actor assets download --help" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "--speaker"、"--force"、"--scope" が含まれる
+    # test: test/e2e/assets_test.go::TestAssetsE2E_DownloadHelp_ExitZeroWithAllFlags
+
+  Scenario: "assets download" に引数なしで実行すると終了コード 2 になる
+    When "vox-actor assets download" を実行する（引数なし）
+    Then 終了コード 2 で完了する
+    # test: test/e2e/assets_test.go::TestAssetsE2E_DownloadNoArgs_ExitCode2
+
+  Scenario: --scope に無効な値を指定すると終了コード 2 でスコープエラーが stderr に出る
+    Given ワークスペースが設定されている
+    When "vox-actor assets download --scope invalid file:///dummy" を実行する
+    Then 終了コード 2 で完了する
+    And 標準エラー出力にスコープエラーを示す文言が含まれる
+    # test: test/e2e/assets_test.go::TestAssetsE2E_DownloadInvalidScope_ExitCode2
+
+  # ─────────────────────────────────────────
+  # B. ローカル fake git リポジトリでの clone 動作
+  # ─────────────────────────────────────────
+
+  Scenario: 通常の clone でスピーカーのアセットがワークスペースに配置される
+    Given "zundamon" のアセット（icon.png、face.png）を含む fake git リポジトリがある
+    And ワークスペースが設定されている
+    When "vox-actor assets download <repoURL>" を実行する
+    Then 終了コード 0 で完了する
+    And ワークスペースの assets/zundamon/icon.png が存在する
+    And ワークスペースの assets/zundamon/face.png が存在する
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_NormalClone
+
+  Scenario: "--scope project" を指定すると assets がプロジェクトワークスペースに配置される
+    Given "kiritan" のアセットを含む fake git リポジトリがある
+    And ワークスペースが設定されている
+    When "vox-actor assets download --scope project <repoURL>" を実行する
+    Then 終了コード 0 で完了する
+    And ワークスペースの assets/kiritan/icon.png が存在する
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_ScopeProject
+
+  Scenario: "--scope home" を指定すると assets がホームディレクトリ配下に配置される
+    Given "metan" のアセットを含む fake git リポジトリがある
+    And HOME が設定されている
+    When "vox-actor assets download --scope home <repoURL>" を実行する
+    Then 終了コード 0 で完了する
+    And "$HOME/.vox-actor/assets/metan/icon.png" が存在する
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_ScopeHome
+
+  Scenario: "--speaker" フラグを複数回指定すると指定したスピーカーのみダウンロードされる
+    Given "zundamon"、"metan"、"kiritan" の3件を含む fake git リポジトリがある
+    And ワークスペースが設定されている
+    When "vox-actor assets download --speaker zundamon --speaker metan <repoURL>" を実行する
+    Then 終了コード 0 で完了する
+    And assets/zundamon/icon.png と assets/metan/icon.png が存在する
+    And assets/kiritan/icon.png は存在しない
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_MultipleSpeakersRepeat
+
+  Scenario: "--speaker" フラグにカンマ区切りで複数スピーカーを指定するとそれらのみダウンロードされる
+    Given "zundamon"、"metan"、"kiritan" の3件を含む fake git リポジトリがある
+    And ワークスペースが設定されている
+    When "vox-actor assets download --speaker zundamon,metan <repoURL>" を実行する
+    Then 終了コード 0 で完了する
+    And assets/zundamon/icon.png と assets/metan/icon.png が存在する
+    And assets/kiritan/icon.png は存在しない
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_MultipleSpeakersComma
+
+  Scenario: "--force" フラグを付けると既存スピーカーを上書きして新しいファイルで置き換わる
+    Given ワークスペースの assets/zundamon/ に古いファイル "old.png" が存在する
+    And fake git リポジトリには "icon.png"（new-content）が登録されている
+    When "vox-actor assets download --force <repoURL>" を実行する
+    Then 終了コード 0 で完了する
+    And assets/zundamon/icon.png が存在する
+    And assets/zundamon/old.png は存在しない
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_Force_OverwritesExisting
+
+  Scenario: "--force" なしで既に存在するスピーカーをダウンロードしようとするとエラーになる
+    Given ワークスペースに assets/zundamon/ ディレクトリが既に存在する
+    And fake git リポジトリに "zundamon" が登録されている
+    When "vox-actor assets download <repoURL>" を実行する（--force なし）
+    Then 終了コードが 0 以外である
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_NoForce_ExistingSpeaker_ExitNonZero
+
+  # ─────────────────────────────────────────
+  # C. エラー系
+  # ─────────────────────────────────────────
+
+  Scenario: 存在しないリポジトリ URL を指定するとエラーになり stderr が出力される
+    Given ワークスペースが設定されている
+    When "vox-actor assets download file:///nonexistent/path/to/repo" を実行する
+    Then 終了コードが 0 以外である
+    And 標準エラー出力が空でない
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_InvalidRepoURL_ExitNonZero
+
+  Scenario: vox-actor-assets.json が存在しないリポジトリを指定するとエラーになる
+    Given vox-actor-assets.json を含まない fake git リポジトリがある
+    And ワークスペースが設定されている
+    When "vox-actor assets download <repoURL>" を実行する
+    Then 終了コードが 0 以外である
+    And 標準エラー出力が空でない
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_NoAssetsJSON_ExitNonZero
+
+  Scenario: vox-actor-assets.json が不正な JSON の場合エラーになる
+    Given "not-valid-json" という内容の vox-actor-assets.json を含む fake git リポジトリがある
+    And ワークスペースが設定されている
+    When "vox-actor assets download <repoURL>" を実行する
+    Then 終了コードが 0 以外である
+    And 標準エラー出力が空でない
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_InvalidJSON_ExitNonZero
+
+  Scenario: vox-actor-assets.json に記載されたアセットパスが存在しない場合エラーになる
+    Given vox-actor-assets.json に "zundamon" のパスが記載されているがそのパスにファイルがない fake git リポジトリがある
+    And ワークスペースが設定されている
+    When "vox-actor assets download <repoURL>" を実行する
+    Then 終了コードが 0 以外である
+    And 標準エラー出力が空でない
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_MissingAssetFile_ExitNonZero
+
+  # ─────────────────────────────────────────
+  # D. ログ
+  # ─────────────────────────────────────────
+
+  Scenario: 正常なダウンロード時に進捗ログとして "cloning" と "copying" が stderr に出力される
+    Given "zundamon" を含む fake git リポジトリがある
+    And ワークスペースが設定されている
+    When "vox-actor assets download <repoURL>" を実行する
+    Then 終了コード 0 で完了する
+    And 標準エラー出力に "cloning" と "copying" が含まれる
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_ProgressLogs
+
+  Scenario: "--verbose" フラグを付けると通常より多くのログ行が stderr に出力される
+    Given "zundamon" を含む fake git リポジトリがある
+    And ワークスペースが設定されている
+    When "--verbose" なしと "--verbose" ありでそれぞれ "vox-actor assets download <repoURL>" を実行する
+    Then 両方とも終了コード 0 で完了する
+    And "--verbose" ありのログ行数が "--verbose" なしより多い
+    # test: test/e2e/assets_test.go::TestAssetsE2E_Download_VerboseFlag_MoreLogs

--- a/docs/acceptance/cli/audio_check.feature
+++ b/docs/acceptance/cli/audio_check.feature
@@ -1,0 +1,17 @@
+Feature: vox-actor audio-check コマンド
+
+  Scenario: 予期しない位置引数を渡すと終了コード 2 になる
+    When "vox-actor audio-check unexpected" を実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/audio_check_test.go::TestAudioCheckE2E_UnexpectedArg_ExitCode2
+
+  Scenario: 存在しないフラグを渡すと終了コードが 0 以外になる
+    When "vox-actor audio-check --bogus" を実行する
+    Then 終了コードが 0 以外である
+    # test: test/e2e/audio_check_test.go::TestAudioCheckE2E_UnknownFlag_NonZeroExit
+
+  Scenario: "--help" フラグで使用方法と "--verbose" が表示される
+    When "vox-actor audio-check --help" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "audio-check" と "--verbose" が含まれる
+    # test: test/e2e/audio_check_test.go::TestAudioCheckE2E_Help_ExitZeroWithUsage

--- a/docs/acceptance/cli/config.feature
+++ b/docs/acceptance/cli/config.feature
@@ -1,0 +1,102 @@
+Feature: vox-actor config コマンド
+
+  Scenario: VOX_ACTOR_WORKSPACE 環境変数を設定して path.workspace を取得する
+    Given 環境変数 "VOX_ACTOR_WORKSPACE" に一時ディレクトリが設定されている
+    When "vox-actor config path.workspace" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が設定したワークスペースパスと一致する（1行＋改行）
+    # test: test/e2e/config_test.go::TestConfigE2E_PathWorkspace_WithEnv
+
+  Scenario: VOX_ACTOR_WORKSPACE 環境変数を設定して path.queue を取得する
+    Given 環境変数 "VOX_ACTOR_WORKSPACE" に一時ディレクトリが設定されている
+    When "vox-actor config path.queue" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が "<workspace>/queue" と一致する（1行＋改行）
+    # test: test/e2e/config_test.go::TestConfigE2E_PathQueue_WithEnv
+
+  Scenario: git リポジトリ内で VOX_ACTOR_WORKSPACE 未設定のとき path.workspace を取得する
+    Given 一時 git リポジトリが初期化されている
+    And 環境変数 "VOX_ACTOR_WORKSPACE" が空文字に設定されている
+    When そのリポジトリ内で "vox-actor config path.workspace" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が "<gitリポジトリルート>/.vox-actor" と一致する（1行＋改行）
+    # test: test/e2e/config_test.go::TestConfigE2E_PathWorkspace_InsideGitRepo
+
+  Scenario: git リポジトリ内で VOX_ACTOR_WORKSPACE 未設定のとき path.queue を取得する
+    Given 一時 git リポジトリが初期化されている
+    And 環境変数 "VOX_ACTOR_WORKSPACE" が空文字に設定されている
+    When そのリポジトリ内で "vox-actor config path.queue" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が "<gitリポジトリルート>/.vox-actor/queue" と一致する（1行＋改行）
+    # test: test/e2e/config_test.go::TestConfigE2E_PathQueue_InsideGitRepo
+
+  Scenario: VOX_ACTOR_WORKSPACE 環境変数を設定して path.tmp を取得する
+    Given 環境変数 "VOX_ACTOR_WORKSPACE" に一時ディレクトリが設定されている
+    When "vox-actor config path.tmp" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が "<workspace>/tmp" と一致する（1行＋改行）
+    # test: test/e2e/config_test.go::TestConfigE2E_PathTmp_WithEnv
+
+  Scenario: git リポジトリ内で VOX_ACTOR_WORKSPACE 未設定のとき path.tmp を取得する
+    Given 一時 git リポジトリが初期化されている
+    And 環境変数 "VOX_ACTOR_WORKSPACE" が空文字に設定されている
+    When そのリポジトリ内で "vox-actor config path.tmp" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が "<gitリポジトリルート>/.vox-actor/tmp" と一致する（1行＋改行）
+    # test: test/e2e/config_test.go::TestConfigE2E_PathTmp_InsideGitRepo
+
+  Scenario: git リポジトリ外で VOX_ACTOR_WORKSPACE 未設定のとき path.workspace を取得する
+    Given git リポジトリ外の一時ディレクトリにいる
+    And 環境変数 "VOX_ACTOR_WORKSPACE" が空文字に設定されている
+    When そのディレクトリ内で "vox-actor config path.workspace" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が "<カレントディレクトリ>/.vox-actor" と一致する（1行＋改行）
+    # test: test/e2e/config_test.go::TestConfigE2E_PathWorkspace_OutsideGitRepo
+
+  Scenario: git リポジトリ外で VOX_ACTOR_WORKSPACE 未設定のとき path.queue を取得する
+    Given git リポジトリ外の一時ディレクトリにいる
+    And 環境変数 "VOX_ACTOR_WORKSPACE" が空文字に設定されている
+    When そのディレクトリ内で "vox-actor config path.queue" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が "<カレントディレクトリ>/.vox-actor/queue" と一致する（1行＋改行）
+    # test: test/e2e/config_test.go::TestConfigE2E_PathQueue_OutsideGitRepo
+
+  Scenario: git リポジトリ外で VOX_ACTOR_WORKSPACE 未設定のとき path.tmp を取得する
+    Given git リポジトリ外の一時ディレクトリにいる
+    And 環境変数 "VOX_ACTOR_WORKSPACE" が空文字に設定されている
+    When そのディレクトリ内で "vox-actor config path.tmp" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が "<カレントディレクトリ>/.vox-actor/tmp" と一致する（1行＋改行）
+    # test: test/e2e/config_test.go::TestConfigE2E_PathTmp_OutsideGitRepo
+
+  Scenario: 未知のキーを指定すると終了コード 2 でエラーメッセージと有効キー一覧が出力される
+    When "vox-actor config path.unknown" を実行する
+    Then 終了コード 2 で完了する
+    And 標準出力が空である
+    And 標準エラー出力に "unknown key: path.unknown"、"path.queue"、"path.tmp"、"path.workspace" が含まれる
+    # test: test/e2e/config_test.go::TestConfigE2E_UnknownKey_ExitCode2
+
+  Scenario: PATH を空にして git が見つからない場合、終了コード 1 で stderr にエラーが出る
+    Given PATH が空に設定されている
+    And 環境変数 "VOX_ACTOR_WORKSPACE" が空文字に設定されている
+    When git リポジトリ外のディレクトリで "vox-actor config path.workspace" を実行する
+    Then 終了コード 1 で完了する
+    And 標準出力が空である
+    And 標準エラー出力が空でない
+    # test: test/e2e/config_test.go::TestConfigE2E_GitNotFound_ExitCode1
+
+  Scenario: 引数なしで "config" を実行すると終了コード 2 になる
+    When "vox-actor config" を実行する（引数なし）
+    Then 終了コード 2 で完了する
+    # test: test/e2e/config_test.go::TestConfigE2E_NoArgs_ExitCode2
+
+  Scenario: 引数が多すぎる場合に終了コード 2 になる
+    When "vox-actor config path.queue extra" を実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/config_test.go::TestConfigE2E_TooManyArgs_ExitCode2
+
+  Scenario: "config --help" は終了コード 0 で使用方法を表示する
+    When "vox-actor config --help" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "config"、"key"、"Usage:" が含まれる
+    # test: test/e2e/config_test.go::TestConfigE2E_Help_ExitZeroWithUsage

--- a/docs/acceptance/cli/e2e.feature
+++ b/docs/acceptance/cli/e2e.feature
@@ -1,0 +1,30 @@
+Feature: vox-actor CLI 共通動作
+
+  Scenario: "--version" フラグで "vox-actor version <文字列>" が1行だけ出力される
+    When "vox-actor --version" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "vox-actor version <バージョン文字列>" の形式の行がちょうど1行含まれる
+    # test: test/e2e/e2e_test.go::TestCLIVersion
+
+  Scenario: "--help" フラグでサブコマンド一覧が表示される
+    When "vox-actor --help" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "say"、"act"、"watch"、"config"、"audio-check" が含まれる
+    # test: test/e2e/e2e_test.go::TestCLIHelp_ListsSubcommands
+
+  Scenario: 引数なしで実行するとヘルプが表示される
+    When "vox-actor" を引数なしで実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "vox-actor" と "Usage:" が含まれる
+    # test: test/e2e/e2e_test.go::TestCLINoArgs_ShowsHelp
+
+  Scenario: 存在しないサブコマンドを指定すると終了コードが 0 以外で stderr が出力される
+    When "vox-actor unknown-cmd" を実行する
+    Then 終了コードが 0 以外である
+    And 標準エラー出力が空でない
+    # test: test/e2e/e2e_test.go::TestCLIUnknownSubcommand_NonZeroWithStderr
+
+  Scenario: 存在しないフラグを指定すると終了コードが 0 以外になる
+    When "vox-actor --no-such-flag" を実行する
+    Then 終了コードが 0 以外である
+    # test: test/e2e/e2e_test.go::TestCLIUnknownFlag_NonZero

--- a/docs/acceptance/cli/say.feature
+++ b/docs/acceptance/cli/say.feature
@@ -1,0 +1,180 @@
+Feature: vox-actor say コマンド
+
+  # ===== ドライラン基本動作 =====
+
+  Scenario: ドライランで発話テキストを渡すと合成完了・再生完了ログが出力される
+    When "vox-actor say --dry-run こんにちは" を実行する
+    Then 終了コード 0 で完了する
+    And stderr に "[dry run] synthesis completed" が含まれる
+    And stderr に "[dry run] playback completed" が含まれる
+    And stderr に "text=こんにちは" が含まれる
+    # test: test/e2e/say_test.go::TestSayE2E_DryRun_Basic
+
+  Scenario: ドライランでフラグを指定するとパラメータがプレイバックログに反映される
+    When "vox-actor say --dry-run --speaker 8 --speed 1.2 --pitch 0.1 --intonation 1.5 テスト" を実行する
+    Then 終了コード 0 で完了する
+    And "[dry run] playback completed" の行に "text=テスト", "speaker=8", "speed=1.2", "pitch=0.1", "intonation=1.5" が含まれる
+    # test: test/e2e/say_test.go::TestSayE2E_DryRun_Flags
+
+  Scenario: VOX_SPEAKER 環境変数でスピーカーを指定するとプレイバックログに反映される
+    Given 環境変数 VOX_SPEAKER=11 が設定されている
+    When "vox-actor say --dry-run 環境変数" を実行する
+    Then 終了コード 0 で完了する
+    And "playback completed" 行に "speaker=11" が含まれる
+    # test: test/e2e/say_test.go::TestSayE2E_DryRun_EnvVarVOXSpeaker
+
+  Scenario: ドライラン中は到達不能な VOX_ENGINE_URL を指定しても正常終了する
+    Given 環境変数 VOX_ENGINE_URL=http://example.invalid:50021 が設定されている
+    When "vox-actor say --dry-run エンジンURL" を実行する
+    Then 終了コード 0 で完了する
+    And stderr に "[dry run] playback completed" が含まれる
+    # test: test/e2e/say_test.go::TestSayE2E_DryRun_EnvVarVOXEngineURL_NotFailing
+
+  # ===== 引数バリデーション =====
+
+  Scenario Outline: 引数の数が不正な場合は終了コード 2 が返る
+    When <引数> で "vox-actor say" を実行する
+    Then 終了コード 2 で完了する
+
+    Examples:
+      | 引数             |
+      | 引数なし         |
+      | 引数が2つ以上    |
+    # test: test/e2e/say_test.go::TestSayE2E_ArgValidation_ExitCode2
+
+  # ===== 詳細ログ =====
+
+  Scenario: --verbose フラグを付けると通常より多くのログ行が出力される
+    Given "--dry-run 詳細ログ" でのベースライン行数を計測する
+    When "vox-actor say --dry-run --verbose 詳細ログ" を実行する
+    Then 終了コード 0 で完了する
+    And ログ行数がベースラインより多い
+    # test: test/e2e/say_test.go::TestSayE2E_Verbose_IncreasesLogs
+
+  # ===== VOICEVOX 実通信エラー =====
+
+  Scenario: VOICEVOX が 5xx を返すと非ゼロ終了コードで "500" または "audio" が stderr に出力される
+    Given VOICEVOX のスタブサーバーが常に 500 を返す
+    When "vox-actor say テスト" を VOX_ENGINE_URL に向けて実行する
+    Then 終了コードが非ゼロである
+    And stderr に "500" または "audio" が含まれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_RealComm_Voicevox5xx_NonZeroExit
+
+  Scenario: VOICEVOX への接続が失敗すると非ゼロ終了コードと stderr が出力される
+    Given 環境変数 VOX_ENGINE_URL=http://127.0.0.1:1 が設定されている
+    When "vox-actor say テスト" を実行する
+    Then 終了コードが非ゼロである
+    And stderr が空でない
+    # test: test/e2e/say_comm_test.go::TestSayE2E_RealComm_VoicevoxConnFailed_NonZeroExit
+
+  Scenario: VOICEVOX が /audio_query に不正 JSON を返すと非ゼロ終了コードと stderr が出力される
+    Given /audio_query が "not-json" を返すスタブサーバーを用意する
+    When "vox-actor say テスト" を VOX_ENGINE_URL に向けて実行する
+    Then 終了コードが非ゼロである
+    And stderr が空でない
+    # test: test/e2e/say_comm_test.go::TestSayE2E_RealComm_VoicevoxBadBody_NonZeroExit
+
+  # ===== viewer 連携 =====
+
+  Scenario: viewer が起動中の場合、/api/play に1回 POST して終了コード 0 が返る
+    Given フェイク viewer サーバーが起動しロックファイルが書き込まれている
+    When "vox-actor say こんにちは" を HOME に向けて実行する
+    Then 終了コード 0 で完了する
+    And /api/play への POST が1回だけ呼ばれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Viewer_POSTsAndExitsZero
+
+  Scenario: viewer がサイレントモードの場合、終了コード 0 かつ WARN ログが出力される
+    Given フェイク viewer がサイレントモード（理由: "test-reason"）で起動している
+    When "vox-actor say テスト" を HOME に向けて実行する
+    Then 終了コード 0 で完了する
+    And stderr の "viewer is in silent mode" 行が WARN レベルプレフィックス "!" で始まる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Viewer_SilentMode_Warns
+
+  Scenario: viewer と VOICEVOX の両方に到達できない場合、非ゼロ終了コードと "viewer not running" ログが出力される
+    Given ロックファイルが到達不能アドレス "127.0.0.1:1" を指している
+    And VOX_ENGINE_URL も "http://127.0.0.1:1" に設定する
+    When "vox-actor say --verbose テスト" を実行する
+    Then 終了コードが非ゼロである
+    And stderr に "viewer not running" が含まれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Viewer_Unreachable_FallbackLogged
+
+  Scenario: --dry-run 時は viewer への POST を行わない
+    Given フェイク viewer サーバーが起動している
+    When "vox-actor say --dry-run テスト" を HOME に向けて実行する
+    Then 終了コード 0 で完了する
+    And /api/play への POST が0回である
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Viewer_DryRun_NoPOST
+
+  Scenario: viewer 起動中は "viewer detected" ログが出力される
+    Given フェイク viewer サーバーが起動している
+    When "vox-actor say テスト" を HOME に向けて実行する
+    Then 終了コード 0 で完了する
+    And stderr に "viewer detected" が含まれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Viewer_Detected_LogMessage
+
+  # ===== 環境変数とフラグの優先順位 =====
+
+  Scenario: --speaker フラグが VOX_SPEAKER 環境変数より優先される
+    Given 環境変数 VOX_SPEAKER=10 が設定されている
+    When "vox-actor say --dry-run --speaker 5 テスト" を実行する
+    Then 終了コード 0 で完了する
+    And "playback completed" 行に "speaker=5" が含まれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Flag_SpeakerOverridesEnv
+
+  Scenario: --engine-url フラグが VOX_ENGINE_URL 環境変数より優先される
+    Given 環境変数 VOX_ENGINE_URL に到達不能アドレスを設定する
+    And --engine-url に 5xx を返すスタブサーバーの URL を指定する
+    When "vox-actor say --engine-url <stub_url> テスト" を実行する
+    Then 終了コードが非ゼロである
+    And stderr に "500" または "audio" が含まれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Flag_EngineURLOverridesEnv
+
+  Scenario: VOX_SPEAKER に不正な値を設定するとデフォルト値（speaker=3）にフォールバックする
+    Given 環境変数 VOX_SPEAKER=not-a-number が設定されている
+    When "vox-actor say --dry-run テスト" を実行する
+    Then 終了コード 0 で完了する
+    And "playback completed" 行に "speaker=3" が含まれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Env_VOXSpeakerInvalid_DefaultFallback
+
+  # ===== ヘルプ =====
+
+  Scenario: --help フラグで終了コード 0 かつ全フラグが表示される
+    When "vox-actor say --help" を実行する
+    Then 終了コード 0 で完了する
+    And stdout に "--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run" が含まれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Help_ExitZeroWithAllFlags
+
+  # ===== 空文字・境界値 =====
+
+  Scenario: 空文字列を渡してドライランすると終了コード 0 かつ "playback completed" が出力される
+    When "vox-actor say --dry-run ''" を実行する
+    Then 終了コード 0 で完了する
+    And stderr に "playback completed" が含まれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_EmptyString_DryRun_ExitsZero
+
+  Scenario Outline: 境界値パラメータを指定してドライランすると終了コード 0 が返る
+    When "vox-actor say --dry-run <フラグ> テスト" を実行する
+    Then 終了コード 0 で完了する
+
+    Examples:
+      | フラグ                      |
+      | --speaker -1               |
+      | --speed 999.0              |
+      | --pitch 1.0                |
+      | --intonation 999.0         |
+    # test: test/e2e/say_comm_test.go::TestSayE2E_BoundaryValues_DryRun_ExitsZero
+
+  # ===== シグナル処理 =====
+
+  Scenario: VOICEVOX 処理中に SIGINT を送ると 5 秒以内にプロセスが終了する
+    Given ハングするスタブ VOICEVOX サーバーを起動する
+    And "vox-actor say --engine-url <stub_url> テスト" をバックグラウンドで起動する
+    When 150ms 後に SIGINT を送る
+    Then 5 秒以内にプロセスが終了する
+    # test: test/e2e/say_comm_test.go::TestSayE2E_SIGINT_DuringVoicevox_Exits
+
+  Scenario: --verbose フラグで "say starting" デバッグ行にテキストが含まれる
+    When "vox-actor say --dry-run --verbose テスト内容" を実行する
+    Then 終了コード 0 で完了する
+    And stderr の "say starting" 行に "text=テスト内容" が含まれる
+    # test: test/e2e/say_comm_test.go::TestSayE2E_Verbose_ShowsSpecificDebugLogs

--- a/docs/acceptance/cli/script.feature
+++ b/docs/acceptance/cli/script.feature
@@ -1,0 +1,217 @@
+Feature: vox-actor script コマンド
+
+  # ─────────────────────────────────────────
+  # A. 基本的な書き出し挙動
+  # ─────────────────────────────────────────
+
+  Scenario: .jsonl ファイルを新規作成してテキストを書き込む
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/out.jsonl こんにちは" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルの "text" フィールドが "こんにちは" である
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Basic_JsonlCreate
+
+  Scenario: .json ファイルを新規作成してテキストを書き込む
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/out.json テスト" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルの "text" フィールドが "テスト" である
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Basic_JsonCreate
+
+  Scenario: .txt ファイルを新規作成してテキストを書き込む
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/out.txt テキスト本文" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルの内容が "テキスト本文" である
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Basic_TxtCreate
+
+  Scenario: 同じ .jsonl ファイルに2回追記すると2行になる
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/out.jsonl 1行目" を実行する
+    And "vox-actor script append <dir>/out.jsonl 2行目" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルが2行あり、1行目の "text" が "1行目"、2行目の "text" が "2行目" である
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Basic_Append
+
+  Scenario: 拡張子なしのパスを指定するとエラーになる
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/noext テスト" を実行する
+    Then 終了コードが 0 以外である
+    And 標準エラー出力に "no extension" が含まれる
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Basic_NoExtension
+
+  Scenario: サポート外の拡張子（.md）を指定するとエラーになる
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/out.md テスト" を実行する
+    Then 終了コードが 0 以外である
+    And 標準エラー出力に "unsupported" が含まれる
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Basic_UnsupportedExtension
+
+  Scenario: 存在しない親ディレクトリを指定するとエラーになる
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/nonexistent/out.jsonl テスト" を実行する
+    Then 終了コードが 0 以外である
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Basic_NoParentDir
+
+  # ─────────────────────────────────────────
+  # B. ボイスパラメータの反映
+  # ─────────────────────────────────────────
+
+  Scenario: ボイスパラメータを指定するとすべて出力に反映される
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append --speaker 5 --speed 1.2 --pitch 0.05 --intonation 1.5 <dir>/out.jsonl パラメータテスト" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルの "speaker" が 5、"speed" が 1.2、"pitch" が 0.05、"intonation" が 1.5 である
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_VoiceParams_Reflected
+
+  Scenario: ボイスパラメータを省略すると出力 JSON に含まれない（omitempty）
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/out.jsonl 省略テスト" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルに "speaker"、"speed"、"pitch"、"intonation" フィールドが存在しない
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_VoiceParams_Omitempty
+
+  Scenario: .txt 出力でボイスパラメータを指定すると警告ログが出る
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append --speaker 3 <dir>/out.txt テキスト警告" を実行する
+    Then 終了コード 0 で完了する
+    And 標準エラー出力に "text-format output cannot store voice parameters" が含まれる
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_VoiceParams_TxtWarn
+
+  # ─────────────────────────────────────────
+  # C. ディレクトリ書き出し
+  # ─────────────────────────────────────────
+
+  Scenario: 末尾にパス区切り文字を付けた既存ディレクトリを指定すると *_say.json が生成される
+    Given 既存の一時ディレクトリが存在する
+    When "vox-actor script append <dir>/ ディレクトリ指定" を実行する（末尾スラッシュあり）
+    Then 終了コード 0 で完了する
+    And ディレクトリ内に *_say.json ファイルが1つ生成され、"text" が "ディレクトリ指定" である
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Dir_TrailingSlash
+
+  Scenario: 末尾スラッシュなしで既存ディレクトリを指定すると *_say.json が生成される
+    Given 既存の一時ディレクトリが存在する
+    When "vox-actor script append <dir> 既存ディレクトリ" を実行する
+    Then 終了コード 0 で完了する
+    And ディレクトリ内に *_say.json ファイルが1つ生成される
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Dir_ExistingDir
+
+  Scenario: 末尾スラッシュ付きの新規ディレクトリを指定するとディレクトリが作成されて *_say.json が生成される
+    Given 存在しない新規サブディレクトリパスがある
+    When "vox-actor script append <newdir>/ 新規ディレクトリ" を実行する
+    Then 終了コード 0 で完了する
+    And 新規ディレクトリが作成される
+    And ディレクトリ内に *_say.json ファイルが1つ生成される
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Dir_CreateNew
+
+  # ─────────────────────────────────────────
+  # D. 引数バリデーション
+  # ─────────────────────────────────────────
+
+  Scenario Outline: 引数が不正なとき終了コード 2 を返す
+    When "vox-actor <args>" を実行する
+    Then 終了コード 2 で完了する
+
+    Examples:
+      | ケース名          | args                                      |
+      | 引数なし          | script append                             |
+      | ファイルのみ      | script append <dir>/out.jsonl             |
+      | 引数が多すぎる    | script append <dir>/out.jsonl a b         |
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_ArgValidation_ExitCode2
+
+  # ─────────────────────────────────────────
+  # E. ヘルプ / 親コマンド / 環境変数
+  # ─────────────────────────────────────────
+
+  Scenario: "script" のみ実行するとヘルプに "append" が含まれる
+    When "vox-actor script" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "append" が含まれる
+    # test: test/e2e/script_test.go::TestScriptE2E_Help_ScriptAlone
+
+  Scenario: "script append --help" でフラグ一覧が表示され、不要フラグが含まれない
+    When "vox-actor script append --help" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "--speaker"、"--speed"、"--pitch"、"--intonation"、"--verbose" が含まれる
+    And 標準出力に "--engine-url"、"--dry-run" が含まれない
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Help_Flags
+
+  Scenario: 環境変数 VOX_SPEAKER のみ設定してもフラグ未指定なら speaker フィールドは省略される
+    Given 環境変数 "VOX_SPEAKER=11" が設定されている
+    When "vox-actor script append <dir>/out.jsonl 環境変数" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルに "speaker" フィールドが存在しない
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_EnvVar_VOXSpeaker
+
+  # ─────────────────────────────────────────
+  # F. ログ内容
+  # ─────────────────────────────────────────
+
+  Scenario: 正常完了時に "output completed" ログが出力され path 属性を含む
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/out.jsonl ログテスト" を実行する
+    Then 終了コード 0 で完了する
+    And 標準エラー出力に "output completed" を含む行があり、その行に "path=" が含まれる
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Log_OutputCompleted
+
+  Scenario: --verbose フラグを付けると "output completed" ログが出力される
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append --verbose <dir>/out.jsonl 詳細ログ" を実行する
+    Then 終了コード 0 で完了する
+    And 標準エラー出力に "output completed" が含まれる
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Log_Verbose
+
+  # ─────────────────────────────────────────
+  # G. 文字エンコーディング / 特殊文字
+  # ─────────────────────────────────────────
+
+  Scenario: マルチバイト文字・絵文字を含むテキストが正しく書き込まれる
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/out.jsonl 日本語テスト🎉" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルの "text" フィールドが "日本語テスト🎉" である
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Encoding_Multibyte
+
+  Scenario: ダブルクォートやバックスラッシュを含む文字列が正しく書き込まれる
+    Given 一時ディレクトリが存在する
+    When ダブルクォートとバックスラッシュを含むテキストで "vox-actor script append" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルの "text" フィールドが元のテキストと一致する
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Encoding_SpecialChars
+
+  Scenario: 空文字列を指定すると "text" フィールドが空文字になる
+    Given 一時ディレクトリが存在する
+    When "vox-actor script append <dir>/out.jsonl 空文字" を実行する（テキストは空文字列）
+    Then 終了コード 0 で完了する
+    And 出力ファイルの "text" フィールドが空文字列である
+    # test: test/e2e/script_test.go::TestScriptAppendE2E_Encoding_EmptyText
+
+  # ─────────────────────────────────────────
+  # script write E2E テスト
+  # ─────────────────────────────────────────
+
+  Scenario: --json フラグで複数エントリを一括書き込みできる
+    Given 一時ディレクトリが存在する
+    When "vox-actor script write --json '[{"text":"おはようなのだ","speaker":3,"intonation":1.1},{"text":"今日もがんばるのだ","speaker":3,"speed":1.0}]' <dir>/out.jsonl" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルが2行あり、1行目の "text" が "おはようなのだ"・"speaker" が 3・"intonation" が 1.1・"speed" が省略、2行目の "text" が "今日もがんばるのだ"・"speed" が 1.0 である
+    # test: test/e2e/script_test.go::TestScriptWriteE2E_Basic
+
+  Scenario: script write は既存ファイルを上書きする
+    Given append で "古いセリフ" が書き込まれた .jsonl ファイルがある
+    When "vox-actor script write --json '[{"text":"新しいセリフ"}]' <dir>/out.jsonl" を実行する
+    Then 終了コード 0 で完了する
+    And 出力ファイルが1行のみで "text" が "新しいセリフ" である
+    # test: test/e2e/script_test.go::TestScriptWriteE2E_OverwritesExisting
+
+  Scenario: --json に不正な JSON を渡すと終了コード 2 を返す
+    Given 一時ディレクトリが存在する
+    When "vox-actor script write --json not-json <dir>/out.jsonl" を実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/script_test.go::TestScriptWriteE2E_InvalidJson_ExitCode2
+
+  Scenario: "script" のみ実行するとヘルプに "write" が含まれる
+    When "vox-actor script" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "write" が含まれる
+    # test: test/e2e/script_test.go::TestScriptE2E_Help_ContainsWrite

--- a/docs/acceptance/cli/speakers.feature
+++ b/docs/acceptance/cli/speakers.feature
@@ -1,0 +1,193 @@
+Feature: vox-actor speakers コマンド
+
+  # ─────────────────────────────────────────
+  # A. 親コマンド / ヘルプ / 引数バリデーション
+  # ─────────────────────────────────────────
+
+  Scenario: "speakers" のみ実行するとヘルプに "list" と "profile" が含まれる
+    When "vox-actor speakers" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "speakers"、"list"、"profile" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_NoSubcmd_ShowsHelp
+
+  Scenario: "speakers list --help" は終了コード 0 で完了する
+    When "vox-actor speakers list --help" を実行する
+    Then 終了コード 0 で完了する
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_ListHelp_ExitZero
+
+  Scenario: "speakers profile --help" は終了コード 0 で完了する
+    When "vox-actor speakers profile --help" を実行する
+    Then 終了コード 0 で完了する
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_ProfileHelp_ExitZero
+
+  Scenario: --id も --name も指定せずに "speakers profile" を実行するとエラーになる
+    Given ワークスペースが設定されている
+    When "vox-actor speakers profile" を実行する（フラグなし）
+    Then 終了コードが 0 以外である
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_ProfileNoFlags_ExitNonZero
+
+  Scenario: --id と --name を同時に指定すると "speakers profile" がエラーになる
+    Given ワークスペースが設定されている
+    When "vox-actor speakers profile --id zundamon --name ずんだもん" を実行する
+    Then 終了コードが 0 以外である
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_ProfileBothFlags_ExitNonZero
+
+  Scenario: "speakers list" に余分な位置引数を渡しても終了コード 0 で完了する
+    Given ワークスペースとホームディレクトリが設定されている
+    When "vox-actor speakers list extra-arg" を実行する
+    Then 終了コード 0 で完了する
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_ListExtraArg_ExitZero
+
+  # ─────────────────────────────────────────
+  # B. 一覧・プロフィール表示（実ファイル経由）
+  # ─────────────────────────────────────────
+
+  Scenario: assets ディレクトリが空のとき "speakers list" は空の JSON 配列を返す
+    Given ワークスペースとホームディレクトリが設定されている（assets なし）
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力が空の JSON 配列 "[]" である
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_EmptyAssetsDir_ReturnsEmptyArray
+
+  Scenario: 1件のスピーカーが存在するとき "speakers list" の出力にそのIDが含まれる
+    Given プロジェクト assets に "zundamon" のスピーカーが存在する
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "zundamon" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_OneSpeaker_InOutput
+
+  Scenario: 複数スピーカーが存在するとき "speakers list" はID昇順でソートして返す
+    Given プロジェクト assets に "zundamon"、"metan"、"kiritan" の3件が存在する
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 出力 JSON 配列が ID 昇順（kiritan → metan → zundamon）に並んでいる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_MultipleSpeakers_SortedByID
+
+  Scenario: スピーカーの名前が "speakers list" の出力に反映される
+    Given プロジェクト assets に名前 "ずんだもん" の "zundamon" が存在する
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "ずんだもん" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_SpeakerNameReflected
+
+  Scenario: "--id" でプロフィールを取得するとすべてのフィールドが返る
+    Given プロジェクト assets に profile 情報と description ファイルを持つ "zundamon" が存在する
+    When "vox-actor speakers profile --id zundamon" を実行する
+    Then 終了コード 0 で完了する
+    And 出力 JSON に "id"、"name"、"pronoun"、"description" フィールドが含まれ正しい値を持つ
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_Profile_ByID_AllFields
+
+  # ─────────────────────────────────────────
+  # C. 階層マージ・優先順位
+  # ─────────────────────────────────────────
+
+  Scenario: プロジェクトスコープのみのスピーカーが "speakers list" に返る
+    Given プロジェクト assets にのみ "zundamon" が存在する
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "zundamon" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_ProjectOnly_ReturnsSpeakers
+
+  Scenario: ホームスコープのみのスピーカーが "speakers list" に返る
+    Given ホーム assets にのみ "metan" が存在する
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "metan" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_HomeOnly_ReturnsSpeakers
+
+  Scenario: プロジェクトとホームの両方にスピーカーがあるとき双方が "speakers list" に返る
+    Given プロジェクト assets に "zundamon"、ホーム assets に "metan" が存在する
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "zundamon" と "metan" の両方が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_ProjectAndHome_ReturnsBoth
+
+  Scenario: 同じIDのスピーカーがプロジェクトとホームにある場合、プロジェクト側が優先される（list）
+    Given プロジェクト assets に名前 "プロジェクト版" の "shared"、ホーム assets に名前 "ホーム版" の "shared" が存在する
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 出力 JSON 配列が1件で名前が "プロジェクト版" である
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_SameID_ProjectPriority
+
+  Scenario: 同じIDのスピーカーがプロジェクトとホームにある場合、プロジェクト側が優先される（profile）
+    Given プロジェクト assets に名前 "プロジェクト版" の "shared"、ホーム assets に名前 "ホーム版" の "shared" が存在する
+    When "vox-actor speakers profile --id shared" を実行する
+    Then 終了コード 0 で完了する
+    And 出力 JSON の "name" が "プロジェクト版" である
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_Profile_SameID_ProjectPriority
+
+  # ─────────────────────────────────────────
+  # D. profile --name 検索
+  # ─────────────────────────────────────────
+
+  Scenario: --name で一意のスピーカー名を検索するとプロフィールが返る
+    Given プロジェクト assets に名前 "ずんだもん" の "zundamon" が存在する
+    When "vox-actor speakers profile --name ずんだもん" を実行する
+    Then 終了コード 0 で完了する
+    And 標準出力に "zundamon" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_Profile_ByName_UniqueMatch_ReturnsProfile
+
+  Scenario: --name で同名のスピーカーが複数マッチするとエラーになりIDが stderr に含まれる
+    Given プロジェクト assets に同じ名前 "重複名前" を持つ "char1" と "char2" が存在する
+    When "vox-actor speakers profile --name 重複名前" を実行する
+    Then 終了コードが 0 以外である
+    And 標準エラー出力に "char1" または "char2" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_Profile_ByName_DuplicateName_ExitNonZero
+
+  Scenario: --name で存在しないスピーカー名を検索するとエラーになる
+    Given assets が空のワークスペースがある
+    When "vox-actor speakers profile --name 存在しない名前" を実行する
+    Then 終了コードが 0 以外である
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_Profile_ByName_NotFound_ExitNonZero
+
+  # ─────────────────────────────────────────
+  # E. profile の description ファイル
+  # ─────────────────────────────────────────
+
+  Scenario: descriptionPath に指定されたファイルが存在する場合、その内容が "description" フィールドに返る
+    Given プロジェクト assets に "descriptionPath: character.md" を持つ "zundamon" と実際のファイルが存在する
+    When "vox-actor speakers profile --id zundamon" を実行する
+    Then 終了コード 0 で完了する
+    And 出力 JSON の "description" フィールドがファイルの内容と一致する
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_Profile_DescriptionFileExists_InOutput
+
+  Scenario: descriptionPath に指定されたファイルが存在しない場合、"description" が空文字で警告が出る
+    Given プロジェクト assets に "descriptionPath: nonexistent.md" を持つ "zundamon" が存在する（ファイルなし）
+    When "vox-actor speakers profile --id zundamon" を実行する
+    Then 終了コード 0 で完了する（警告付き）
+    And 出力 JSON の "description" フィールドが空文字である
+    And 標準エラー出力に "nonexistent.md" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_Profile_DescriptionFileMissing_EmptyDescriptionWithWarning
+
+  # ─────────────────────────────────────────
+  # F. 異常系・エラーハンドリング
+  # ─────────────────────────────────────────
+
+  Scenario: assets ディレクトリ自体が存在しない場合、"speakers list" は空リストを返す
+    Given ワークスペースとホームディレクトリは設定されているが assets ディレクトリが存在しない
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 出力 JSON 配列が空である
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_AssetsDirMissing_EmptyList
+
+  Scenario: speaker.json が存在しないスピーカーディレクトリがある場合、警告を出してスキップする
+    Given プロジェクト assets に "zundamon" ディレクトリが存在するが speaker.json がない
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 出力 JSON 配列が空である
+    And 標準エラー出力に警告として "zundamon" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_SpeakerJSONMissing_WarningAndSkip
+
+  Scenario: speaker.json が不正な JSON の場合、警告を出してスキップする
+    Given プロジェクト assets の "zundamon" の speaker.json が "{invalid json}" である
+    When "vox-actor speakers list" を実行する
+    Then 終了コード 0 で完了する
+    And 出力 JSON 配列が空である
+    And 標準エラー出力に警告として "zundamon" が含まれる
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_List_SpeakerJSONInvalid_WarningAndSkip
+
+  Scenario: 存在しない ID で "speakers profile" を実行するとエラーになる
+    Given assets が空のワークスペースがある
+    When "vox-actor speakers profile --id nonexistent" を実行する
+    Then 終了コードが 0 以外である
+    # test: test/e2e/speakers_test.go::TestSpeakersE2E_Profile_ByID_NotFound_ExitNonZero

--- a/docs/acceptance/cli/watch.feature
+++ b/docs/acceptance/cli/watch.feature
@@ -1,0 +1,307 @@
+Feature: vox-actor watch コマンド
+
+  # ===== Group A: 基本的なファイル監視とファイル後処理 =====
+
+  Scenario: ドライランでファイルを検知すると再生完了後に done/ へ移動する
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When ディレクトリに .jsonl ファイルを書き込む
+    Then "playback completed" ログが "[dry run]" を含む行として出力される
+    And ファイルが done/ サブディレクトリに移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_DryRun_DoneMove
+
+  Scenario: --delete フラグ使用時は処理済みファイルを削除し done/ は作成しない
+    Given テンポラリディレクトリで watch を --dry-run --delete で起動する
+    And "watching directory" ログが出るまで待機する
+    When ディレクトリに .jsonl ファイルを書き込む
+    Then "playback completed" ログが出力される
+    And ファイルが削除される
+    And done/ ディレクトリは作成されない
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_DryRun_DeleteMode
+
+  Scenario: --queue フラグで VOX_ACTOR_WORKSPACE/queue ディレクトリが自動作成され処理される
+    Given 環境変数 VOX_ACTOR_WORKSPACE にワークスペースを設定して --queue --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    Then queue ディレクトリが自動作成されている
+    When queue ディレクトリに .jsonl ファイルを書き込む
+    Then "playback completed" ログが出力される
+    And ファイルが done/ に移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_Queue_AutoCreatesAndProcesses
+
+  # ===== Group A: 引数バリデーション =====
+
+  Scenario Outline: 不正な引数を渡すと終了コード 2 と stderr が返る
+    When <コマンド> を実行する
+    Then 終了コード 2 で完了する
+    And stderr が空でない
+
+    Examples:
+      | コマンド                                                    |
+      | watch --queue --dry-run <ディレクトリパス>（位置引数あり） |
+      | watch --stream <dir>（廃止済みフラグ）                      |
+      | watch --stream-addr 0.0.0.0:9090 <dir>（廃止済みフラグ）   |
+    # test: test/e2e/watch_test.go::TestWatchE2E_UsageError_ExitCode2
+
+  Scenario: 引数なしで実行すると非ゼロ終了コードが返る
+    When "vox-actor watch" を引数なしで実行する
+    Then 終了コードが非ゼロである
+    # test: test/e2e/watch_test.go::TestWatchE2E_NoArgs_NonZero
+
+  # ===== Group B: ファイル形式ごとの処理 =====
+
+  Scenario: .txt ファイルはファイル全体が1スクリプトとして処理される
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When ディレクトリに複数行の .txt ファイルを書き込む
+    Then "playback completed" が1回だけ出力される
+    And ファイルが done/ に移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_TxtFile_DryRun_SingleScript
+
+  Scenario: .json ファイルの各パラメータがプレイバックログに反映される
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When パラメータ付き .json ファイルをディレクトリに書き込む
+    Then "playback completed" の行に "text=こんにちは", "speaker=11", "speed=1.2", "pitch=0.1", "intonation=1.5" が含まれる
+    And ファイルが done/ に移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_JsonFile_DryRun_OverrideParams
+
+  Scenario: .jsonl ファイルの各行が独立したスクリプトとして順番に処理される
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When 3行の .jsonl ファイルをディレクトリに書き込む
+    Then "playback completed" が3回出力される
+    And テキストの出力順が "いちぎょうめ → にぎょうめ → さんぎょうめ" である
+    And ファイルが done/ に移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_JsonlFile_DryRun_MultipleScripts
+
+  Scenario: 不正な JSON ファイルはエラーログを出力して done/ に移動し、監視を継続する
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When 不正 JSON ファイルをディレクトリに書き込む
+    Then "read error" ログが出力される
+    And 不正ファイルが done/ に移動する
+    When 続けて有効な .txt ファイルをディレクトリに書き込む
+    Then "playback completed" ログが出力される
+    And 有効ファイルも done/ に移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_InvalidJson_ErrorThenContinues
+
+  Scenario: サポート外の拡張子（.md）はプレーンテキストとして処理される
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When .md ファイルをディレクトリに書き込む
+    Then "playback completed" ログが出力される
+    And ファイルが done/ に移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_UnsupportedExtension_ProcessedAsText
+
+  Scenario: 空ファイルは "playback completed" を出力せずに done/ に移動する
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When 空の .txt ファイルをディレクトリに書き込む
+    Then ファイルが done/ に移動する
+    And stderr に "playback completed" は含まれない
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_EmptyFile_MovedToDone
+
+  # ===== Group C: 複数ディレクトリ並列監視 =====
+
+  Scenario: 複数ディレクトリを指定すると各ディレクトリの "watching directory" ログが出力される
+    Given 2つのテンポラリディレクトリで watch を --dry-run で起動する
+    Then "watching directory" ログが2回出力される
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_MultipleDir_WatchingLogs
+
+  Scenario: 複数ディレクトリに書き込んだファイルが両方処理される
+    Given 2つのテンポラリディレクトリで watch を --dry-run で起動する
+    And 両ディレクトリの "watching directory" ログが出るまで待機する
+    When 各ディレクトリに .txt ファイルを書き込む
+    Then "playback completed" が2回出力される
+    And 各ファイルがそれぞれの done/ に移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_MultipleDir_BothProcessed
+
+  Scenario: 複数ディレクトリを監視すると各ディレクトリに done/ が作成される
+    Given 2つのテンポラリディレクトリで watch を --dry-run で起動する
+    And 両ディレクトリの "watching directory" ログが出るまで待機する
+    When 各ディレクトリに .txt ファイルを書き込む
+    Then 各ファイルがそれぞれのディレクトリの done/ に移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_MultipleDir_EachDoneCreated
+
+  # ===== Group D: 引数バリデーション（パス系） =====
+
+  Scenario: ファイルパス（ディレクトリでない）を指定すると終了コード 2 が返る
+    Given 空のファイルを作成する
+    When "vox-actor watch --dry-run <file_path>" を実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_FilePath_ExitCode2
+
+  Scenario: 存在しないパスを指定すると終了コード 2 が返る
+    When "vox-actor watch --dry-run /nonexistent/path/12345" を実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_NonExistentPath_ExitCode2
+
+  Scenario: 複数パスのうち1つが存在しない場合、終了コード 2 が返る
+    Given テンポラリディレクトリと存在しないパスを用意する
+    When "vox-actor watch --dry-run <valid_dir> /nonexistent/path/12345" を実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_MultiplePathsOneMissing_ExitCode2
+
+  # ===== Group E: フラグと環境変数の優先順位 =====
+
+  Scenario: --speaker フラグが VOX_SPEAKER 環境変数より優先される
+    Given 環境変数 VOX_SPEAKER=10 が設定されている
+    And テンポラリディレクトリで watch を --dry-run --speaker 5 で起動する
+    And "watching directory" ログが出るまで待機する
+    When ディレクトリに .txt ファイルを書き込む
+    Then "playback completed" 行に "speaker=5" が含まれる
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_Flag_SpeakerOverridesEnv
+
+  Scenario: --engine-url フラグが VOX_ENGINE_URL 環境変数より優先され、5xx サーバーに接続して非ゼロ終了する
+    Given 環境変数 VOX_ENGINE_URL に到達不能アドレスを設定する
+    And --engine-url に 5xx を返すスタブサーバーの URL を指定して watch を起動する
+    Then watch プロセスが 10 秒以内に終了する
+    And 終了コードが非ゼロである
+    And stderr に "500" または "audio" が含まれる
+    # test: test/e2e/watch_test.go::TestWatchE2E_Flag_EngineURLOverridesEnv
+
+  Scenario: VOX_SPEAKER に不正な値を設定するとデフォルト値（speaker=3）にフォールバックする
+    Given 環境変数 VOX_SPEAKER=not-a-number が設定されている
+    And テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When ディレクトリに .txt ファイルを書き込む
+    Then "playback completed" 行に "speaker=3" が含まれる
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_Env_VOXSpeakerInvalid_DefaultFallback
+
+  Scenario: .jsonl 各行パラメータがプレイバックログに反映される（ドライラン）
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When パラメータ付き .jsonl ファイルをディレクトリに書き込む
+    Then "playback completed" 行に "speaker=11", "speed=1.2", "pitch=0.1", "intonation=1.5" が含まれる
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_JsonlPerLineOverride_DryRun
+
+  # ===== Group F: ライフサイクル / シグナル =====
+
+  Scenario: 監視中に SIGINT を送ると 5 秒以内に終了コード 0 で正常終了する
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When SIGINT を送る
+    Then 5 秒以内にプロセスが終了する
+    And 終了コードが 0 である
+    # test: test/e2e/watch_test.go::TestWatchE2E_SIGINT_GracefulShutdown
+
+  # ===== Group G: ヘルプ / 境界 =====
+
+  Scenario: --help フラグで終了コード 0 かつ主要フラグが表示される
+    When "vox-actor watch --help" を実行する
+    Then 終了コード 0 で完了する
+    And stdout に "--delete", "--queue", "--dry-run", "--speaker", "--engine-url" が含まれる
+    # test: test/e2e/watch_test.go::TestWatchE2E_Help_ExitZero
+
+  Scenario: done/ に同名ファイルが存在する場合、タイムスタンプ付きリネームで両ファイルが残る
+    Given done/ ディレクトリに既存の "a.txt" を作成する
+    And テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When 同名の "a.txt" をディレクトリに書き込む
+    Then "playback completed" ログが出力される
+    And 新しいファイルが done/ に移動する
+    And done/ に少なくとも2つのファイルが存在する（既存 + タイムスタンプ付きリネーム）
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_DoneCollision_TimestampRename
+
+  Scenario: done/ ディレクトリ内のファイルは監視対象外である
+    Given done/ ディレクトリに既存ファイルを作成する
+    And テンポラリディレクトリで watch を --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When 2秒間待機する
+    Then done/ 内の既存ファイルがそのまま残っている
+    And stderr に "file detected" が含まれない
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_DoneDir_NotMonitored
+
+  # ===== Group H: ログ内容 =====
+
+  Scenario: --verbose フラグで "watch mode starting" デバッグログが出力される
+    Given テンポラリディレクトリで watch を --dry-run --verbose で起動する
+    And "watching directory" ログが出るまで待機する
+    When ディレクトリに .txt ファイルを書き込む
+    Then "playback completed" ログが出力される
+    And stderr に "watch mode starting" が含まれる
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_Verbose_DebugLogs
+
+  Scenario: "watching directory" ログにディレクトリパスが含まれる
+    Given テンポラリディレクトリで watch を --dry-run で起動する
+    Then "watching directory" ログにディレクトリパスが含まれる
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_WatchingDirectoryLog
+
+  Scenario: --verbose フラグで "file detected" ログにファイル名が含まれる
+    Given テンポラリディレクトリで watch を --dry-run --verbose で起動する
+    And "watching directory" ログが出るまで待機する
+    When "detected.txt" をディレクトリに書き込む
+    Then "file detected" ログに "detected.txt" が含まれる
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_FileDetectedLog
+
+  # ===== Group I: --queue 系の追加検証 =====
+
+  Scenario: --queue --delete の組み合わせで処理済みファイルが削除され done/ は作成されない
+    Given 環境変数 VOX_ACTOR_WORKSPACE にワークスペースを設定して --queue --delete --dry-run で起動する
+    And "watching directory" ログが出るまで待機する
+    When queue ディレクトリに .txt ファイルを書き込む
+    Then "playback completed" ログが出力される
+    And ファイルが削除される
+    And done/ ディレクトリは作成されない
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_test.go::TestWatchE2E_Queue_Delete_Combination
+
+  # ===== VOICEVOX 実通信エラー =====
+
+  Scenario: ヘルスチェックで VOICEVOX が 5xx を返すと非ゼロ終了コードで終了する
+    Given VOICEVOX のスタブサーバーが常に 500 を返す
+    When watch を VOX_ENGINE_URL に向けて起動する
+    Then watch プロセスが 10 秒以内に終了する
+    And 終了コードが非ゼロである
+    And stderr が空でない
+    # test: test/e2e/watch_comm_test.go::TestWatchE2E_RealComm_HealthCheck5xx_ExitsNonZero
+
+  Scenario: ヘルスチェックで VOICEVOX への接続が失敗すると非ゼロ終了コードで終了する
+    Given 環境変数 VOX_ENGINE_URL=http://127.0.0.1:1 が設定されている
+    When watch を起動する
+    Then watch プロセスが 10 秒以内に終了する
+    And 終了コードが非ゼロである
+    # test: test/e2e/watch_comm_test.go::TestWatchE2E_RealComm_HealthCheckConnFailed_ExitsNonZero
+
+  Scenario: ヘルスチェック成功後に音声クエリが失敗してもエラーを記録して監視を継続する
+    Given ヘルスチェックは通過し /audio_query が 500 を返すスタブサーバーを用意する
+    And 音声デバイスが存在する環境であること（skipIfNoAudioDevice）
+    When watch を起動して "watching directory" ログが出るまで待機する
+    And ファイルを書き込む
+    Then "create query error" ログが出力される
+    And ファイルが done/ に移動する
+    When さらにもう1つファイルを書き込む
+    Then 再び "create query error" ログが出力され、そのファイルも done/ に移動する
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_comm_test.go::TestWatchE2E_RealComm_QueryFails_MonitoringContinues
+
+  Scenario: /audio_query と /synthesis エンドポイントが呼ばれて合成パイプラインが実行される
+    Given /audio_query と /synthesis が正常レスポンスを返すスタブサーバーを用意する
+    And 音声デバイスが存在する環境であること（skipIfNoAudioDevice）
+    When watch を起動して "watching directory" ログが出るまで待機する
+    And ファイルを書き込む
+    Then /audio_query が少なくとも1回呼ばれる
+    And /synthesis が少なくとも1回呼ばれる
+    And stderr に "create query error" や "synthesize error" が含まれない
+    And SIGTERM 送信後に終了コード 0 で完了する
+    # test: test/e2e/watch_comm_test.go::TestWatchE2E_RealComm_SynthPipeline_Invoked

--- a/docs/acceptance/viewer/backend/viewer.feature
+++ b/docs/acceptance/viewer/backend/viewer.feature
@@ -1,0 +1,116 @@
+Feature: viewer バックエンド 起動・ステータス・インデックス・viewer-check
+
+  # ── viewer_test.go ──────────────────────────────────────────────
+
+  Scenario: /api/status エンドポイントが JSON を返す
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    Then 標準エラーに "stream server listening" が出力される
+    And ログから addr フィールドが抽出できる
+    When GET /api/status を送信する
+    Then ステータスコード 200 が返る
+    And レスポンスボディが JSON である
+    And JSON に "silent" フィールドが含まれる
+    And SIGTERM 送信後に終了コード 0 で終了する
+    # test: test/e2e/viewer_test.go::TestViewerE2E_StatusEndpoint
+
+  Scenario Outline: 不正なポート番号を指定すると終了コード 2 が返る
+    Given vox-actor バイナリがビルド済みである
+    When "vox-actor viewer --port <port>" を実行する
+    Then 終了コード 2 が返る
+    And 標準エラーが空でない
+
+    Examples:
+      | port  |
+      | 0     |
+      | 99999 |
+    # test: test/e2e/viewer_test.go::TestViewerE2E_InvalidPort_ReturnsUsageError
+
+  Scenario: /api/history が起動後に追記されたエントリを返す
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    And 一時ディレクトリを HOME・VOX_ACTOR_WORKSPACE に設定している
+    When "vox-actor viewer --port <port>" を起動する
+    Then 標準エラーに "stream server listening" が出力される
+    When viewer 起動後に今日の日付の JSONL 履歴ファイルにエントリを追記する
+    And GET /api/history を送信する
+    Then ステータスコード 200 が返る
+    And レスポンスボディが JSON であり entries 配列が 1 件である
+    And エントリの text が "起動後追記テキスト" である
+    And SIGTERM 送信後に終了コード 0 で終了する
+    # test: test/e2e/viewer_test.go::TestViewerE2E_APIHistory_ReturnsUpdatedHistory
+
+  # ── viewer_check_test.go ─────────────────────────────────────────
+
+  Scenario: viewer-check に予期しない引数を渡すと終了コード 2 が返る
+    Given vox-actor バイナリがビルド済みである
+    When "vox-actor viewer-check unexpected" を実行する
+    Then 終了コード 2 が返る
+    # test: test/e2e/viewer_check_test.go::TestViewerCheckE2E_UnexpectedArg_ExitCode2
+
+  Scenario: viewer-check に未知のフラグを渡すと非ゼロで終了する
+    Given vox-actor バイナリがビルド済みである
+    When "vox-actor viewer-check --bogus" を実行する
+    Then 終了コードが 0 以外である
+    # test: test/e2e/viewer_check_test.go::TestViewerCheckE2E_UnknownFlag_NonZeroExit
+
+  Scenario: viewer-check --help がゼロ終了し使用方法を出力する
+    Given vox-actor バイナリがビルド済みである
+    When "vox-actor viewer-check --help" を実行する
+    Then 終了コード 0 が返る
+    And 標準出力に "viewer-check" が含まれる
+    And 標準出力に "--verbose" が含まれる
+    # test: test/e2e/viewer_check_test.go::TestViewerCheckE2E_Help_ExitZeroWithUsage
+
+  Scenario: viewer が起動していない環境では viewer-check が非ゼロで終了する
+    Given vox-actor バイナリがビルド済みである
+    And viewer プロセスが起動していない
+    When "vox-actor viewer-check" を実行する
+    Then 終了コードが 0 以外である（viewer が起動中の環境では 0 になる場合がある）
+    # test: test/e2e/viewer_check_test.go::TestViewerCheckE2E_NoViewer_NonZeroExit
+
+  # ── viewer_index_test.go ─────────────────────────────────────────
+
+  Scenario: GET / がステータスコード 200 を返す
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET / を送信する
+    Then ステータスコード 200 が返る
+    # test: test/e2e/viewer_index_test.go::TestViewerE2E_Index_StatusCode
+
+  Scenario: GET / の Content-Type が text/html を含む
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET / を送信する
+    Then レスポンスヘッダの Content-Type が "text/html" を含む
+    # test: test/e2e/viewer_index_test.go::TestViewerE2E_Index_ContentType
+
+  Scenario: index.html がハッシュ付きアセットを参照し各アセットが 200 を返す
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET / を送信する
+    Then レスポンスボディに "/assets/<ハッシュ>..." 形式のアセットパスが 1 件以上含まれる
+    And 各アセットパスへの GET がステータスコード 200 を返す
+    # test: test/e2e/viewer_index_test.go::TestViewerE2E_Index_HashedAssets
+
+  Scenario: index.html が必須文字列を含む
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET / を送信する
+    Then レスポンスボディに "<!DOCTYPE html>" が含まれる
+    And レスポンスボディに 'id="root"' が含まれる
+    And レスポンスボディに "vox-actor" が含まれる
+    # test: test/e2e/viewer_index_test.go::TestViewerE2E_Index_KeyStrings
+
+  Scenario: 存在しないパスへの GET が 404 を返す
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET /unknown-path を送信する
+    Then ステータスコード 404 が返る
+    # test: test/e2e/viewer_index_test.go::TestViewerE2E_Index_UnknownPath

--- a/docs/acceptance/viewer/backend/viewer_assets.feature
+++ b/docs/acceptance/viewer/backend/viewer_assets.feature
@@ -1,0 +1,86 @@
+Feature: viewer 静的アセット・画像配信
+
+  # ── フロントエンドハッシュ付きアセット（viewer_assets_test.go） ──────────────
+
+  Background:
+    Given viewer が起動してHTTPサーバーが待ち受け中である
+
+  Scenario: ハッシュ付きフロントエンドアセットに 200 が返る
+    Given index.html にハッシュ付きアセットパス（/assets/<hash>.js|css）が含まれる
+    When そのアセットパスに GET リクエストを送る
+    Then HTTP ステータス 200 が返る
+    And レスポンスボディが空でない
+    # test: test/e2e/viewer_assets_test.go::TestViewerE2E_Assets_Hashed_200
+
+  Scenario: ハッシュ付きフロントエンドアセットに長期キャッシュヘッダーが付与される
+    Given index.html にハッシュ付きアセットパスが含まれる
+    When そのアセットパスに GET リクエストを送る
+    Then レスポンスヘッダー Cache-Control が "public, max-age=31536000, immutable" である
+    # test: test/e2e/viewer_assets_test.go::TestViewerE2E_Assets_Hashed_CacheControl
+
+  Scenario: ハッシュ付き JS アセットの Content-Type に "javascript" が含まれる
+    Given index.html に .js アセットパスが少なくとも1つ含まれる
+    When その .js アセットパスに GET リクエストを送る
+    Then レスポンスヘッダー Content-Type に "javascript" が含まれる
+    # test: test/e2e/viewer_assets_test.go::TestViewerE2E_Assets_Hashed_ContentType_JS
+
+  Scenario: ハッシュ付き CSS アセットの Content-Type に "text/css" が含まれる
+    Given index.html に .css アセットパスが含まれる（ない場合はスキップ）
+    When その .css アセットパスに GET リクエストを送る
+    Then レスポンスヘッダー Content-Type に "text/css" が含まれる
+    # test: test/e2e/viewer_assets_test.go::TestViewerE2E_Assets_Hashed_ContentType_CSS
+
+  Scenario: 存在しないハッシュ付きアセットに 404 が返る
+    When "/assets/nonexistent-abc12345.js" に GET リクエストを送る
+    Then HTTP ステータス 404 が返る
+    # test: test/e2e/viewer_assets_test.go::TestViewerE2E_Assets_NotFound_404
+
+  Scenario: ハッシュ付きフロントエンドアセットとキャラクター画像が共存して両方配信される
+    Given VOX_ACTOR_WORKSPACE/assets/zundamon/face.png が配置されている
+    When ハッシュ付きアセットパスに GET リクエストを送る
+    Then HTTP ステータス 200 が返る
+    When "/assets/images/zundamon/face.png" に GET リクエストを送る
+    Then HTTP ステータス 200 が返る
+    # test: test/e2e/viewer_assets_test.go::TestViewerE2E_Assets_RoutingMix
+
+  # ── キャラクター画像（viewer_images_test.go） ────────────────────────────────
+
+  Scenario: プロジェクト assets ディレクトリの画像を 200 で取得できる
+    Given VOX_ACTOR_WORKSPACE/assets/zundamon/face.png が配置されている
+    When "/assets/images/zundamon/face.png" に GET リクエストを送る
+    Then HTTP ステータス 200 が返る
+    And レスポンスボディがファイルの内容と一致する
+    # test: test/e2e/viewer_images_test.go::TestViewerE2E_Image_ProjectAssets_200
+
+  Scenario: HOME assets ディレクトリの画像を 200 で取得できる
+    Given "${HOME}/.vox-actor/assets/metan/face.png" が配置されている
+    When "/assets/images/metan/face.png" に GET リクエストを送る
+    Then HTTP ステータス 200 が返る
+    And レスポンスボディがファイルの内容と一致する
+    # test: test/e2e/viewer_images_test.go::TestViewerE2E_Image_HomeAssets_200
+
+  Scenario: 同じキャラクターIDがプロジェクトとHOMEの両方にある場合プロジェクトが優先される
+    Given VOX_ACTOR_WORKSPACE/assets/zundamon/face.png にプロジェクト用コンテンツが配置されている
+    And "${HOME}/.vox-actor/assets/zundamon/face.png" にHOME用コンテンツが配置されている
+    When "/assets/images/zundamon/face.png" に GET リクエストを送る
+    Then HTTP ステータス 200 が返る
+    And レスポンスボディがプロジェクト側のコンテンツと一致する
+    # test: test/e2e/viewer_images_test.go::TestViewerE2E_Image_ProjectPriorityOverHome
+
+  Scenario: 存在しないキャラクターIDの画像に 404 が返る
+    Given VOX_ACTOR_WORKSPACE/assets/zundamon/face.png が配置されている
+    When "/assets/images/nonexistent-char/face.png" に GET リクエストを送る
+    Then HTTP ステータス 404 が返る
+    # test: test/e2e/viewer_images_test.go::TestViewerE2E_Image_NotFound_404
+
+  Scenario: パストラバーサル（../）を含む画像リクエストが拒否される
+    Given VOX_ACTOR_WORKSPACE/assets/zundamon/face.png が配置されている
+    When "/assets/images/zundamon/../../../etc/passwd" に GET リクエストを送る
+    Then HTTP ステータスが 200 以外である
+    # test: test/e2e/viewer_images_test.go::TestViewerE2E_Image_PathTraversal_Rejected
+
+  Scenario: assets ディレクトリが存在しない場合に画像リクエストで 404 が返る
+    Given プロジェクトにも HOME にも assets ディレクトリが存在しない
+    When "/assets/images/zundamon/face.png" に GET リクエストを送る
+    Then HTTP ステータス 404 が返る
+    # test: test/e2e/viewer_images_test.go::TestViewerE2E_Image_NoAssetsDir_404

--- a/docs/acceptance/viewer/backend/viewer_characters.feature
+++ b/docs/acceptance/viewer/backend/viewer_characters.feature
@@ -1,0 +1,60 @@
+Feature: viewer キャラクター一覧 API（GET /api/characters）
+
+  Background:
+    Given viewer が起動してHTTPサーバーが待ち受け中である
+
+  Scenario: assets ディレクトリが存在しない場合は enabled=false で空リストが返る
+    Given プロジェクトにも HOME にも assets ディレクトリが存在しない
+    When GET /api/characters にリクエストする
+    Then HTTP ステータス 200 が返る
+    And レスポンス JSON の "enabled" が false である
+    And レスポンス JSON の "characters" が空配列である
+    # test: test/e2e/viewer_characters_test.go::TestViewerE2E_Characters_NoAssetsDir
+
+  Scenario: プロジェクト assets のみにキャラクターが存在する場合はそのキャラクターが返る
+    Given VOX_ACTOR_WORKSPACE/assets/zundamon/ に speaker.json と画像を配置する（speakerName: ずんだもん、スタイル: ノーマル）
+    When GET /api/characters にリクエストする
+    Then レスポンス JSON の "enabled" が true である
+    And "characters" に1件のエントリが含まれる
+    And そのエントリの "speakerName" が "ずんだもん" である
+    # test: test/e2e/viewer_characters_test.go::TestViewerE2E_Characters_ProjectAssetsOnly
+
+  Scenario: HOME assets のみにキャラクターが存在する場合はそのキャラクターが返る
+    Given "${HOME}/.vox-actor/assets/metan/" に speaker.json と画像を配置する（speakerName: 四国めたん、スタイル: ノーマル）
+    When GET /api/characters にリクエストする
+    Then レスポンス JSON の "enabled" が true である
+    And "characters" に1件のエントリが含まれる
+    And そのエントリの "speakerName" が "四国めたん" である
+    # test: test/e2e/viewer_characters_test.go::TestViewerE2E_Characters_HomeAssetsOnly
+
+  Scenario: 同じキャラクターIDがプロジェクトとHOMEの両方にある場合プロジェクトが優先される
+    Given VOX_ACTOR_WORKSPACE/assets/zundamon/ に speakerName "ずんだもんproject" のキャラクターを配置する
+    And "${HOME}/.vox-actor/assets/zundamon/" に speakerName "ずんだもんhome" のキャラクターを配置する
+    When GET /api/characters にリクエストする
+    Then レスポンス JSON の "enabled" が true である
+    And "characters" が1件（プロジェクト側のみ）である
+    And そのエントリの "speakerName" が "ずんだもんproject" である
+    # test: test/e2e/viewer_characters_test.go::TestViewerE2E_Characters_ProjectPriorityOverHome
+
+  Scenario: 複数スタイルを持つキャラクターはスタイルごとにエントリが展開される
+    Given VOX_ACTOR_WORKSPACE/assets/zundamon/ に "ノーマル" と "あまあま" の2スタイルを持つキャラクターを配置する
+    When GET /api/characters にリクエストする
+    Then レスポンス JSON の "enabled" が true である
+    And "characters" に2件のエントリが含まれる
+    And エントリに "ノーマル" スタイルが含まれる
+    And エントリに "あまあま" スタイルが含まれる
+    # test: test/e2e/viewer_characters_test.go::TestViewerE2E_Characters_StylesExpanded
+
+  Scenario: 不正な speaker.json を持つキャラクターはスキップされ有効なキャラクターは返る
+    Given VOX_ACTOR_WORKSPACE/assets/zundamon/ に有効なキャラクターを配置する
+    And VOX_ACTOR_WORKSPACE/assets/invalid-char/speaker.json に不正なJSONを配置する
+    When GET /api/characters にリクエストする
+    Then レスポンス JSON の "enabled" が true である
+    And "characters" に1件（有効なキャラクターのみ）が含まれる
+    And そのエントリの "speakerName" が "ずんだもん" である
+    # test: test/e2e/viewer_characters_test.go::TestViewerE2E_Characters_InvalidSpeakerJSONSkipped
+
+  Scenario: /api/characters のレスポンスの Content-Type が JSON UTF-8 である
+    When GET /api/characters にリクエストする
+    Then レスポンスヘッダー Content-Type が "application/json; charset=utf-8" である
+    # test: test/e2e/viewer_characters_test.go::TestViewerE2E_Characters_ContentType

--- a/docs/acceptance/viewer/backend/viewer_events.feature
+++ b/docs/acceptance/viewer/backend/viewer_events.feature
@@ -1,0 +1,70 @@
+Feature: viewer バックエンド SSE イベントストリーム
+
+  # ── viewer_events_test.go ────────────────────────────────────────
+
+  Scenario: /events への接続が正しいレスポンスヘッダを返す
+    Given vox-actor バイナリがビルド済みである
+    And VOX_ENGINE_URL が到達不能なアドレス "http://127.0.0.1:1" に設定されている（サイレントモード）
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET /events に SSE 接続する
+    Then ステータスコード 200 が返る
+    And Content-Type が "text/event-stream" である
+    And Cache-Control が "no-cache" である
+    And Connection が "keep-alive" である
+    And SIGTERM 送信後に終了コード 0 で終了する
+    # test: test/e2e/viewer_events_test.go::TestViewerE2E_Events_ConnectionHeaders
+
+  Scenario: POST /api/play 後に SSE で clip イベントが配信される
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And /events に SSE 接続する
+    And 100ms 待機して subscriber 登録を確保する
+    And POST /api/play に {"clips": [{"text": "テスト発話", "speaker_id": 3}]} を送信する
+    Then ステータスコード 200 が返る
+    And SSE ストリームに "clip" イベントが配信される
+    And clip イベントの data.text が "テスト発話" である
+    And clip イベントの data.speakerName が空でない
+    And clip イベントの data.url が空でない
+    And SIGTERM 送信後に終了コード 0 で終了する
+    # test: test/e2e/viewer_events_test.go::TestViewerE2E_Events_ClipEventAfterAPIPlay
+
+  Scenario: 複数クライアントが同時に SSE 接続している場合に全員が clip イベントを受信する
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And 3 クライアントが /events に SSE 接続する
+    And 200ms 待機して全クライアントの subscriber 登録を確保する
+    And POST /api/play に {"clips": [{"text": "マルチキャストテスト", "speaker_id": 3}]} を送信する
+    Then POST /api/play がステータスコード 200 を返す
+    And 3 クライアント全員が "clip" イベントを受信する
+    And SIGTERM 送信後に終了コード 0 で終了する
+    # test: test/e2e/viewer_events_test.go::TestViewerE2E_Events_MultipleClients
+
+  Scenario: サーバーシャットダウン時に SSE 接続が切断される
+    Given vox-actor バイナリがビルド済みである
+    And VOX_ENGINE_URL が到達不能なアドレス "http://127.0.0.1:1" に設定されている（サイレントモード）
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And /events に SSE 接続する
+    And SIGTERM を送信する（Shutdown() → subscribers.closeAll() が呼ばれる）
+    Then SSE 接続が EOF またはエラーで切断される（5 秒以内）
+    # test: test/e2e/viewer_events_test.go::TestViewerE2E_Events_ServerShutdownClosesSSE
+
+  Scenario: サイレントモードで POST /api/play しても SSE に clip イベントが配信されない
+    Given vox-actor バイナリがビルド済みである
+    And VOX_ENGINE_URL が到達不能なアドレス "http://127.0.0.1:1" に設定されている（サイレントモード）
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する（サイレントモードになる）
+    And /events に SSE 接続する
+    Then /events への接続が 200 を返す
+    And 100ms 待機して subscriber 登録を確保する
+    When POST /api/play に {"clips": [{"text": "サイレントテスト", "speaker_id": 3}]} を送信する
+    Then POST /api/play がステータスコード 200 を返す
+    And レスポンス JSON の silent フィールドが true である
+    And 2 秒間 SSE ストリームに "clip" イベントが配信されない
+    And SIGTERM 送信後に終了コード 0 で終了する
+    # test: test/e2e/viewer_events_test.go::TestViewerE2E_Events_SilentMode_ConnectionAndNoClip

--- a/docs/acceptance/viewer/backend/viewer_flags.feature
+++ b/docs/acceptance/viewer/backend/viewer_flags.feature
@@ -1,0 +1,29 @@
+Feature: viewer 起動フラグ・環境変数
+
+  Scenario: --help が exit 0 で終了し主要フラグが表示される
+    When "viewer --help" を実行する
+    Then 終了コードが 0 である
+    And 標準出力に "--port" が含まれる
+    And 標準出力に "--host" が含まれる
+    And 標準出力に "--engine-url" が含まれる
+    And 標準出力に "--speaker" が含まれる
+    And 標準出力に "--watch" は含まれない
+    And 標準出力に "--watch-queue" は含まれない
+    And 標準出力に "--delete" は含まれない
+    # test: test/e2e/viewer_flags_test.go::TestViewerE2E_Help_ExitZero
+
+  Scenario: VOX_ENGINE_URL 環境変数で指定した VOICEVOX サーバーに接続する
+    Given フェイク VOICEVOX サーバーが起動している
+    When --engine-url フラグを使わずに VOX_ENGINE_URL 環境変数でフェイクサーバーを指定して viewer を起動する
+    Then stderr に "speakers loaded" ログが出力される
+    And viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_flags_test.go::TestViewerE2E_Env_VOXEngineURL_Applied
+
+  Scenario: --host 0.0.0.0 を指定したとき 127.0.0.1 でアクセスできる
+    Given VOICEVOX エンジンが到達不能なURL（http://127.0.0.1:1）として設定されている
+    When "--host 0.0.0.0" を指定して viewer を起動する
+    And "stream server listening" ログを確認する
+    And "http://127.0.0.1:<port>/api/status" に GET リクエストを送る
+    Then HTTP ステータス 200 が返る
+    And viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_flags_test.go::TestViewerE2E_Host_0000_Binds

--- a/docs/acceptance/viewer/backend/viewer_lockfile.feature
+++ b/docs/acceptance/viewer/backend/viewer_lockfile.feature
@@ -1,0 +1,32 @@
+Feature: viewer ロックファイル管理
+
+  Background:
+    Given VOICEVOX エンジンが到達不能なURL（http://127.0.0.1:1）として設定されている
+
+  Scenario: viewer 起動時にロックファイルが作成される
+    When viewer を起動する
+    Then "${HOME}/.vox-actor/viewer/viewer.lock" にロックファイルが存在する
+    And viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_lockfile_test.go::TestViewerE2E_Lockfile_CreatedOnStart
+
+  Scenario: ロックファイルは HOME 配下に作成され VOX_ACTOR_WORKSPACE 配下には作成されない
+    When viewer を起動する
+    Then "${HOME}/.vox-actor/viewer/viewer.lock" にロックファイルが存在する
+    And VOX_ACTOR_WORKSPACE ディレクトリ直下に "viewer.lock" は存在しない
+    And viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_lockfile_test.go::TestViewerE2E_Lockfile_UnderHome_NotWorkspace
+
+  Scenario: 同じ HOME で viewer を二重起動すると2番目が非ゼロ終了コードで失敗する
+    Given 1番目の viewer が起動して稼働中である
+    When 同じ HOME で2番目の viewer を別ポートで起動する
+    Then 2番目の viewer が非ゼロ終了コードで終了する
+    And 1番目の viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_lockfile_test.go::TestViewerE2E_Lockfile_DoubleStart_ErrorExit
+
+  Scenario: 1番目の viewer 終了後に同じ HOME で再起動が成功する
+    Given 1番目の viewer を起動し "stream server listening" ログを確認する
+    When 1番目の viewer を正常終了させる
+    And 同じ HOME で2番目の viewer を別ポートで起動する
+    Then 2番目の viewer の "stream server listening" ログが出力される
+    And 2番目の viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_lockfile_test.go::TestViewerE2E_Lockfile_Restart_AfterStop

--- a/docs/acceptance/viewer/backend/viewer_log.feature
+++ b/docs/acceptance/viewer/backend/viewer_log.feature
@@ -1,0 +1,17 @@
+Feature: viewer 起動ログ
+
+  Scenario: VOICEVOX 接続成功時に "speakers loaded" ログが出力される
+    Given フェイク VOICEVOX サーバーが起動している
+    When viewer を VOX_ENGINE_URL にフェイクサーバーを指定して起動する
+    Then stderr に "speakers loaded" ログが出力される
+    And そのログに "speakerCount" または "styleCount" が含まれる
+    And viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_log_test.go::TestViewerE2E_Log_SpeakersLoaded
+
+  Scenario: VOICEVOX 不在時にサイレントモード移行の WARN ログが出力される
+    Given VOICEVOX エンジンが到達不能なURL（http://127.0.0.1:1）として設定されている
+    When viewer を起動する
+    Then stderr に "VOICEVOX engine unreachable" ログが出力される
+    And そのログに "silent mode" が含まれる
+    And viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_log_test.go::TestViewerE2E_Log_SilentModeWarn

--- a/docs/acceptance/viewer/backend/viewer_play.feature
+++ b/docs/acceptance/viewer/backend/viewer_play.feature
@@ -1,0 +1,172 @@
+Feature: viewer バックエンド 再生API・クリップ配信・テストクリップ
+
+  # ── viewer_play_test.go ──────────────────────────────────────────
+
+  Scenario: POST /api/play が正常に 200 と JSON を返す
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And POST /api/play に {"clips": [{"text": "テスト", "speaker_id": 3}]} を送信する
+    Then ステータスコード 200 が返る
+    And Content-Type が "application/json; charset=utf-8" である
+    And レスポンス JSON の silent フィールドが false である
+    # test: test/e2e/viewer_play_test.go::TestViewerE2E_APIPlay_Success
+
+  Scenario: VOICEVOX に接続できない状態で POST /api/play がサイレントモードレスポンスを返す
+    Given vox-actor バイナリがビルド済みである
+    And VOX_ENGINE_URL が到達不能なアドレス "http://127.0.0.1:1" に設定されている
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And POST /api/play に {"clips": [{"text": "サイレントテスト", "speaker_id": 3}]} を送信する
+    Then ステータスコード 200 が返る
+    And Content-Type が "application/json; charset=utf-8" である
+    And レスポンス JSON の silent フィールドが true である
+    And レスポンス JSON の silent_reason フィールドが空でない
+    # test: test/e2e/viewer_play_test.go::TestViewerE2E_APIPlay_SilentModeResponse
+
+  Scenario: GET /api/play が 405 を返す
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET /api/play を送信する
+    Then ステータスコード 405 が返る
+    # test: test/e2e/viewer_play_test.go::TestViewerE2E_APIPlay_MethodNotAllowed
+
+  Scenario: 不正な JSON ボディを POST /api/play に送ると 400 が返る
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And POST /api/play に不正な JSON "not-json" を送信する
+    Then ステータスコード 400 が返る
+    # test: test/e2e/viewer_play_test.go::TestViewerE2E_APIPlay_InvalidJSON
+
+  Scenario: /audio_query が 500 を返す場合に POST /api/play が即座に 200 を返す（非同期 worker）
+    Given vox-actor バイナリがビルド済みである
+    And /audio_query エンドポイントが 500 を返すフェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And POST /api/play に {"clips": [{"text": "テスト", "speaker_id": 3}]} を送信する
+    Then ステータスコード 200 が即座に返る（非同期 worker がエラーを処理する）
+    # test: test/e2e/viewer_play_test.go::TestViewerE2E_APIPlay_CreateQueryFails
+
+  Scenario: /synthesis が 500 を返す場合に POST /api/play が即座に 200 を返す（非同期 worker）
+    Given vox-actor バイナリがビルド済みである
+    And /synthesis エンドポイントが 500 を返すフェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And POST /api/play に {"clips": [{"text": "テスト", "speaker_id": 3}]} を送信する
+    Then ステータスコード 200 が即座に返る（非同期 worker がエラーを処理する）
+    And SIGTERM 送信後に終了コード 0 で終了する
+    # test: test/e2e/viewer_play_test.go::TestViewerE2E_APIPlay_SynthesisFails
+
+  # ── viewer_clip_test.go ──────────────────────────────────────────
+
+  Scenario: SSE で受信したクリップ URL が WAV を返す
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And /events に SSE 接続する
+    And POST /api/play を送信する
+    Then SSE ストリームに "clip" イベントが配信される
+    And clip イベントの data.url が空でない
+    When clip URL に GET する
+    Then ステータスコード 200 が返る
+    And レスポンスボディが空でない（WAV バイト列）
+    # test: test/e2e/viewer_clip_test.go::TestViewerE2E_Clip_Success
+
+  Scenario: クリップ URL のレスポンスの Content-Type が audio/wav である
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And SSE 経由でクリップ URL を取得する
+    And clip URL に GET する
+    Then Content-Type が "audio/wav" である
+    # test: test/e2e/viewer_clip_test.go::TestViewerE2E_Clip_ContentType
+
+  Scenario: クリップ URL のレスポンスの Cache-Control が immutable キャッシュ指定である
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And SSE 経由でクリップ URL を取得する
+    And clip URL に GET する
+    Then Cache-Control ヘッダが "public, max-age=31536000, immutable" である
+    # test: test/e2e/viewer_clip_test.go::TestViewerE2E_Clip_CacheControl
+
+  Scenario: タイムスタンプでない不正な ID を持つクリップ URL が 404 を返す
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET /clips/not-a-timestamp.wav を送信する
+    Then ステータスコード 404 が返る
+    # test: test/e2e/viewer_clip_test.go::TestViewerE2E_Clip_InvalidID_404
+
+  Scenario: 存在しないタイムスタンプのクリップ URL が 404 を返す
+    Given vox-actor バイナリがビルド済みである
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET /clips/1.wav を送信する（非常に過去のタイムスタンプ）
+    Then ステータスコード 404 が返る
+    # test: test/e2e/viewer_clip_test.go::TestViewerE2E_Clip_NonExistent_404
+
+  Scenario: 再起動後に生成されるクリップ URL が前回と異なる
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    When 1 回目の viewer を起動して SSE 経由でクリップ URL1 を取得し停止する
+    And 2 回目の viewer を別インスタンスで起動して SSE 経由でクリップ URL2 を取得する
+    Then URL1 と URL2 が異なる（再起動後の衝突回避）
+    # test: test/e2e/viewer_clip_test.go::TestViewerE2E_Clip_RestartCollisionAvoidance
+
+  # ── viewer_test_clip_test.go ─────────────────────────────────────
+
+  Scenario: GET /test-clip?speaker=<id> が WAV を返す
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET /test-clip?speaker=3 を送信する
+    Then ステータスコード 200 が返る
+    And レスポンスボディが空でない（WAV バイト列）
+    # test: test/e2e/viewer_test_clip_test.go::TestViewerE2E_TestClip_Success
+
+  Scenario: GET /test-clip の Content-Type が audio/wav である
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET /test-clip?speaker=3 を送信する
+    Then Content-Type が "audio/wav" である
+    # test: test/e2e/viewer_test_clip_test.go::TestViewerE2E_TestClip_ContentType
+
+  Scenario: GET /test-clip の Content-Length がボディのバイト数と一致する
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET /test-clip?speaker=3 を送信する
+    Then Content-Length ヘッダが空でない
+    And Content-Length の値がレスポンスボディのバイト数と一致する
+    # test: test/e2e/viewer_test_clip_test.go::TestViewerE2E_TestClip_ContentLength
+
+  Scenario: GET /test-clip を 2 回呼ぶと同一のボディが返る（冪等性）
+    Given vox-actor バイナリがビルド済みである
+    And フェイク VOICEVOX サーバーが起動している
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する
+    And GET /test-clip?speaker=3 を 1 回目として送信する
+    And GET /test-clip?speaker=3 を 2 回目として送信する
+    Then 1 回目と 2 回目のボディが同一である
+    # test: test/e2e/viewer_test_clip_test.go::TestViewerE2E_TestClip_Idempotent
+
+  Scenario: VOICEVOX 接続不可（サイレントモード）の場合に GET /test-clip が 400 を返す
+    Given vox-actor バイナリがビルド済みである
+    And VOX_ENGINE_URL が到達不能なアドレス "http://127.0.0.1:1" に設定されている
+    And 空きポートを取得している
+    When "vox-actor viewer --port <port>" を起動する（サイレントモードになる）
+    And GET /test-clip?speaker=3 を送信する
+    Then ステータスコード 400 が返る（speakerLookup が空のため speaker not found）
+    # test: test/e2e/viewer_test_clip_test.go::TestViewerE2E_TestClip_SilentMode

--- a/docs/acceptance/viewer/backend/viewer_shutdown.feature
+++ b/docs/acceptance/viewer/backend/viewer_shutdown.feature
@@ -1,0 +1,17 @@
+Feature: viewer グレースフルシャットダウン
+
+  Background:
+    Given VOICEVOX エンジンが到達不能なURL（http://127.0.0.1:1）として設定されている
+    And viewer が起動してHTTPサーバーが待ち受け中である
+
+  Scenario: SIGINT 受信時に viewer がグレースフルシャットダウンする
+    When viewer プロセスに SIGINT を送信する
+    Then 5秒以内に viewer プロセスが終了する
+    And 終了コードが 0 である
+    # test: test/e2e/viewer_shutdown_test.go::TestViewerE2E_SIGINT_GracefulShutdown
+
+  Scenario: SIGTERM 受信時に viewer がグレースフルシャットダウンする
+    When viewer プロセスに SIGTERM を送信する
+    Then 3秒以内に viewer プロセスが正常終了する
+    And 終了コードが 0 である
+    # test: test/e2e/viewer_shutdown_test.go::TestViewerE2E_SIGTERM_GracefulShutdown

--- a/docs/acceptance/viewer/backend/viewer_silent.feature
+++ b/docs/acceptance/viewer/backend/viewer_silent.feature
@@ -1,0 +1,19 @@
+Feature: viewer サイレントモード
+
+  Background:
+    Given VOICEVOX エンジンが到達不能なURL（http://127.0.0.1:1）として設定されている
+
+  Scenario: サイレントモード移行時に WARN ログと silent=true が出力される
+    When viewer を起動する
+    Then stderr に "VOICEVOX engine unreachable" ログが出力される
+    And stderr の "stream server listening" ログに "silent=true" が含まれる
+    And viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_silent_test.go::TestViewerE2E_SilentMode_WarnLog
+
+  Scenario: /api/status レスポンスにサイレントモードのフィールドが含まれる
+    When viewer を起動して /api/status にリクエストする
+    Then HTTP ステータス 200 が返る
+    And レスポンス JSON の "silent" フィールドが true である
+    And レスポンス JSON の "silentReason" フィールドが空でない
+    And viewer は正常終了（exit code 0）する
+    # test: test/e2e/viewer_silent_test.go::TestViewerE2E_SilentMode_StatusFields


### PR DESCRIPTION
## Summary

- `test/e2e/` 配下の Go e2e テスト（28 ファイル）から受け入れ条件を抽出し、Gherkin `.feature` ファイルとして整備した
- CLI 系 9 ファイルを `docs/acceptance/cli/` に配置
- viewer バックエンド系 10 ファイルを `docs/acceptance/viewer/backend/` に配置
- 全 Scenario に `# test: test/e2e/<ファイル名>::<関数名>` の参照を付与
- すべて日本語で記述

## 生成ファイル一覧

### CLI 系 (`docs/acceptance/cli/`)
| feature ファイル | 元テストファイル |
|---|---|
| `act.feature` | `act_test.go` + `act_comm_test.go` |
| `say.feature` | `say_test.go` + `say_comm_test.go` |
| `watch.feature` | `watch_test.go` + `watch_comm_test.go` |
| `script.feature` | `script_test.go` |
| `speakers.feature` | `speakers_test.go` |
| `config.feature` | `config_test.go` |
| `audio_check.feature` | `audio_check_test.go` |
| `assets.feature` | `assets_test.go` |
| `e2e.feature` | `e2e_test.go` |

### viewer バックエンド系 (`docs/acceptance/viewer/backend/`)
| feature ファイル | 元テストファイル |
|---|---|
| `viewer.feature` | `viewer_test.go` + `viewer_check_test.go` + `viewer_index_test.go` |
| `viewer_play.feature` | `viewer_play_test.go` + `viewer_clip_test.go` + `viewer_test_clip_test.go` |
| `viewer_events.feature` | `viewer_events_test.go` |
| `viewer_silent.feature` | `viewer_silent_test.go` |
| `viewer_log.feature` | `viewer_log_test.go` |
| `viewer_lockfile.feature` | `viewer_lockfile_test.go` |
| `viewer_shutdown.feature` | `viewer_shutdown_test.go` |
| `viewer_assets.feature` | `viewer_assets_test.go` + `viewer_images_test.go` |
| `viewer_characters.feature` | `viewer_characters_test.go` |
| `viewer_flags.feature` | `viewer_flags_test.go` |

## Test plan

- [x] 全対象ファイルに対応する `.feature` が揃っている（19 ファイル）
- [x] 全 Scenario に `# test:` 参照が付いている
- [x] Gherkin 構文として `Feature:` / `Scenario:` / `Given/When/Then` が存在する
- [x] 日本語で記述されている

Closes #503

---
🤖 Generated with [Claude Code](https://claude.ai/code)
