### PR TITLE
fix(viewer): showCharacters の初期値を true に変更して他のトグルと統一する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -111,7 +111,7 @@ export function App() {
   );
   const [showCharacters, setShowCharacters] = usePersistedState(
     STORAGE_KEYS.showCharacters,
-    false,
+    true,
     parseBool,
     String,
   );


### PR DESCRIPTION
## Summary

- `frontend/src/App.tsx` の `showCharacters` (`usePersistedState` 初期値) を `false` から `true` へ変更
- 他のトグル (`showSpeakerName`, `showStyleName`, `showTimestamp`) と初期値を統一

## Test plan

- [x] `vitest run` で全153テスト通過確認
- [ ] 新規ユーザー（`localStorage` に `vox-actor.stream.showCharacters` がない状態）で初期表示時にキャラ画像チェックボックスが ON になっていることを手動確認

Closes #519

---
🤖 Generated with [Claude Code](https://claude.ai/code)
