### PR TITLE
feat(say): say コマンドに --save-wav フラグを追加する (#534)

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -69,9 +69,19 @@ func registerViewerURLFlag(cmd *cobra.Command) {
 	cmd.Flags().String("viewer-url", viewerURLDefaultFromEnv(), "viewer の HTTP エンドポイント URL (例: http://192.168.1.10:8080)。指定時は lockfile auto-detect をスキップして明示 URL の viewer に POST する。")
 }
 
+// saveWavDefaultFromEnv は VOX_SAVE_WAV 環境変数からデフォルトの保存パスを解決する。
+func saveWavDefaultFromEnv() string {
+	return os.Getenv("VOX_SAVE_WAV")
+}
+
 // registerCommonFlags は各サブコマンド共通のフラグを登録する。
 func registerCommonFlags(cmd *cobra.Command) {
 	registerBaseFlags(cmd)
 	cmd.Flags().Bool("dry-run", false, "VOICEVOX・音声再生を行わず、読み上げ対象をログ出力")
 	registerViewerURLFlag(cmd)
+}
+
+// registerSaveWavFlag は --save-wav フラグを登録する。say コマンドなど wav 保存が必要なコマンドで呼ぶ。
+func registerSaveWavFlag(cmd *cobra.Command) {
+	cmd.Flags().String("save-wav", saveWavDefaultFromEnv(), "合成した WAV を保存するパス（ローカル合成時のみ。親ディレクトリは自動作成）")
 }

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -41,6 +41,7 @@ func makeSayCmd(deps *SayDeps) *cobra.Command {
 	}
 
 	registerCommonFlags(cmd)
+	registerSaveWavFlag(cmd)
 
 	return cmd
 }
@@ -120,13 +121,16 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 		return err
 	}
 
+	saveWavPath, _ := cmd.Flags().GetString("save-wav")
+
 	params := app.SayParams{
-		Text:       args[0],
-		SpeakerID:  speakerID,
-		Speed:      &speed,
-		Pitch:      &pitch,
-		Intonation: &intonation,
-		DryRun:     dryRun,
+		Text:        args[0],
+		SpeakerID:   speakerID,
+		Speed:       &speed,
+		Pitch:       &pitch,
+		Intonation:  &intonation,
+		DryRun:      dryRun,
+		SaveWavPath: saveWavPath,
 	}
 
 	client := deps.ClientFactory(engineURL)
@@ -134,7 +138,12 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 		return fmt.Errorf("failed to create VoicevoxClient for %s", engineURL)
 	}
 
-	uc := app.NewSayUsecase(client, deps.Player, app.WithSayLogger(logger))
+	opts := []app.SayOption{app.WithSayLogger(logger)}
+	if saveWavPath != "" {
+		opts = append(opts, app.WithWavSaver(infra.NewWavSaver()))
+	}
+
+	uc := app.NewSayUsecase(client, deps.Player, opts...)
 	if err := uc.Run(ctx, params); err != nil {
 		return err
 	}

