### PR TITLE
docs(acceptance): cli/playback.feature を新設し e2e テストを追加する

### DIFF
--- a/docs/acceptance/cli/playback.feature
+++ b/docs/acceptance/cli/playback.feature
@@ -1,0 +1,47 @@
+Feature: vox-actor playback コマンド
+
+  # ===== 正常系 =====
+
+  Scenario: local_playback を渡すと即時に終了コード 0 が返る
+    When "vox-actor playback wait local_playback" を実行する
+    Then 終了コード 0 で完了する
+    # test: test/e2e/playback_test.go::TestPlaybackWaitE2E_LocalPlayback_ExitsZero
+
+  Scenario: viewer から完了通知を受信して終了コード 0 が返る
+    Given フェイク viewer サーバーが起動しロックファイルが書き込まれている
+    And フェイク viewer が playback_id の status=completed を返す
+    When "vox-actor playback wait <id>" を HOME に向けて実行する
+    Then 終了コード 0 で完了する
+    # test: test/e2e/playback_test.go::TestPlaybackWaitE2E_Completed_ExitsZero
+
+  Scenario: --viewer-url 明示時は lockfile auto-detect をスキップして接続する
+    Given フェイク viewer サーバーが status=completed を返す
+    When "vox-actor playback wait <id> --viewer-url <url>" をロックファイルなしで実行する
+    Then 終了コード 0 で完了する
+    # test: test/e2e/playback_test.go::TestPlaybackWaitE2E_ViewerURL_SkipsLockfile
+
+  # ===== エラー系 =====
+
+  Scenario: --server-down-timeout 経過後にサーバ未応答だった場合は非ゼロ終了コードが返る
+    When "vox-actor playback wait <id> --viewer-url <到達不能URL> --server-down-timeout 500ms" を実行する
+    Then 終了コードが非ゼロである
+    # test: test/e2e/playback_test.go::TestPlaybackWaitE2E_ServerDownTimeout_NonZero
+
+  Scenario: 引数 <id> 未指定時は終了コード 2 が返る
+    When "vox-actor playback wait" を引数なしで実行する
+    Then 終了コード 2 で完了する
+    # test: test/e2e/playback_test.go::TestPlaybackWaitE2E_NoArgs_ExitCode2
+
+  Scenario: viewer 未起動かつ --viewer-url 未指定時はエラーが返る
+    Given ロックファイルが存在しない HOME ディレクトリを用意する
+    When "vox-actor playback wait <id>" を実行する
+    Then 終了コードが非ゼロである
+    # test: test/e2e/playback_test.go::TestPlaybackWaitE2E_ViewerNotFound_Error
+
+  # ===== ヘルプ =====
+
+  Scenario: --help フラグで終了コード 0 かつ主要フラグが表示される
+    When "vox-actor playback wait --help" を実行する
+    Then 終了コード 0 で完了する
+    And stdout に "--viewer-url", "--server-down-timeout" が含まれる
+    # test: test/e2e/playback_test.go::TestPlaybackWaitE2E_Help_ExitZeroWithAllFlags

