### PR TITLE
fix(viewer): キャラ非表示を audio ended イベント非依存のウォッチドッグ方式に置き換える

### DIFF
--- a/frontend/src/hooks/usePlaybackQueue.test.ts
+++ b/frontend/src/hooks/usePlaybackQueue.test.ts
@@ -22,6 +22,27 @@ function makeFetchMock() {
   });
 }
 
+function setAudioEnded(audio: HTMLAudioElement, value: boolean): void {
+  Object.defineProperty(audio, "ended", {
+    get: () => value,
+    configurable: true,
+  });
+}
+
+function setAudioDuration(audio: HTMLAudioElement, value: number): void {
+  Object.defineProperty(audio, "duration", {
+    get: () => value,
+    configurable: true,
+  });
+}
+
+function setAudioCurrentTime(audio: HTMLAudioElement, value: number): void {
+  Object.defineProperty(audio, "currentTime", {
+    get: () => value,
+    configurable: true,
+  });
+}
+
 describe("usePlaybackQueue", () => {
   let audio: HTMLAudioElement;
   let audioRef: { current: HTMLAudioElement };
@@ -51,6 +72,7 @@ describe("usePlaybackQueue", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it("enqueue で audio.play が呼ばれ playingClipTimestamp が更新される", async () => {
@@ -76,24 +98,60 @@ describe("usePlaybackQueue", () => {
     expect(audio.src).toMatch(/^blob:/);
   });
 
-  it("ended イベント発火で次クリップが再生されキューが空なら null", async () => {
+  it("timeupdate で audio.ended=true のとき次クリップが再生されキューが空なら null", async () => {
     const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
     await act(async () => {
       result.current.enqueue(makeClip(1));
       result.current.enqueue(makeClip(2));
     });
     expect(result.current.playingClipTimestamp).toBe(1000);
+
+    setAudioEnded(audio, true);
     await act(async () => {
-      audio.dispatchEvent(new Event("ended"));
+      audio.dispatchEvent(new Event("timeupdate"));
     });
     expect(result.current.playingClipTimestamp).toBe(2000);
+
+    setAudioEnded(audio, true);
     await act(async () => {
-      audio.dispatchEvent(new Event("ended"));
+      audio.dispatchEvent(new Event("timeupdate"));
     });
     expect(result.current.playingClipTimestamp).toBeNull();
   });
 
-  it("ended イベント発火時に先読み済みクリップが即再生される", async () => {
+  it("duration/currentTime 判定でウォッチドッグが発火して次クリップが再生される", async () => {
+    const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+      result.current.enqueue(makeClip(2));
+    });
+    expect(result.current.playingClipTimestamp).toBe(1000);
+
+    // currentTime が duration - EPSILON に到達した状態を作る
+    setAudioDuration(audio, 3.0);
+    setAudioCurrentTime(audio, 2.96);
+    await act(async () => {
+      audio.dispatchEvent(new Event("timeupdate"));
+    });
+    expect(result.current.playingClipTimestamp).toBe(2000);
+  });
+
+  it("setInterval でウォッチドッグが発火する", async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+    });
+    expect(result.current.playingClipTimestamp).toBe(1000);
+
+    setAudioEnded(audio, true);
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current.playingClipTimestamp).toBeNull();
+  });
+
+  it("ウォッチドッグ発火時に先読み済みクリップが即再生される", async () => {
     const { result } = renderHook(() => usePlaybackQueue(audioRef, true));
     await act(async () => {
       result.current.enqueue(makeClip(1));
@@ -102,10 +160,12 @@ describe("usePlaybackQueue", () => {
     // clip1 再生中、clip2 が先読み済み
     expect(result.current.playingClipTimestamp).toBe(1000);
     const playCallsBefore = mockPlay.mock.calls.length;
+
+    setAudioEnded(audio, true);
     await act(async () => {
-      audio.dispatchEvent(new Event("ended"));
+      audio.dispatchEvent(new Event("timeupdate"));
     });
-    // ended 直後に fetch を待たず即 play() が追加呼び出しされる
+    // ウォッチドッグ発火直後に fetch を待たず即 play() が追加呼び出しされる
     expect(mockPlay.mock.calls.length).toBeGreaterThan(playCallsBefore);
     expect(result.current.playingClipTimestamp).toBe(2000);
   });
@@ -188,13 +248,15 @@ describe("usePlaybackQueue", () => {
     expect((capturedSignal as unknown as AbortSignal).aborted).toBe(true);
   });
 
-  it("アンマウントで ended リスナーが解除される", () => {
-    const removeEventListenerSpy = vi.spyOn(audio, "removeEventListener");
-    const { unmount } = renderHook(() => usePlaybackQueue(audioRef, true));
-    unmount();
-    expect(removeEventListenerSpy).toHaveBeenCalledWith(
-      "ended",
-      expect.any(Function),
+  it("アンマウントでウォッチドッグがクリアされる", async () => {
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+    const { result, unmount } = renderHook(() =>
+      usePlaybackQueue(audioRef, true),
     );
+    await act(async () => {
+      result.current.enqueue(makeClip(1));
+    });
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/usePlaybackQueue.ts
+++ b/frontend/src/hooks/usePlaybackQueue.ts
@@ -17,6 +17,9 @@ interface ReadyClip {
   objectUrl: string;
 }
 
+const WATCHDOG_EPSILON = 0.05;
+const WATCHDOG_INTERVAL_MS = 250;
+
 // active=false の間は enqueue してもキューに積まれず、既存の再生は停止される。
 export function usePlaybackQueue(
   audioRef: RefObject<HTMLAudioElement>,
@@ -38,6 +41,51 @@ export function usePlaybackQueue(
   // 互いに依存する循環呼び出しを ref で解決する。
   const startNextRef = useRef<() => void>(() => {});
   const startPrefetchRef = useRef<() => void>(() => {});
+  const watchdogCleanupRef = useRef<(() => void) | null>(null);
+
+  const clearWatchdog = useCallback((): void => {
+    if (watchdogCleanupRef.current) {
+      watchdogCleanupRef.current();
+      watchdogCleanupRef.current = null;
+    }
+  }, []);
+
+  const startWatchdog = useCallback(
+    (audio: HTMLAudioElement): void => {
+      clearWatchdog();
+      let fired = false;
+
+      const checkEnded = (): void => {
+        if (fired) return;
+        const ended =
+          audio.ended ||
+          (Number.isFinite(audio.duration) &&
+            audio.duration > 0 &&
+            audio.currentTime >= audio.duration - WATCHDOG_EPSILON);
+        if (!ended) return;
+
+        fired = true;
+        watchdogCleanupRef.current?.();
+        watchdogCleanupRef.current = null;
+        if (playingObjUrlRef.current) {
+          URL.revokeObjectURL(playingObjUrlRef.current);
+          playingObjUrlRef.current = null;
+        }
+        playingClipTimestampRef.current = null;
+        setPlayingClipTimestamp(null);
+        startNextRef.current();
+      };
+
+      audio.addEventListener("timeupdate", checkEnded);
+      const intervalId = setInterval(checkEnded, WATCHDOG_INTERVAL_MS);
+
+      watchdogCleanupRef.current = (): void => {
+        audio.removeEventListener("timeupdate", checkEnded);
+        clearInterval(intervalId);
+      };
+    },
+    [clearWatchdog],
+  );
 
   const startNext = useCallback((): void => {
     if (!activeRef.current) return;
@@ -60,16 +108,18 @@ export function usePlaybackQueue(
         if (playingObjUrlRef.current === ready.objectUrl) {
           playingObjUrlRef.current = null;
         }
+        clearWatchdog();
         playingClipTimestampRef.current = null;
         setPlayingClipTimestamp(null);
         startNextRef.current();
       });
+      startWatchdog(audio);
       startPrefetchRef.current();
       return;
     }
 
     startPrefetchRef.current();
-  }, [audioRef]);
+  }, [audioRef, clearWatchdog, startWatchdog]);
 
   const startPrefetch = useCallback((): void => {
     if (prefetchedRef.current) return;
@@ -116,6 +166,7 @@ export function usePlaybackQueue(
   );
 
   const stop = useCallback((): void => {
+    clearWatchdog();
     const audio = audioRef.current;
     if (audio) {
       audio.pause();
@@ -137,7 +188,7 @@ export function usePlaybackQueue(
     waitingRef.current = [];
     playingClipTimestampRef.current = null;
     setPlayingClipTimestamp(null);
-  }, [audioRef]);
+  }, [audioRef, clearWatchdog]);
 
   useEffect(() => {
     if (!active) {
@@ -150,24 +201,6 @@ export function usePlaybackQueue(
       stop();
     };
   }, [stop]);
-
-  useEffect(() => {
-    const audio = audioRef.current;
-    if (!audio) return;
-    const onEnded = (): void => {
-      if (playingObjUrlRef.current) {
-        URL.revokeObjectURL(playingObjUrlRef.current);
-        playingObjUrlRef.current = null;
-      }
-      playingClipTimestampRef.current = null;
-      setPlayingClipTimestamp(null);
-      startNextRef.current();
-    };
-    audio.addEventListener("ended", onEnded);
-    return () => {
-      audio.removeEventListener("ended", onEnded);
-    };
-  }, [audioRef]);
 
   return { playingClipTimestamp, enqueue };
 }


### PR DESCRIPTION
## Summary

- `usePlaybackQueue` の再生終了検知を `audio.ended` イベントから `timeupdate` + `setInterval(250ms)` のハイブリッドウォッチドッグ方式に置き換えた
- 判定条件: `audio.ended === true` または `audio.currentTime >= audio.duration - 0.05`
- 二重発火防止のため `fired` フラグを watchdog インスタンスごとに導入
- `stop()` および `play()` reject 時に watchdog を明示的にクリアするよう対応
- `ended` イベントを使ったテストを watchdog 経路のテスト（timeupdate / setInterval / duration-currentTime 判定）に書き換え

## Test plan

- [x] `npx vitest run` — 155/155 テスト全通過
- [x] `npm run typecheck` — TypeScript 型エラーなし
- [ ] viewer で複数クリップ連続再生し、各クリップ終了 → 次クリップ再生が動作することを手動確認（VOICEVOX 接続が必要）
- [ ] 最後のクリップ再生終了から 15 秒後にキャラが非表示になることを手動確認

Closes #530

---

🤖 Generated with [Claude Code](https://claude.ai/code)
