### PR TITLE
fix(infra): TestHTTPStreamPlayer_APIPlayback_TTLExpiry のflaky解消（setPlaybackStatusの自動再生成削除＋テスト同期化）

### DIFF
--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -1024,10 +1024,11 @@ func (p *HTTPStreamPlayer) initPlayback(id string, clipCount int) {
 func (p *HTTPStreamPlayer) setPlaybackStatus(id string, status playbackStatus, reason string) {
 	p.playbackMu.Lock()
 	defer p.playbackMu.Unlock()
-	if _, ok := p.playbacks[id]; !ok {
-		p.playbacks[id] = &playbackStateRecord{createdAt: p.nowFunc()}
+	state, ok := p.playbacks[id]
+	if !ok {
+		// pruned or unregistered; ignore late updates from workers.
+		return
 	}
-	state := p.playbacks[id]
 	state.status = status
 	state.reason = reason
 	now := p.nowFunc().UnixMilli()

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -3412,6 +3412,30 @@ func TestHTTPStreamPlayer_Prefetch_SynthesizeFailureDuringPrefetchFails(t *testi
 	}
 }
 
+// waitForPlaybackTerminal polls GET /api/playback/<id> until status is "completed" or "failed",
+// or until the timeout is reached (test fails on timeout).
+func waitForPlaybackTerminal(t *testing.T, baseURL, playbackID string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/api/playback/" + playbackID)
+		if err != nil {
+			t.Fatalf("polling GET /api/playback: %v", err)
+		}
+		var result ViewerPlaybackResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			_ = resp.Body.Close()
+			t.Fatalf("decode polling response: %v", err)
+		}
+		_ = resp.Body.Close()
+		if result.Status == "completed" || result.Status == "failed" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for playback %s to reach terminal status", playbackID)
+}
+
 func TestHTTPStreamPlayer_APIPlayback_TTLExpiry(t *testing.T) {
 	t.Parallel()
 	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
@@ -3433,6 +3457,10 @@ func TestHTTPStreamPlayer_APIPlayback_TTLExpiry(t *testing.T) {
 		t.Fatalf("decode POST response: %v", err)
 	}
 	_ = postResp.Body.Close()
+
+	// ワーカーが completed/failed に遷移するまで待機してから prune する。
+	// これにより、prune 後のワーカーによる自動再生成（修正前の挙動）が起きないことを保証する。
+	waitForPlaybackTerminal(t, "http://"+p.Addr(), playResult.PlaybackID, 2*time.Second)
 
 	// 現在時刻を "今" に進め、GC を走らせる（createdAt = 2h前 < cutoff = now - 1h）
 	fixedTime = time.Now()


### PR DESCRIPTION
## 概要

`internal/infra` の `TestHTTPStreamPlayer_APIPlayback_TTLExpiry` が flaky になっていた問題を修正する。

- **プロダクション修正**: `setPlaybackStatus` の「無ければ作る」自動再生成ロジックを削除。pruned済みIDへのワーカーの後追い更新を no-op にする
- **テスト修正**: `PrunePlaybacks` 呼び出し前に `waitForPlaybackTerminal` ヘルパーでワーカーの完了を待機し、race condition を排除する

## 変更ファイル

- `internal/infra/http_stream_player.go`: `setPlaybackStatus` から自動再生成ロジックを削除
- `internal/infra/http_stream_player_test.go`: `waitForPlaybackTerminal` ヘルパー追加、`TestHTTPStreamPlayer_APIPlayback_TTLExpiry` でポーリング待機を挿入

## Test plan

- [x] `go test ./internal/infra -run TestHTTPStreamPlayer_APIPlayback_TTLExpiry -count=50` 全成功確認済み
- [x] `go test ./internal/...` 全成功確認済み
- [x] `gofmt -l .` 出力なし
- [x] `golangci-lint run ./internal/infra/...` 0 issues

Closes #526

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