--- a/cmd/say_test.go
+++ b/cmd/say_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -735,5 +736,80 @@ func TestRunSay_LocalMode_PrintsLocalPlaybackToStdout(t *testing.T) {
 	got := strings.TrimSpace(stdout.String())
 	if got != "local_playback" {
 		t.Errorf("expected stdout=local_playback, got %q", got)
+	}
+}
+
+// --- #534 --save-wav テスト ---
+// DONE: --save-wav フラグがヘルプに含まれる             → TestSayCmd_HelpContainsSaveWav
+// DONE: --save-wav デフォルトは空文字                   → TestSayCmd_SaveWavFlag_DefaultEmpty
+// DONE: VOX_SAVE_WAV 環境変数でデフォルト値が設定される → TestSayCmd_EnvVarVOXSaveWav
+// DONE: --save-wav 指定時にファイルが保存される          → TestRunSay_SaveWav_SavesFile
+
+func TestSayCmd_HelpContainsSaveWav(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"say", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected no error for --help, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "--save-wav") {
+		t.Error("expected help output to contain '--save-wav'")
+	}
+}
+
+func TestSayCmd_SaveWavFlag_DefaultEmpty(t *testing.T) {
+	t.Setenv("VOX_SAVE_WAV", "")
+
+	rootCmd := makeRootCmd()
+	sayCmd := findSayCmd(t, rootCmd)
+
+	saveWav, err := sayCmd.Flags().GetString("save-wav")
+	if err != nil {
+		t.Fatalf("expected save-wav flag to exist, got error: %v", err)
+	}
+	if saveWav != "" {
+		t.Errorf("expected default save-wav to be empty, got: %s", saveWav)
+	}
+}
+
+func TestSayCmd_EnvVarVOXSaveWav(t *testing.T) {
+	t.Setenv("VOX_SAVE_WAV", "/tmp/output.wav")
+
+	rootCmd := makeRootCmd()
+	sayCmd := findSayCmd(t, rootCmd)
+
+	saveWav, err := sayCmd.Flags().GetString("save-wav")
+	if err != nil {
+		t.Fatalf("expected save-wav flag to exist, got error: %v", err)
+	}
+	if saveWav != "/tmp/output.wav" {
+		t.Errorf("expected save-wav '/tmp/output.wav', got: %s", saveWav)
+	}
+}
+
+func TestRunSay_SaveWav_SavesFile(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "viewer.lock")
+	wavPath := filepath.Join(dir, "output.wav")
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	registerSaveWavFlag(cmd)
+	_ = cmd.ParseFlags([]string{"--save-wav", wavPath})
+
+	deps := &SayDeps{
+		ClientFactory:    func(_ string) app.VoicevoxClient { return &mockSayClient{} },
+		Player:           &trackingPlayer{playFn: func() {}},
+		LockPathResolver: func() (string, error) { return lockPath, nil },
+	}
+
+	if err := runSay(cmd, []string{"こんにちは"}, deps); err != nil {
+		t.Fatalf("runSay: %v", err)
+	}
+
+	if _, err := os.Stat(wavPath); os.IsNotExist(err) {
+		t.Errorf("expected wav file to be saved at %s", wavPath)
 	}
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,6 +85,7 @@ vox-actor say <text>
 | `--intonation` | — | `1.0` | 抑揚 |
 | `--verbose` | — | `false` | 詳細ログを出力 |
 | `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#dry-runモード)） |
+| `--save-wav` | `VOX_SAVE_WAV` | (未指定) | 合成した WAV をファイルに保存するパス。ローカル合成時のみ有効（viewer 送信経路では保存しない）。親ディレクトリが存在しない場合は自動作成。既存ファイルは上書き。`--dry-run` 時は保存しない。 |
 
 ## `script` サブコマンド
 

--- a/internal/app/port.go
+++ b/internal/app/port.go
@@ -52,6 +52,14 @@ type GitCloner interface {
 	Clone(ctx context.Context, repoURL string, destDir string) error
 }
 
+// WavSaver は WAV データをファイルに保存するインターフェース。
+type WavSaver interface {
+	// Save は wavData を path に保存する。
+	// 親ディレクトリが存在しない場合は自動作成する。
+	// 既存ファイルがある場合は上書きする。
+	Save(path string, wavData []byte) error
+}
+
 // VoicevoxClient はVOICEVOXエンジンとの通信を抽象化するインターフェース。
 type VoicevoxClient interface {
 	// HealthCheck はエンジンの疎通確認を行う。

--- a/internal/app/say_usecase.go
+++ b/internal/app/say_usecase.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 )
 
@@ -14,6 +15,9 @@ type SayParams struct {
 	Intonation *float64
 	// DryRun が true の場合、VOICEVOXエンジン/音声再生を一切呼ばずログ出力のみ行う。
 	DryRun bool
+	// SaveWavPath が空でない場合、合成した WAV をこのパスに保存する。
+	// DryRun 時・viewer 送信経路では保存しない。
+	SaveWavPath string
 }
 
 // SayOption はSayUsecaseの生成時に指定するオプション。
@@ -28,11 +32,21 @@ func WithSayLogger(logger *slog.Logger) SayOption {
 	}
 }
 
+// WithWavSaver は WavSaver を設定するオプション。
+func WithWavSaver(saver WavSaver) SayOption {
+	return func(u *SayUsecase) {
+		if saver != nil {
+			u.wavSaver = saver
+		}
+	}
+}
+
 // SayUsecase はsayサブコマンドのユースケース。
 type SayUsecase struct {
-	client VoicevoxClient
-	player AudioPlayer
-	logger *slog.Logger
+	client   VoicevoxClient
+	player   AudioPlayer
+	logger   *slog.Logger
+	wavSaver WavSaver
 }
 
 // NewSayUsecase は新しいSayUsecaseを生成する。
@@ -87,6 +101,13 @@ func (u *SayUsecase) Run(ctx context.Context, params SayParams) error {
 		return err
 	}
 	u.logger.Info("synthesis completed", "wavSize", len(wavData))
+
+	if params.SaveWavPath != "" && u.wavSaver != nil {
+		if err := u.wavSaver.Save(params.SaveWavPath, wavData); err != nil {
+			return fmt.Errorf("save wav: %w", err)
+		}
+		u.logger.Info("wav saved", "path", params.SaveWavPath)
+	}
 
 	if err := u.player.Play(ctx, wavData, PlayMeta{Text: params.Text, SpeakerID: params.SpeakerID}); err != nil {
 		if ctx.Err() != nil {

--- a/internal/app/say_usecase_test.go
+++ b/internal/app/say_usecase_test.go
@@ -303,3 +303,124 @@ func TestSayUsecase_Run_CancelledContext_ReturnsNil(t *testing.T) {
 		t.Fatalf("expected nil for cancelled context, got: %v", err)
 	}
 }
+
+// --- SaveWavPath テスト (#534) ---
+// DONE: 正常系: SaveWavPath 指定時に WavSaver.Save が呼ばれる
+// DONE: 正常系: SaveWavPath が空の場合 WavSaver.Save は呼ばれない
+// DONE: 正常系: DryRun 時は SaveWavPath 指定でも WavSaver.Save は呼ばれない
+// DONE: 異常系: WavSaver.Save がエラーを返したらエラーが返る
+
+type mockWavSaver struct {
+	saveCalls int
+	savedPath string
+	savedData []byte
+	err       error
+}
+
+func (m *mockWavSaver) Save(path string, data []byte) error {
+	m.saveCalls++
+	m.savedPath = path
+	m.savedData = data
+	return m.err
+}
+
+func TestSayUsecase_Run_SaveWav_SavesFile(t *testing.T) {
+	wavData := []byte("RIFF fake-wav")
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: wavData,
+	}
+	player := &mockAudioPlayer{}
+	saver := &mockWavSaver{}
+
+	uc := app.NewSayUsecase(client, player, app.WithWavSaver(saver))
+	params := app.SayParams{
+		Text:        "こんにちは",
+		SpeakerID:   3,
+		SaveWavPath: "/tmp/test.wav",
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if saver.saveCalls != 1 {
+		t.Errorf("expected 1 Save call, got: %d", saver.saveCalls)
+	}
+	if saver.savedPath != "/tmp/test.wav" {
+		t.Errorf("expected saved path /tmp/test.wav, got: %s", saver.savedPath)
+	}
+	if string(saver.savedData) != string(wavData) {
+		t.Errorf("expected saved data %q, got %q", wavData, saver.savedData)
+	}
+	// 保存後も再生は行われる
+	if player.playCalls != 1 {
+		t.Errorf("expected 1 Play call after save, got: %d", player.playCalls)
+	}
+}
+
+func TestSayUsecase_Run_SaveWav_EmptyPath_NotSaved(t *testing.T) {
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("RIFF fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	saver := &mockWavSaver{}
+
+	uc := app.NewSayUsecase(client, player, app.WithWavSaver(saver))
+	params := app.SayParams{
+		Text:        "こんにちは",
+		SpeakerID:   3,
+		SaveWavPath: "",
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if saver.saveCalls != 0 {
+		t.Errorf("expected 0 Save calls when path is empty, got: %d", saver.saveCalls)
+	}
+}
+
+func TestSayUsecase_Run_SaveWav_DryRun_NotSaved(t *testing.T) {
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("RIFF fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	saver := &mockWavSaver{}
+
+	uc := app.NewSayUsecase(client, player, app.WithWavSaver(saver))
+	params := app.SayParams{
+		Text:        "こんにちは",
+		SpeakerID:   3,
+		SaveWavPath: "/tmp/test.wav",
+		DryRun:      true,
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if saver.saveCalls != 0 {
+		t.Errorf("expected 0 Save calls in dry-run, got: %d", saver.saveCalls)
+	}
+}
+
+func TestSayUsecase_Run_SaveWav_SaveError_ReturnsError(t *testing.T) {
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("RIFF fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	saver := &mockWavSaver{err: errors.New("disk full")}
+
+	uc := app.NewSayUsecase(client, player, app.WithWavSaver(saver))
+	params := app.SayParams{
+		Text:        "こんにちは",
+		SpeakerID:   3,
+		SaveWavPath: "/tmp/test.wav",
+	}
+
+	if err := uc.Run(context.Background(), params); err == nil {
+		t.Fatal("expected error when WavSaver.Save fails, got nil")
+	}
+}

--- a/internal/infra/wav_saver.go
+++ b/internal/infra/wav_saver.go
@@ -1,0 +1,34 @@
+package infra
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canpok1/vox-actor/internal/app"
+)
+
+// WavSaver は WAV データをファイルに保存する。
+// app.WavSaver インターフェースを実装する。
+type WavSaver struct{}
+
+var _ app.WavSaver = (*WavSaver)(nil)
+
+// NewWavSaver は WavSaver を生成する。
+func NewWavSaver() *WavSaver {
+	return &WavSaver{}
+}
+
+// Save は wavData を path に保存する。
+// 親ディレクトリが存在しない場合は自動作成する。
+// 既存ファイルがある場合は上書きする。
+func (s *WavSaver) Save(path string, wavData []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+	if err := os.WriteFile(path, wavData, 0o644); err != nil {
+		return fmt.Errorf("failed to write wav to %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/infra/wav_saver_test.go
+++ b/internal/infra/wav_saver_test.go
@@ -1,0 +1,76 @@
+package infra_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/infra"
+)
+
+// WavSaver テストリスト
+// DONE: 正常系: wav データをファイルに保存できる
+// DONE: 正常系: 既存ファイルを上書きできる
+// DONE: 正常系: 親ディレクトリが存在しない場合に自動作成される
+
+func TestWavSaver_Save_CreatesFileWithContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.wav")
+	data := []byte("RIFF fake wav data")
+
+	saver := infra.NewWavSaver()
+	if err := saver.Save(path, data); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file to exist, got error: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("expected file content %q, got %q", data, got)
+	}
+}
+
+func TestWavSaver_Save_OverwritesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.wav")
+
+	// 既存ファイルを作成
+	if err := os.WriteFile(path, []byte("old content"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	newData := []byte("new wav content")
+	saver := infra.NewWavSaver()
+	if err := saver.Save(path, newData); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file to exist, got error: %v", err)
+	}
+	if string(got) != string(newData) {
+		t.Errorf("expected overwritten content %q, got %q", newData, got)
+	}
+}
+
+func TestWavSaver_Save_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a", "b", "c", "output.wav")
+	data := []byte("RIFF nested wav")
+
+	saver := infra.NewWavSaver()
+	if err := saver.Save(path, data); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file to exist after mkdir-p, got error: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("expected file content %q, got %q", data, got)
+	}
+}


### PR DESCRIPTION
## Summary

- `say` コマンドに `--save-wav <path>` フラグを追加し、ローカル合成した WAV を指定パスに保存できるようにする
- `VOX_SAVE_WAV` 環境変数でも同じ設定が可能
- `internal/infra/wav_saver.go` に `WavSaver` 実装を追加（後続の act/watch コマンドから再利用可能）

## 変更内容

- `internal/app/port.go`: `WavSaver` インターフェース追加
- `internal/infra/wav_saver.go`: `WavSaver` 実装（`mkdir -p` + 上書き保存）
- `internal/app/say_usecase.go`: `SayParams.SaveWavPath` / `WithWavSaver` オプション追加。合成後に保存してから再生
- `cmd/flags.go`: `saveWavDefaultFromEnv()` / `registerSaveWavFlag()` 追加
- `cmd/say.go`: `--save-wav` フラグ読み取り・`WavSaver` 注入
- `docs/reference/cli.md`: `say` セクションに `--save-wav` / `VOX_SAVE_WAV` を追記

## 受け入れ条件チェック

- [x] `say --save-wav <path> "..."` で `<path>` に wav が保存される
- [x] 保存しても再生が行われる
- [x] 保存先親ディレクトリが存在しなければ自動作成される
- [x] 既存ファイルは上書きされる
- [x] viewer 送信経路時は保存されない（`sayViaViewer()` が早期リターン）
- [x] `--dry-run` 併用時は保存されない
- [x] `docs/reference/cli.md` の `say` セクションにフラグ・環境変数を追記

## Test plan

- `go test ./...` で全テスト通過を確認（watch AudioProbe テスト 2件は dev 環境に viewer が起動しているための既存失敗）
- VOICEVOX 接続が必要な手動検証は CI 環境外のため PR test plan に記載:
  - `vox-actor say --save-wav /tmp/test.wav "こんにちは"` で `/tmp/test.wav` に wav ファイルが生成されること
  - `vox-actor say --save-wav /tmp/subdir/test.wav "こんにちは"` で親ディレクトリが自動作成されること
  - viewer 起動中に `vox-actor say --save-wav /tmp/test.wav "..."` で wav が保存されないこと
  - `vox-actor say --dry-run --save-wav /tmp/test.wav "..."` で wav が保存されないこと

Closes #534

---
🤖 Generated with [Claude Code](https://claude.ai/code)