--- a/test/e2e/playback_test.go
+++ b/test/e2e/playback_test.go
@@ -1,0 +1,130 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// playbackStatusHandler は GET /api/playback/{id} に status を返すハンドラを生成する。
+func playbackStatusHandler(status string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimPrefix(r.URL.Path, "/api/playback/")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":     id,
+			"status": status,
+		})
+	}
+}
+
+// setupFakeViewerWithPlayback は /api/status と /api/playback/{id} を実装した
+// fake viewer サーバーを起動し、ロックファイルを書き込んだ homeDir を返す。
+// playbackStatus に指定したステータスが GET /api/playback/{id} のレスポンスに使われる。
+func setupFakeViewerWithPlayback(t *testing.T, playbackStatus string) string {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/api/playback/", playbackStatusHandler(playbackStatus))
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	homeDir := t.TempDir()
+	writeViewerLockFile(t, homeDir, srv.Listener.Addr().String())
+	return homeDir
+}
+
+func TestPlaybackWaitE2E_LocalPlayback_ExitsZero(t *testing.T) {
+	t.Parallel()
+
+	_, _, exitCode := runCLI(t, nil, "playback", "wait", "local_playback")
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 for local_playback, got %d", exitCode)
+	}
+}
+
+func TestPlaybackWaitE2E_Completed_ExitsZero(t *testing.T) {
+	t.Parallel()
+
+	homeDir := setupFakeViewerWithPlayback(t, "completed")
+
+	_, _, exitCode := runCLI(t, map[string]string{"HOME": homeDir}, "playback", "wait", "test-id-123")
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 when playback completed, got %d", exitCode)
+	}
+}
+
+func TestPlaybackWaitE2E_ViewerURL_SkipsLockfile(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/playback/", playbackStatusHandler("completed"))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	homeDir := t.TempDir() // ロックファイルなし
+
+	_, _, exitCode := runCLI(t, map[string]string{"HOME": homeDir},
+		"playback", "wait", "test-id-456", "--viewer-url", srv.URL)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 with --viewer-url, got %d", exitCode)
+	}
+}
+
+func TestPlaybackWaitE2E_ServerDownTimeout_NonZero(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, exitCode := runCLI(t, nil,
+		"playback", "wait", "test-id",
+		"--viewer-url", "http://127.0.0.1:1",
+		"--server-down-timeout", "500ms",
+	)
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit when server is unreachable, got 0\nstderr:\n%s", stderr)
+	}
+}
+
+func TestPlaybackWaitE2E_NoArgs_ExitCode2(t *testing.T) {
+	t.Parallel()
+
+	_, _, exitCode := runCLI(t, nil, "playback", "wait")
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2 for missing args, got %d", exitCode)
+	}
+}
+
+func TestPlaybackWaitE2E_ViewerNotFound_Error(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir() // ロックファイルなし
+
+	_, stderr, exitCode := runCLI(t, map[string]string{"HOME": homeDir}, "playback", "wait", "test-id")
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit when viewer not found, got 0")
+	}
+	if !strings.Contains(stderr, "viewer not found") {
+		t.Errorf("expected stderr to contain 'viewer not found'\nstderr:\n%s", stderr)
+	}
+}
+
+func TestPlaybackWaitE2E_Help_ExitZeroWithAllFlags(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runCLI(t, nil, "playback", "wait", "--help")
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 for --help, got %d", exitCode)
+	}
+	for _, flag := range []string{"--viewer-url", "--server-down-timeout"} {
+		if !strings.Contains(stdout, flag) {
+			t.Errorf("expected --help output to contain %q\nstdout:\n%s", flag, stdout)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `docs/acceptance/cli/playback.feature` を新規作成し、`playback wait` サブコマンドの受け入れ条件を Gherkin で記述（7 シナリオ）
- `test/e2e/playback_test.go` を新規作成し、受け入れ条件と 1 対 1 で対応する e2e テストを実装

### 実装シナリオ

| シナリオ | テスト関数 |
|---|---|
| `local_playback` → 即時 exit 0 | `TestPlaybackWaitE2E_LocalPlayback_ExitsZero` |
| viewer から completed 受信 → exit 0 | `TestPlaybackWaitE2E_Completed_ExitsZero` |
| `--viewer-url` 明示 → lockfile auto-detect スキップ | `TestPlaybackWaitE2E_ViewerURL_SkipsLockfile` |
| `--server-down-timeout` 経過後に非ゼロ | `TestPlaybackWaitE2E_ServerDownTimeout_NonZero` |
| 引数 `<id>` 未指定 → exit 2 | `TestPlaybackWaitE2E_NoArgs_ExitCode2` |
| viewer 未起動かつ `--viewer-url` 未指定 → エラー | `TestPlaybackWaitE2E_ViewerNotFound_Error` |
| `--help` 表示 → exit 0 かつフラグ一覧 | `TestPlaybackWaitE2E_Help_ExitZeroWithAllFlags` |

## Test plan

- [x] `go test -tags=e2e -run TestPlaybackWaitE2E ./test/e2e/` → 7 テスト全 PASS
- [x] `golangci-lint run --build-tags=e2e ./test/e2e/` → 0 issues
- [x] `go build ./...` → エラーなし

Closes #513

---
🤖 Generated with [Claude Code](https://claude.ai/code)
