### PR TITLE
fix(viewer): 口パク感度を改善（THRESHOLD_RATIO 0.5→0.7、hysteresisMs 80→40ms）

### DIFF
--- a/frontend/src/components/LipSyncImage.test.tsx
+++ b/frontend/src/components/LipSyncImage.test.tsx
@@ -75,9 +75,9 @@ describe("LipSyncImage", () => {
     // ヒステリシス前は口開
     expect(openImg).toHaveStyle({ display: "block" });
 
-    // ヒステリシス時間進める（デフォルト 80ms）
+    // ヒステリシス時間進める（デフォルト 40ms）
     act(() => {
-      vi.advanceTimersByTime(80);
+      vi.advanceTimersByTime(40);
     });
 
     // ヒステリシス後は口閉
@@ -123,8 +123,8 @@ describe("LipSyncImage", () => {
       />,
     );
 
-    // 40ms進める（ヒステリシス80msの途中）
-    vi.advanceTimersByTime(40);
+    // 20ms進める（ヒステリシス40msの途中）
+    vi.advanceTimersByTime(20);
 
     // 音量を高く戻す
     rerender(
@@ -202,8 +202,8 @@ describe("LipSyncImage", () => {
     expect(openImg).toHaveStyle({ display: "block" });
 
     // 音量が少し低下（音節間の振幅低下をシミュレート）
-    // 動的閾値は recentMax * 0.5 = 0.1 * 0.5 = 0.05
-    // 0.02 < 0.05 なのでタイマーが開始
+    // 動的閾値は recentMax * 0.7 = 0.1 * 0.7 = 0.07
+    // 0.02 < 0.07 なのでタイマーが開始
     rerender(
       <LipSyncImage
         mouthClosedUrl="/closed.png"
@@ -216,7 +216,7 @@ describe("LipSyncImage", () => {
 
     // ヒステリシス後に口が閉じる
     act(() => {
-      vi.advanceTimersByTime(80);
+      vi.advanceTimersByTime(40);
     });
 
     const closedImg = screen.getByAltText("character mouth closed");

--- a/frontend/src/components/LipSyncImage.tsx
+++ b/frontend/src/components/LipSyncImage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 
 // Dynamic threshold parameters
 const WINDOW_MS = 500;
-const THRESHOLD_RATIO = 0.5;
+const THRESHOLD_RATIO = 0.7;
 const MIN_THRESHOLD = 0.01;
 
 interface LipSyncImageProps {
@@ -15,13 +15,13 @@ interface LipSyncImageProps {
 /**
  * LipSyncImage は音量に応じて口閉/口開の2枚の画像を切り替える。
  * 動的閾値（envelope follower）を使用して、音節単位での開閉を実現する。
- * - hysteresisMs: 開→閉切替時のヒステリシス時間（デフォルト 80ms）
+ * - hysteresisMs: 開→閉切替時のヒステリシス時間（デフォルト 40ms）
  */
 export function LipSyncImage({
   mouthClosedUrl,
   mouthOpenUrl,
   volume,
-  hysteresisMs = 80,
+  hysteresisMs = 40,
 }: LipSyncImageProps) {
   const [isOpen, setIsOpen] = useState(false);
   const closeTimerRef = useRef<NodeJS.Timeout | null>(null);


### PR DESCRIPTION
## 概要

- 連続発音中にモーラ間の音量の谷を検出できず口が開きっぱなしになる問題を改善
- `THRESHOLD_RATIO` を 0.5 → 0.7 に引き上げ、谷での閾値越えを検出しやすくした
- `hysteresisMs` のデフォルトを 80 → 40ms に短縮し、モーラ単位（150〜200ms）の開閉を実現

## 変更内容

| 定数/パラメータ | 変更前 | 変更後 | 理由 |
|---|---|---|---|
| `THRESHOLD_RATIO` | 0.5 | 0.7 | 連続発音中の谷が `recentMax * 0.5` を下回らなかった |
| `hysteresisMs` デフォルト | 80ms | 40ms | 80ms だとモーラ間の谷を埋めてしまっていた |

## テスト

- 既存の全 7 ユニットテストが通過（コメントと数値を新しいデフォルト値に更新）
- Playwright による DOM 監視で口の開閉状態を確認（再生前: 閉 / 再生中: 開 / 再生後: 閉）

## Test Plan

- [ ] `npm run test:unit` で全テスト通過確認
- [ ] viewer を起動し `vox-actor say` で複数モーラのセリフを再生して口パクが機能することを目視確認（自動テストでは再生中の開閉挙動は保証されないため）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
