### PR TITLE
docs(agent): doc-validator に CLI サブコマンド・フラグ／プラグイン構成の追記漏れチェック観点を追加する

### DIFF
--- a/.claude/agents/doc-validator.md
+++ b/.claude/agents/doc-validator.md
@@ -12,7 +12,9 @@ model: sonnet
 ## 対象ドキュメント
 
 - `README.md`
-- `docs/` 配下のドキュメント（存在する場合）
+- `docs/reference/cli.md`
+- `docs/reference/plugins.md`
+- `docs/` 配下のその他のドキュメント（存在する場合）
 
 ## チェック観点
 
@@ -31,6 +33,51 @@ model: sonnet
 
 - 新しく追加されたパッケージやファイルがドキュメントに反映されているか確認する
 - `git diff --name-only HEAD~1` 等で最近の変更ファイルを確認し、関連するドキュメント記述を検証する
+
+### 4. CLI サブコマンド・フラグの追記漏れチェック
+
+`docs/reference/cli.md` と実装コード（`cmd/` 配下）を突き合わせ、以下を確認する。
+
+**実装側の列挙方法:**
+
+```bash
+grep -rn "cobra.Command\|Use:\s\|\.Flags()\|StringVar\|BoolVar\|StringArray\|IntVar" cmd/
+```
+
+**突き合わせ対象:** `docs/reference/cli.md` の章構成・フラグ表（4列: `オプション / 環境変数 / デフォルト値 / 説明`）
+
+**検出すべきケース:**
+- 新規追加された cobra サブコマンド（`Use:` フィールド）が `docs/reference/cli.md` に章として存在しない
+- 既存サブコマンドに追加されたフラグ（`cmd.Flags().XxxVar()` 等）がフラグ表に未追記
+- フラグのデフォルト値・環境変数が実装と乖離している
+
+**除外すべき正常パターン:**
+- 内部専用フラグ（テスト用、hidden フラグ等）は対象外
+- ドキュメントに「補足」「注意」として記載済みのものは追記漏れではない
+
+### 5. プラグイン skill／command／agent／hook の追記漏れチェック
+
+`docs/reference/plugins.md` とプラグイン実装を突き合わせ、以下を確認する。
+
+**実装側の列挙方法:**
+
+```bash
+ls plugins/
+ls plugins/<name>/skills/   2>/dev/null
+ls plugins/<name>/commands/ 2>/dev/null
+ls plugins/<name>/agents/   2>/dev/null
+ls plugins/<name>/hooks/    2>/dev/null
+```
+
+**突き合わせ対象:** `docs/reference/plugins.md` の記載（スキル一覧・コマンド一覧・フック説明等）
+
+**検出すべきケース:**
+- 新規追加されたスキル・コマンド・エージェント・フックが `docs/reference/plugins.md` に未記載
+- プラグイン自体が新規追加されたがプラグイン説明が未記載
+- `plugin.json` 等のメタデータとドキュメントの記述が乖離している
+
+**除外すべき正常パターン:**
+- スキル SKILL.md に `description` で「直接呼び出し非想定」と明記された内部スキルは外部ドキュメントへの露出不要
 
 ## ワークフロー
 


### PR DESCRIPTION
## Summary

- `.claude/agents/doc-validator.md` に「CLI サブコマンド・フラグの追記漏れチェック」観点（観点4）を追加
  - `grep -rn "cobra.Command\|Use:\s\|..."` で実装側を列挙し `docs/reference/cli.md` と突き合わせる手順を明文化
  - 検出すべきケース（サブコマンド章欠落・フラグ未追記・デフォルト値乖離）と除外パターンを明記
- `.claude/agents/doc-validator.md` に「プラグイン skill／command／agent／hook の追記漏れチェック」観点（観点5）を追加
  - `ls plugins/<name>/skills/` 等で実装を列挙し `docs/reference/plugins.md` と突き合わせる手順を明文化
- 対象ドキュメントリストに `docs/reference/cli.md` と `docs/reference/plugins.md` を個別ファイル名で明示（従来は「`docs/` 配下」の一括記載のみ）

## Test Plan

- [x] `.claude/agents/doc-validator.md` の変更内容を目視確認（観点4・5・対象ドキュメント明示）
- [x] `cmd/` の cobra コマンド定義（`playback`, `assets`, `speakers`）が `docs/reference/cli.md` に章として存在することを手動確認（#509 相当の差分で観点4が機能することを確認）

Closes #510

---
🤖 Generated with [Claude Code](https://claude.ai/code)
