### PR TITLE
feat(docs): Playwright e2e 受け入れ条件の Gherkin .feature 整備と acceptance-doc-reviewer 追加 (#504/#505)

### DIFF
--- a/.claude/agents/acceptance-doc-reviewer.md
+++ b/.claude/agents/acceptance-doc-reviewer.md
@@ -1,0 +1,135 @@
+---
+name: acceptance-doc-reviewer
+description: 変更差分に対して .feature ファイルと e2e テスト / reference ドキュメントの同期漏れをチェックするエージェント。
+tools: Read, Glob, Grep, Bash(ls *), Bash(git *)
+model: sonnet
+---
+
+# 受け入れ条件ドキュメントレビューエージェント
+
+変更差分を取得し、`docs/acceptance/**/*.feature` と e2e テスト・reference ドキュメントとの同期漏れを検出する。自動修正は行わず、指摘のみを報告する。
+
+## 発火対象
+
+以下のいずれかを含む差分に対して実行する。
+
+- `test/e2e/**/*.go`
+- `frontend/test/e2e/**/*.spec.ts`
+- `docs/acceptance/**/*.feature`
+- `docs/**/*.md`（reference 系ドキュメント）
+
+## チェック観点
+
+### A. `.feature` ↔ e2e の同期
+
+#### 観点1: 追加漏れ
+
+新規追加された e2e テスト関数 / Playwright `test('...')` に対応する `# test:` 参照が `docs/acceptance/` の `.feature` 側にあるか確認する。
+
+代表的な違反兆候:
+
+- 差分に `func Test...` の新規追加がある一方、対応する `# test: test/e2e/<file>.go::Test...` が `.feature` に存在しない
+- 差分に `test('...', ...)` の新規追加がある一方、対応する `# test: frontend/test/e2e/<file>.spec.ts::"..."` が `.feature` に存在しない
+
+#### 観点2: 参照切れ
+
+削除された e2e テスト関数を参照している `# test:` コメントが `.feature` 側に残っていないか確認する。
+
+代表的な違反兆候:
+
+- 差分に `func Test...` の削除がある一方、`# test: test/e2e/<file>.go::Test...` が `.feature` に残っている
+- 差分に `test('...', ...)` の削除がある一方、対応する `# test:` コメントが `.feature` に残っている
+
+#### 観点3: リネーム追従
+
+テスト関数名が変わった際に `# test:` 参照が更新されているか確認する。
+
+代表的な違反兆候:
+
+- 差分で `-func TestXxx` → `+func TestYyy` のようなリネームがある一方、`.feature` 内の `# test:` 参照が `TestXxx` のまま残っている
+
+#### 観点4: 挙動変更追従
+
+期待値・API フォーマット・HTTP ステータス等の破壊的変更時に、対応する `Given/When/Then` が更新されているか確認する。
+
+代表的な違反兆候:
+
+- 差分にステータスコードや API レスポンス形式の変更があるが、`.feature` の `Then` 行が旧仕様のままである
+- 差分に CLI フラグの変更があるが、`.feature` の `When` 行が旧フラグ名のままである
+
+### B. `.feature` ↔ reference ドキュメントの整合
+
+#### 観点5: reference 改訂時の `.feature` 追従漏れ
+
+`docs/` 配下の reference 系ドキュメント（CLI フラグ・API 仕様・viewer 振る舞い等）が変更された PR で、関連する `.feature` の `Given/When/Then` が更新されていないかを差分ベースで指摘する。
+
+代表的な違反兆候:
+
+- `docs/` 配下の reference が新しい API フォーマットを説明しているが、`.feature` がその仕様を反映していない `Given/When/Then` を持つ
+- CLI フラグの説明が変更されたが、`.feature` の `When` 行が旧フラグ名のままである
+
+> **スコープ注記**: 「reference 全文と `.feature` 全件のクロスチェック（カバレッジ全件確認）」は本エージェントの対象外（差分ベースのレビューエージェントとしては過大スコープのため）。reference の正しさ自体の検証は既存 `doc-validator` の責務とする。
+
+## 除外パターン（誤検出防止のため明示）
+
+以下は検出対象外とする。
+
+- `helper_test.go` / `helpers.ts` 等のヘルパーファイル
+- `TestMain` / セットアップ関数（`func TestMain(m *testing.M)`、`test.beforeEach` 等）
+- 関数名のリネームのみで挙動同一の場合（diff body が `Given/When/Then` に対応する部分が無変更）の観点4での更新要求
+- `docs/` 配下でも typo 修正・表現調整など仕様変更を伴わない編集（観点5）
+
+## ワークフロー
+
+1. `git diff --name-only origin/main...HEAD` で変更ファイルを取得する
+   - ローカル作業中の場合は `git diff --name-only HEAD` を使う
+   - 変更ファイルがない場合はその旨を報告して終了
+2. 変更ファイルを以下に絞り込む
+   - `test/e2e/**/*.go`（ヘルパーファイルを除く）
+   - `frontend/test/e2e/**/*.spec.ts`（`helpers.ts` を除く）
+   - `docs/acceptance/**/*.feature`
+   - `docs/**/*.md`
+   - 対象ファイルがない場合は「対象ファイルの変更なし」と報告して終了
+3. 各対象ファイルの差分（`git diff origin/main...HEAD -- <file>`）を取得する
+4. 観点 A（1〜4）: e2e テストの追加・削除・リネーム・挙動変更に対して `.feature` の同期状況を確認する
+5. 観点 B（5）: `docs/**/*.md` の変更に対して、関連する `.feature` の `Given/When/Then` の同期状況を確認する
+6. 結果を出力する（自動修正はしない）
+
+## 出力形式
+
+### 問題なしの場合
+
+```
+acceptance-doc レビュー: 問題なし
+
+チェック対象: N ファイル（変更差分）
+- test/e2e/xxx_test.go
+- docs/acceptance/cli/say.feature
+...
+```
+
+### 問題ありの場合
+
+ファイルパス・該当するチェック観点・違反内容・改善案をリスト形式で報告する。
+
+```
+acceptance-doc レビュー: 要注意（M 件）
+
+## 1. 追加漏れ（観点 A-1）
+
+- ファイル: test/e2e/viewer_play_test.go
+- 違反内容: 新規追加 `TestViewerE2E_APIPlay_NewCase` に対応する `# test:` 参照が `docs/acceptance/viewer/backend/viewer_play.feature` に存在しない
+- 改善案: `viewer_play.feature` に対応する `Scenario` と `# test:` 参照を追加する
+
+## 2. 参照切れ（観点 A-2）
+
+- ファイル: docs/acceptance/cli/say.feature
+- 違反内容: `# test: test/e2e/say_test.go::TestDeletedFunction` が残っているが、対応するテスト関数が削除されている
+- 改善案: `.feature` から該当の `# test:` 参照を削除する
+```
+
+## 注意事項
+
+- 自動修正は行わない。指摘のみを報告し、修正は人間（またはメインエージェント）の判断に委ねる
+- 違反かどうかの判断が曖昧な場合は、断定せず「疑わしい箇所」として報告する
+- 差分に含まれない既存コードの同期漏れは対象外。今回の変更で追加・修正・削除されたコードのみをチェックする

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: true
 
 ## 手順
 
-以下の4つのサブエージェントを同時並行で実行する。
+以下の5つのサブエージェントを同時並行で実行する。
 
 - `doc-validator` サブエージェントを呼び出して、ドキュメントの整合性をチェックする
   - `context: fork` + `agent: doc-validator` で呼び出す
@@ -19,5 +19,7 @@ user-invocable: true
   - `context: fork` + `agent: flaky-test-reviewer` で呼び出す
 - `plugin-version-reviewer` サブエージェントを呼び出して、`plugins/<name>/.claude-plugin/plugin.json` の version bump 漏れをチェックする
   - `context: fork` + `agent: plugin-version-reviewer` で呼び出す
+- `acceptance-doc-reviewer` サブエージェントを呼び出して、`docs/acceptance/**/*.feature` と e2e テスト / reference ドキュメントの同期漏れをチェックする
+  - `context: fork` + `agent: acceptance-doc-reviewer` で呼び出す
 
 全サブエージェントからの指摘を集約し、呼び出し元に報告する。修正が必要な場合は呼び出し元が精査して対応する。

--- a/docs/acceptance/viewer/frontend/character.feature
+++ b/docs/acceptance/viewer/frontend/character.feature
@@ -1,0 +1,21 @@
+Feature: キャラ画像表示（配信タブ統合）
+
+  Scenario: 「キャラ」タブが存在しないこと
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    Then 「キャラ」タブが表示されない
+    # test: frontend/test/e2e/character.spec.ts::"「キャラ」タブが存在しないこと"
+
+  Scenario: charactersEnabled=true のとき「キャラ画像」チェックボックスが配信タブに表示される
+    Given viewer フロントエンドが起動している
+    And API のキャラクター設定が enabled=true で characters に1件登録されている
+    When ページを開く
+    Then 配信タブに「キャラ画像」チェックボックスが表示される
+    # test: frontend/test/e2e/character.spec.ts::"charactersEnabled=true のとき「キャラ画像」チェックボックスが配信タブに表示される"
+
+  Scenario: charactersEnabled=false のとき「キャラ画像」チェックボックスが非表示になる
+    Given viewer フロントエンドが起動している
+    And API のキャラクター設定が enabled=false である
+    When ページを開く
+    Then 「キャラ画像」チェックボックスが表示されない
+    # test: frontend/test/e2e/character.spec.ts::"charactersEnabled=false のとき「キャラ画像」チェックボックスが非表示になる"

--- a/docs/acceptance/viewer/frontend/history.feature
+++ b/docs/acceptance/viewer/frontend/history.feature
@@ -1,0 +1,41 @@
+Feature: 配信タブ: 再生履歴
+
+  Scenario: ページ読み込み時に /api/history の履歴がタイムラインに表示される
+    Given viewer フロントエンドが起動している
+    And /api/history に2件の履歴が登録されている
+    When ページを開く
+    Then SSE 接続ステータスが「接続中」になる
+    And タイムラインに2件の履歴エントリが表示される
+    # test: frontend/test/e2e/history.spec.ts::"ページ読み込み時に /api/history の履歴がタイムラインに表示される"
+
+  Scenario: 履歴項目の表示後に audio の src が空のまま（音声再生が起きない）
+    Given viewer フロントエンドが起動している
+    And /api/history に1件の履歴が登録されている
+    When ページを開く
+    Then 履歴エントリがタイムラインに表示される
+    And audio.src が空のまま（再生キューに積まれていない）
+    # test: frontend/test/e2e/history.spec.ts::"履歴項目の表示後に audio の src が空のまま（音声再生が起きない）"
+
+  Scenario: viewer 起動直後に履歴リストが末尾（最新エントリ）にスクロールされる
+    Given viewer フロントエンドが起動している
+    And /api/history に20件の履歴が登録されている
+    When ページを開く
+    Then 最新（最後）の履歴エントリがビューポート内に表示される
+    And 最古（先頭）の履歴エントリはビューポート外になる
+    # test: frontend/test/e2e/history.spec.ts::"viewer 起動直後に履歴リストが末尾（最新エントリ）にスクロールされる"
+
+  Scenario: 履歴が空のとき従来どおりリストは空のまま
+    Given viewer フロントエンドが起動している
+    And /api/history の履歴が空である
+    When ページを開く
+    Then タイムラインリストが空のまま
+    # test: frontend/test/e2e/history.spec.ts::"履歴が空のとき従来どおりリストは空のまま"
+
+  Scenario: リロード後も最新の /api/history が表示される
+    Given viewer フロントエンドが起動している
+    And /api/history に1件の履歴が登録されている
+    When ページを開く
+    And /api/history に新たな履歴を1件追加する
+    And ページをリロードする
+    Then 追加した履歴エントリがタイムラインに表示される
+    # test: frontend/test/e2e/history.spec.ts::"リロード後も最新の /api/history が表示される"

--- a/docs/acceptance/viewer/frontend/lip-sync-image.feature
+++ b/docs/acceptance/viewer/frontend/lip-sync-image.feature
@@ -1,0 +1,37 @@
+Feature: LipSyncImage 表示
+
+  Scenario: charactersEnabled=false のとき「キャラ画像」チェックボックスが表示されず画像エリアも非表示
+    Given viewer フロントエンドが起動している
+    And API のキャラクター設定が enabled=false である
+    When ページを開く
+    Then 「キャラ画像」チェックボックスが表示されない
+    And 口パク画像エリアが非表示になる
+    # test: frontend/test/e2e/lip-sync-image.spec.ts::"charactersEnabled=false のとき「キャラ画像」チェックボックスが表示されず画像エリアも非表示"
+
+  Scenario: charactersEnabled=true でキャラ画像チェックON・clip受信後に口パク画像が表示される
+    Given viewer フロントエンドが起動している
+    And API のキャラクター設定が enabled=true でキャラクターが1件登録されている
+    When ページを開く
+    And 消音チェックボックスをオフにする
+    And 「キャラ画像」チェックボックスをオンにする
+    And そのキャラクターに対応する clip イベントを受信する
+    Then 口パク画像（mouth closed / mouth open）が DOM に存在する
+    # test: frontend/test/e2e/lip-sync-image.spec.ts::"charactersEnabled=true でキャラ画像チェックON・clip受信後に口パク画像が表示される"
+
+  Scenario: 「キャラ画像」チェックを OFF にするとキャラ画像エリアが非表示になる
+    Given viewer フロントエンドが起動している
+    And API のキャラクター設定が enabled=true である
+    When ページを開く
+    And 「キャラ画像」チェックボックスをオフにする
+    Then 口パク画像エリアが非表示になる
+    # test: frontend/test/e2e/lip-sync-image.spec.ts::"「キャラ画像」チェックを OFF にするとキャラ画像エリアが非表示になる"
+
+  Scenario: キャラに対応しない speakerName の clip 受信時は画像が表示されない
+    Given viewer フロントエンドが起動している
+    And API のキャラクター設定が enabled=true でキャラクターA が登録されている
+    When ページを開く
+    And 「キャラ画像」チェックボックスをオンにする
+    And キャラクターA と一致しない話者の clip イベントを受信する
+    Then タイムラインには clip が表示される
+    And 口パク画像エリアは表示されない
+    # test: frontend/test/e2e/lip-sync-image.spec.ts::"キャラに対応しない speakerName の clip 受信時は画像が表示されない"

--- a/docs/acceptance/viewer/frontend/persistence.feature
+++ b/docs/acceptance/viewer/frontend/persistence.feature
@@ -1,0 +1,19 @@
+Feature: 各種設定の localStorage 永続化
+
+  Scenario: 履歴上限・表示トグルが localStorage に保存され、リロード後も復元される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 履歴上限を 50 に変更する
+    And 「キャラ名」チェックボックスをオフにする
+    And 「スタイル」チェックボックスをオフにする
+    And 「時刻」チェックボックスをオフにする
+    Then localStorage に historySize=50 が保存される
+    And localStorage に showSpeakerName=false が保存される
+    And localStorage に showStyleName=false が保存される
+    And localStorage に showTimestamp=false が保存される
+    When ページをリロードする
+    Then 履歴上限が 50 のままである
+    And 「キャラ名」チェックボックスがオフのままである
+    And 「スタイル」チェックボックスがオフのままである
+    And 「時刻」チェックボックスがオフのままである
+    # test: frontend/test/e2e/persistence.spec.ts::"履歴上限・表示トグルが localStorage に保存され、リロード後も復元される"

--- a/docs/acceptance/viewer/frontend/playback-queue.feature
+++ b/docs/acceptance/viewer/frontend/playback-queue.feature
@@ -1,0 +1,33 @@
+Feature: 再生キュー
+
+  Scenario: 連続して clip を受信した場合 Timeline の表示順は受信順になる
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 連続して3件の clip イベントを受信する
+    Then タイムラインに3件すべてが表示される
+    And 表示順が受信順（timestamp 昇順）になっている
+    # test: frontend/test/e2e/playback-queue.spec.ts::"連続して clip を受信した場合 Timeline の表示順は受信順になる"
+
+  Scenario: muted 状態でも Timeline には clip が積まれる
+    Given viewer フロントエンドが起動している
+    When ページを開く（デフォルトで消音 ON）
+    And clip イベントを受信する
+    Then audio.muted が true のまま
+    And タイムラインに clip が表示される
+    # test: frontend/test/e2e/playback-queue.spec.ts::"muted 状態でも Timeline には clip が積まれる"
+
+  Scenario: URL が空の clip は Timeline には表示されるが audio.src は更新されない
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And URL が空の clip イベントを受信する
+    Then タイムラインに clip が表示される
+    And audio.src が空のまま
+    # test: frontend/test/e2e/playback-queue.spec.ts::"URL が空の clip は Timeline には表示されるが audio.src は更新されない"
+
+  Scenario: audio.src に clip の URL が反映される（再生キューへの積み込み確認）
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 消音チェックボックスをオフにする
+    And URL 付きの clip イベントを受信する
+    Then audio.src に blob URL が設定される（先読みにより fetch 完了）
+    # test: frontend/test/e2e/playback-queue.spec.ts::"audio.src に clip の URL が反映される（再生キューへの積み込み確認）"

--- a/docs/acceptance/viewer/frontend/silent.feature
+++ b/docs/acceptance/viewer/frontend/silent.feature
@@ -1,0 +1,18 @@
+Feature: 無音モード
+
+  Scenario: SilentBadge が表示され、音声テストタブは描画されない
+    Given viewer フロントエンドが起動している
+    And API ステータスが silent=true に設定されている
+    When ページを開く
+    Then 無音モードバッジが表示される
+    And 「配信」タブが表示される
+    And 「音声テスト」タブが表示されない
+    # test: frontend/test/e2e/silent.spec.ts::"SilentBadge が表示され、音声テストタブは描画されない"
+
+  Scenario: URL 空の clip イベントもタイムラインに表示される
+    Given viewer フロントエンドが起動している
+    And API ステータスが silent=true に設定されている
+    When ページを開く
+    And URL が空の clip イベントを受信する
+    Then タイムラインに clip のテキストが表示される
+    # test: frontend/test/e2e/silent.spec.ts::"URL 空の clip イベントもタイムラインに表示される"

--- a/docs/acceptance/viewer/frontend/stream.feature
+++ b/docs/acceptance/viewer/frontend/stream.feature
@@ -1,0 +1,25 @@
+Feature: 配信タブ: SSE と Timeline
+
+  Scenario: SSE 接続後、clip イベントが Timeline に反映される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    Then SSE 接続ステータスが「接続中」になる
+    When clip イベントを受信する
+    Then タイムラインに clip のテキストと話者名が表示される
+    # test: frontend/test/e2e/stream.spec.ts::"SSE 接続後、clip イベントが Timeline に反映される"
+
+  Scenario: error イベントが Timeline にエラーとして表示される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And error イベントを受信する（category=synthesis）
+    Then タイムラインにエラーアイテムが表示される
+    And エラーアイテムに「合成エラー」ラベルとメッセージが含まれる
+    # test: frontend/test/e2e/stream.spec.ts::"error イベントが Timeline にエラーとして表示される"
+
+  Scenario: SSE 切断後、自動再接続される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And SSE を強制切断する
+    Then ステータスが「切断」になる
+    And 再接続されステータスが「接続中」に戻る
+    # test: frontend/test/e2e/stream.spec.ts::"SSE 切断後、自動再接続される"

--- a/docs/acceptance/viewer/frontend/tabs.feature
+++ b/docs/acceptance/viewer/frontend/tabs.feature
@@ -1,0 +1,20 @@
+Feature: タブ切替
+
+  Scenario: 配信タブと音声テストタブを切り替えられる
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    Then 「配信」タブパネルが表示され「音声テスト」タブパネルが非表示である
+    When 「音声テスト」タブをクリックする
+    Then 「音声テスト」タブパネルが表示され「配信」タブパネルが非表示になる
+    When 「配信」タブをクリックする
+    Then 「配信」タブパネルが表示され「音声テスト」タブパネルが非表示になる
+    # test: frontend/test/e2e/tabs.spec.ts::"配信タブと音声テストタブを切り替えられる"
+
+  Scenario: 選択したタブはリロード後も復元される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 「音声テスト」タブをクリックする
+    Then localStorage に activeTab=test が保存される
+    When ページをリロードする
+    Then 「音声テスト」タブパネルが表示され「配信」タブパネルが非表示である
+    # test: frontend/test/e2e/tabs.spec.ts::"選択したタブはリロード後も復元される"

--- a/docs/acceptance/viewer/frontend/test-panel.feature
+++ b/docs/acceptance/viewer/frontend/test-panel.feature
@@ -1,0 +1,22 @@
+Feature: 音声テストタブ
+
+  Scenario: 話者選択は localStorage に保存され、リロード後も復元される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 「音声テスト」タブに切り替える
+    And 話者セレクタで話者ID=1 を選択する
+    Then localStorage に testSpeakerId=1 が保存される
+    When ページをリロードする
+    And 「音声テスト」タブに切り替える
+    Then 話者セレクタが話者ID=1 のままである
+    # test: frontend/test/e2e/test-panel.spec.ts::"話者選択は localStorage に保存され、リロード後も復元される"
+
+  Scenario: テスト再生ボタンで /test-clip にリクエストが飛び、audio.src も更新される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 「音声テスト」タブに切り替える
+    And 話者セレクタで話者ID=3 を選択する
+    And 「テスト再生」ボタンをクリックする
+    Then /test-clip?speaker=3 へのリクエストが発生する
+    And audio.src が /test-clip?speaker=3 の URL になる
+    # test: frontend/test/e2e/test-panel.spec.ts::"テスト再生ボタンで /test-clip にリクエストが飛び、audio.src も更新される"

--- a/docs/acceptance/viewer/frontend/timeline-item.feature
+++ b/docs/acceptance/viewer/frontend/timeline-item.feature
@@ -1,0 +1,90 @@
+Feature: TimelineItem の個別 UI 要素
+
+  # ── clip: メタ情報の表示切替 ──────────────────────────────────────
+
+  Scenario: 「キャラ名」ON のとき話者名が表示される
+    Given viewer フロントエンドが起動している
+    When ページを開く（「キャラ名」チェックボックスはデフォルト ON）
+    And clip イベントを受信する
+    Then タイムラインアイテムに話者名が表示される
+    # test: frontend/test/e2e/timeline-item.spec.ts::"「キャラ名」ON のとき話者名が表示される"
+
+  Scenario: 「キャラ名」OFF のとき話者名が非表示になる
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 「キャラ名」チェックボックスをオフにする
+    And clip イベントを受信する
+    Then タイムラインアイテムに話者名が表示されない
+    # test: frontend/test/e2e/timeline-item.spec.ts::"「キャラ名」OFF のとき話者名が非表示になる"
+
+  Scenario: 「スタイル」ON のときスタイル名が表示される
+    Given viewer フロントエンドが起動している
+    When ページを開く（「スタイル」チェックボックスはデフォルト ON）
+    And clip イベントを受信する
+    Then タイムラインアイテムにスタイル名が表示される
+    # test: frontend/test/e2e/timeline-item.spec.ts::"「スタイル」ON のときスタイル名が表示される"
+
+  Scenario: 「スタイル」OFF のときスタイル名が非表示になる
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 「スタイル」チェックボックスをオフにする
+    And clip イベントを受信する
+    Then タイムラインアイテムにスタイル名が表示されない
+    # test: frontend/test/e2e/timeline-item.spec.ts::"「スタイル」OFF のときスタイル名が非表示になる"
+
+  Scenario: 「時刻」ON のときタイムスタンプが表示される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 「時刻」チェックボックスをオンにする
+    And clip イベントを受信する
+    Then タイムラインアイテムに HH:MM:SS 形式の時刻が表示される
+    # test: frontend/test/e2e/timeline-item.spec.ts::"「時刻」ON のときタイムスタンプが表示される"
+
+  Scenario: 「時刻」OFF のときタイムスタンプが非表示になる
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 「時刻」チェックボックスをオフにする
+    And clip イベントを受信する
+    Then タイムラインアイテムに HH:MM:SS 形式の時刻が表示されない
+    # test: frontend/test/e2e/timeline-item.spec.ts::"「時刻」OFF のときタイムスタンプが非表示になる"
+
+  # ── error: エラーカテゴリ別ラベル表示 ────────────────────────────
+
+  Scenario: synthesis エラーは「合成エラー」ラベルが表示される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And error イベントを受信する（category=synthesis）
+    Then タイムラインアイテムに「合成エラー」ラベルとメッセージが表示される
+    # test: frontend/test/e2e/timeline-item.spec.ts::"synthesis エラーは「合成エラー」ラベルが表示される"
+
+  Scenario: file エラーは「ファイルエラー」ラベルが表示される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And error イベントを受信する（category=file）
+    Then タイムラインアイテムに「ファイルエラー」ラベルが表示される
+    # test: frontend/test/e2e/timeline-item.spec.ts::"file エラーは「ファイルエラー」ラベルが表示される"
+
+  Scenario: connection エラーは「接続エラー」ラベルが表示される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And error イベントを受信する（category=connection）
+    Then タイムラインアイテムに「接続エラー」ラベルが表示される
+    # test: frontend/test/e2e/timeline-item.spec.ts::"connection エラーは「接続エラー」ラベルが表示される"
+
+  Scenario: error に speakerName と text が含まれている場合は表示される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And speakerName と text を含む error イベントを受信する
+    Then タイムラインアイテムにテキストと話者名が表示される
+    # test: frontend/test/e2e/timeline-item.spec.ts::"error に speakerName と text が含まれている場合は表示される"
+
+  # ── Timeline: 履歴件数上限 ────────────────────────────────────────
+
+  Scenario: 履歴件数が上限を超えると古いエントリが削除される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 履歴上限を 10 に設定する
+    And URL が空の clip を 11 件受信する
+    Then 最新10件はタイムラインに表示される
+    And 最古のエントリはタイムラインから削除されている
+    # test: frontend/test/e2e/timeline-item.spec.ts::"履歴件数が上限を超えると古いエントリが削除される"

--- a/docs/acceptance/viewer/frontend/volume.feature
+++ b/docs/acceptance/viewer/frontend/volume.feature
@@ -1,0 +1,20 @@
+Feature: 音量・消音コントロール
+
+  Scenario: 音量スライダーの値が localStorage に保存され、リロード後も復元される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And 音量スライダーを 23 に設定する
+    Then localStorage に volume=23 が保存される
+    When ページをリロードする
+    Then 音量スライダーの値が 23 のままである
+    # test: frontend/test/e2e/volume.spec.ts::"音量スライダーの値が localStorage に保存され、リロード後も復元される"
+
+  Scenario: 消音チェックボックスの操作で audio.muted が連動する
+    Given viewer フロントエンドが起動している
+    When ページを開く（デフォルトで audio.muted=true）
+    Then audio.muted が true である
+    When 消音チェックボックスをオフにする
+    Then audio.muted が false になる
+    When 消音チェックボックスをオンにする
+    Then audio.muted が true に戻る
+    # test: frontend/test/e2e/volume.spec.ts::"消音チェックボックスの操作で audio.muted が連動する"


### PR DESCRIPTION
## Summary

- `docs/acceptance/viewer/frontend/` 配下に 11 ファイルの `.feature` を新規追加（#504 対応）
  - `character.feature` / `history.feature` / `lip-sync-image.feature` / `persistence.feature` / `playback-queue.feature` / `silent.feature` / `stream.feature` / `tabs.feature` / `test-panel.feature` / `timeline-item.feature` / `volume.feature`
  - `frontend/test/e2e/*.spec.ts` の全テストケース（39 Scenario）に対応
  - 各 Scenario 末尾に `# test: frontend/test/e2e/<file>.spec.ts::"<test 名>"` 参照を付与
- `.claude/agents/acceptance-doc-reviewer.md` を新規追加（#505 対応）
  - `.feature` ↔ e2e テストの同期漏れ（追加漏れ・参照切れ・リネーム追従・挙動変更追従）と `.feature` ↔ reference ドキュメントの整合を検出するサブエージェント
  - 既存 4 エージェント（`architecture-reviewer` / `doc-validator` / `flaky-test-reviewer` / `plugin-version-reviewer`）と同じ frontmatter 構造
  - 除外パターン・スコープ境界（全件カバレッジは対象外）を明記
- `.claude/skills/review/SKILL.md` に `acceptance-doc-reviewer` の呼び出しを追記

Closes #504
Closes #505

## Test plan

- [ ] `docs/acceptance/viewer/frontend/` 配下に 11 ファイルの `.feature` が存在することを確認
- [ ] 各 `.feature` の全 Scenario に `# test:` 参照が付いていることを確認
- [ ] `.claude/agents/acceptance-doc-reviewer.md` が追加されていることを確認
- [ ] `review` スキル実行時に `acceptance-doc-reviewer` が呼び出されることを確認（新セッションで検証）

---
🤖 Generated with [Claude Code](https://claude.ai/code)
