### PR TITLE
feat(watch): --save-wav-dir フラグを追加して検出セリフの WAV を保存する

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -85,3 +85,13 @@ func registerCommonFlags(cmd *cobra.Command) {
 func registerSaveWavFlag(cmd *cobra.Command) {
 	cmd.Flags().String("save-wav", saveWavDefaultFromEnv(), "合成した WAV を保存するパス（ローカル合成時のみ。親ディレクトリは自動作成）")
 }
+
+// saveWavDirDefaultFromEnv は VOX_SAVE_WAV_DIR 環境変数からデフォルトの保存ディレクトリを解決する。
+func saveWavDirDefaultFromEnv() string {
+	return os.Getenv("VOX_SAVE_WAV_DIR")
+}
+
+// registerSaveWavDirFlag は --save-wav-dir フラグを登録する。watch コマンドなど wav 一括保存が必要なコマンドで呼ぶ。
+func registerSaveWavDirFlag(cmd *cobra.Command) {
+	cmd.Flags().String("save-wav-dir", saveWavDirDefaultFromEnv(), "合成した WAV を保存するディレクトリ（ローカル合成時のみ。未作成なら自動作成）")
+}

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -53,6 +53,7 @@ func makeWatchCmd(deps *WatchDeps) *cobra.Command {
 	}
 
 	registerCommonFlags(cmd)
+	registerSaveWavDirFlag(cmd)
 	cmd.Flags().Bool("delete", false, "処理済みファイルを削除する（未指定時は各ディレクトリの done/ に移動）")
 	cmd.Flags().Bool("queue", false, "vox-actor config path.queue で解決される queue ディレクトリを監視対象に自動選択する（位置引数と併用不可、起動時に自動作成）")
 
@@ -169,6 +170,7 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	saveWavDir, _ := cmd.Flags().GetString("save-wav-dir")
 
 	if deps == nil || deps.ClientFactory == nil || deps.Reader == nil || deps.Player == nil || deps.Mover == nil || deps.DirWatcherFactory == nil {
 		return fmt.Errorf("watch command dependencies are not initialized")
@@ -238,6 +240,10 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 		return err
 	}
 
+	if saveWavDir != "" {
+		opts = append(opts, app.WithWatchWavSaver(infra.NewWavSaver()))
+	}
+
 	uc := app.NewWatchUsecase(deps.Reader, client, deps.Player, deps.Mover, watcher, opts...)
 	return uc.Run(ctx, app.WatchParams{
 		Paths:      args,
@@ -246,5 +252,6 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 		Pitch:      &pitch,
 		Intonation: &intonation,
 		DryRun:     dryRun,
+		SaveWavDir: saveWavDir,
 	})
 }

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -799,3 +799,121 @@ func TestRunWatch_LockfileAutoDetect_PostsToViewer(t *testing.T) {
 		t.Error("expected at least 1 POST to /api/play via lockfile auto-detect, got 0")
 	}
 }
+
+// --- --save-wav-dir フラグテスト ---
+// DONE: --save-wav-dir がヘルプに含まれる                          → TestWatchCmd_HelpContainsSaveWavDir
+// DONE: --save-wav-dir デフォルトは空文字                          → TestWatchCmd_SaveWavDirFlag_DefaultEmpty
+// DONE: VOX_SAVE_WAV_DIR 環境変数でデフォルト値が設定される        → TestWatchCmd_EnvVarVOXSaveWavDir
+
+func TestWatchCmd_HelpContainsSaveWavDir(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"watch", "--help"})
+
+	_ = rootCmd.Execute()
+	if !strings.Contains(buf.String(), "--save-wav-dir") {
+		t.Error("expected help output to contain '--save-wav-dir'")
+	}
+}
+
+func TestWatchCmd_SaveWavDirFlag_DefaultEmpty(t *testing.T) {
+	t.Setenv("VOX_SAVE_WAV_DIR", "")
+
+	rootCmd := makeRootCmd()
+	watchCmd := findWatchCmd(t, rootCmd)
+
+	val, err := watchCmd.Flags().GetString("save-wav-dir")
+	if err != nil {
+		t.Fatalf("expected save-wav-dir flag to exist, got error: %v", err)
+	}
+	if val != "" {
+		t.Errorf("expected default save-wav-dir to be empty, got: %s", val)
+	}
+}
+
+func TestWatchCmd_EnvVarVOXSaveWavDir(t *testing.T) {
+	t.Setenv("VOX_SAVE_WAV_DIR", "/tmp/wav-out")
+
+	rootCmd := makeRootCmd()
+	watchCmd := findWatchCmd(t, rootCmd)
+
+	val, err := watchCmd.Flags().GetString("save-wav-dir")
+	if err != nil {
+		t.Fatalf("expected save-wav-dir flag to exist, got error: %v", err)
+	}
+	if val != "/tmp/wav-out" {
+		t.Errorf("expected save-wav-dir '/tmp/wav-out', got: %s", val)
+	}
+}
+
+// DONE: --save-wav-dir 指定時にローカル合成で wav ファイルが saveDir に書き出される → TestRunWatch_SaveWavDir_WritesFileToDir
+
+// fixedScriptReader は固定スクリプトを返すテスト用 ScriptReader。
+type fixedScriptReader struct {
+	scripts []entity.Script
+}
+
+func (r fixedScriptReader) Read(_ string) ([]entity.Script, error) { return r.scripts, nil }
+
+func TestRunWatch_SaveWavDir_WritesFileToDir(t *testing.T) {
+	watchDir := t.TempDir()
+	saveDir := t.TempDir()
+	lockPath := filepath.Join(t.TempDir(), "viewer.lock") // 存在しない = viewer なし
+	scriptFile := filepath.Join(watchDir, "a.txt")
+
+	cmd := newCmdWithContext(t)
+	registerCommonFlags(cmd)
+	registerSaveWavDirFlag(cmd)
+	cmd.Flags().Bool("delete", false, "")
+	cmd.Flags().Bool("queue", false, "")
+	_ = cmd.ParseFlags([]string{"--save-wav-dir", saveDir})
+
+	deps := &WatchDeps{
+		ClientFactory: func(_ string) app.VoicevoxClient { return &mockSayClient{} },
+		Reader: fixedScriptReader{scripts: []entity.Script{
+			{Path: scriptFile, Text: "テスト", IsEmpty: false},
+		}},
+		Player:            stubAudioPlayer{},
+		Mover:             stubFileMover{},
+		DirWatcherFactory: func(_ *slog.Logger) app.DirWatcher { return &oneFileDirWatcher{filePath: scriptFile} },
+		LockPathResolver:  func() (string, error) { return lockPath, nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd.SetContext(ctx)
+
+	done := make(chan error, 1)
+	go func() { done <- runWatch(cmd, []string{watchDir}, deps) }()
+
+	for range 100 {
+		entries, _ := os.ReadDir(saveDir)
+		var count int
+		for _, e := range entries {
+			if filepath.Ext(e.Name()) == ".wav" {
+				count++
+			}
+		}
+		if count > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	entries, err := os.ReadDir(saveDir)
+	if err != nil {
+		t.Fatalf("failed to read saveDir: %v", err)
+	}
+	var wavFiles []string
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".wav" {
+			wavFiles = append(wavFiles, e.Name())
+		}
+	}
+	if len(wavFiles) != 1 {
+		t.Errorf("expected 1 wav file in saveDir, got %d: %v", len(wavFiles), wavFiles)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -212,6 +212,7 @@ vox-actor watch --queue
 | `--intonation` | — | `1.0` | 抑揚 |
 | `--delete` | — | `false` | 処理済みファイルを削除（未指定時は各ディレクトリの `done/` に移動） |
 | `--queue` | — | `false` | `vox-actor config path.queue` で解決される queue ディレクトリを監視対象に自動選択（[詳細](#queueオプション)） |
+| `--save-wav-dir` | `VOX_SAVE_WAV_DIR` | (未指定) | 合成した WAV を保存するディレクトリ。ファイル名は `<UnixMs>_<text先頭20文字>.wav`（ローカル合成時のみ保存。未作成なら自動作成。`--dry-run` および viewer 送信時は保存しない） |
 | `--verbose` | — | `false` | 詳細ログを出力 |
 | `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#dry-runモード)） |
 

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -5,10 +5,32 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"sync"
+	"time"
+	"unicode"
 
 	"github.com/canpok1/vox-actor/internal/domain/entity"
 )
+
+// GenerateWavFilename はタイムスタンプとテキストから WAV ファイル名を生成する。
+// テキストはパス区切り文字と制御文字を _ に置換し、先頭 20 ルーンに切り捨てる。
+// 書式: <nowMs>_<sanitized20>.wav
+func GenerateWavFilename(text string, nowMs int64) string {
+	runes := []rune(text)
+	if len(runes) > 20 {
+		runes = runes[:20]
+	}
+	var b strings.Builder
+	for _, r := range runes {
+		if r == '/' || r == '\\' || unicode.IsControl(r) {
+			b.WriteRune('_')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return fmt.Sprintf("%d_%s.wav", nowMs, b.String())
+}
 
 // WatchParams はWatchUsecaseのパラメータ。
 type WatchParams struct {
@@ -20,6 +42,9 @@ type WatchParams struct {
 	// DryRun が true の場合、VOICEVOXエンジン/音声再生は一切呼ばずログ出力のみ行う。
 	// ディレクトリ監視・done/移動・削除は通常通り実施する。
 	DryRun bool
+	// SaveWavDir が空でない場合、ローカル合成した WAV をこのディレクトリに保存する。
+	// DryRun 時・viewer 送信経路では保存しない。
+	SaveWavDir string
 }
 
 // WatchOption はWatchUsecaseの生成時に指定するオプション。
@@ -45,6 +70,20 @@ func WithDeleteMode() WatchOption {
 func WithSilent() WatchOption {
 	return func(u *WatchUsecase) {
 		u.silent = true
+	}
+}
+
+// WithWatchWavSaver は WAV 保存機能を有効にするオプション。
+func WithWatchWavSaver(saver WavSaver) WatchOption {
+	return func(u *WatchUsecase) {
+		u.wavSaver = saver
+	}
+}
+
+// WithWatchNowFunc は時刻取得関数を差し替えるオプション（テスト用）。
+func WithWatchNowFunc(now func() time.Time) WatchOption {
+	return func(u *WatchUsecase) {
+		u.nowFunc = now
 	}
 }
 
@@ -93,7 +132,9 @@ type WatchUsecase struct {
 	deleteMode bool
 	// silent が true の場合、HealthCheck / 合成パイプラインを一切呼ばず
 	// player.PlayText 経由でテキストのみ配信する。
-	silent bool
+	silent   bool
+	wavSaver WavSaver
+	nowFunc  func() time.Time
 }
 
 // NewWatchUsecase は新しいWatchUsecaseを生成する。
@@ -105,6 +146,7 @@ func NewWatchUsecase(reader ScriptReader, client VoicevoxClient, player AudioPla
 		mover:   mover,
 		watcher: watcher,
 		logger:  discardLogger(),
+		nowFunc: time.Now,
 	}
 	for _, opt := range opts {
 		opt(u)
@@ -290,6 +332,16 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 		}
 
 		u.logger.Debug("processing script", "path", result.script.Path)
+
+		if params.SaveWavDir != "" && u.wavSaver != nil {
+			filename := GenerateWavFilename(result.script.Text, u.nowFunc().UnixMilli())
+			savePath := filepath.Join(params.SaveWavDir, filename)
+			if err := u.wavSaver.Save(savePath, result.wav); err != nil {
+				u.logger.Error("save wav error (skipping save)", "path", savePath, "error", err)
+			} else {
+				u.logger.Info("wav saved", "path", savePath)
+			}
+		}
 
 		if err := u.player.Play(ctx, result.wav, PlayMeta{Text: result.script.Text, SpeakerID: speakerID}); err != nil {
 			u.logger.Error("play error (skipping script)", "path", result.script.Path, "error", err)

--- a/internal/app/watch_usecase_test.go
+++ b/internal/app/watch_usecase_test.go
@@ -1601,3 +1601,203 @@ func TestWatchUsecase_Run_BroadcastsConnectionError_OnHealthCheckFailure(t *test
 		t.Errorf("expected message to contain underlying error, got %q", e.Message)
 	}
 }
+
+// --- GenerateWavFilename テスト ---
+// DONE: 基本形: <UnixMs>_<text>.wav が生成される               → TestGenerateWavFilename_Basic
+// DONE: テキスト20文字超は先頭20文字に切り捨て               → TestGenerateWavFilename_Truncates20Runes
+// DONE: / を _ に置換する                                       → TestGenerateWavFilename_SanitizesForwardSlash
+// DONE: \ を _ に置換する                                       → TestGenerateWavFilename_SanitizesBackslash
+// DONE: 制御文字を _ に置換する                                 → TestGenerateWavFilename_SanitizesControlChars
+
+func TestGenerateWavFilename_Basic(t *testing.T) {
+	got := app.GenerateWavFilename("こんにちは", 1000)
+	want := "1000_こんにちは.wav"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestGenerateWavFilename_Truncates20Runes(t *testing.T) {
+	text := "あいうえおかきくけこさしすせそたちつてと超過分"
+	got := app.GenerateWavFilename(text, 2000)
+	want := "2000_あいうえおかきくけこさしすせそたちつてと.wav"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestGenerateWavFilename_SanitizesForwardSlash(t *testing.T) {
+	got := app.GenerateWavFilename("a/b", 3000)
+	want := "3000_a_b.wav"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestGenerateWavFilename_SanitizesBackslash(t *testing.T) {
+	got := app.GenerateWavFilename("a\\b", 4000)
+	want := "4000_a_b.wav"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestGenerateWavFilename_SanitizesControlChars(t *testing.T) {
+	got := app.GenerateWavFilename("a\nb", 5000)
+	want := "5000_a_b.wav"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// --- WatchUsecase WavSaver 統合テスト ---
+// DONE: SaveWavDir 指定時にローカル合成で wavSaver.Save が呼ばれる     → TestWatchUsecase_Run_SavesWav_WhenSaveWavDirSet
+// DONE: SaveWavDir が空の場合は wavSaver.Save は呼ばれない             → TestWatchUsecase_Run_DoesNotSaveWav_WhenSaveWavDirEmpty
+// DONE: DryRun 時は wavSaver.Save は呼ばれない                         → TestWatchUsecase_Run_DoesNotSaveWav_WhenDryRun
+// DONE: WithSilent（viewer 経路）時は wavSaver.Save は呼ばれない       → TestWatchUsecase_Run_DoesNotSaveWav_WhenSilent
+
+type mockWavSaverForWatch struct {
+	mu         sync.Mutex
+	savedPaths []string
+	savedData  [][]byte
+	err        error
+}
+
+func (m *mockWavSaverForWatch) Save(path string, data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.savedPaths = append(m.savedPaths, path)
+	m.savedData = append(m.savedData, data)
+	return m.err
+}
+
+func TestWatchUsecase_Run_SavesWav_WhenSaveWavDirSet(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "こんにちは", IsEmpty: false},
+		},
+	}
+	wavBytes := []byte("fake-wav")
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: wavBytes,
+	}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+	saver := &mockWavSaverForWatch{}
+	fixedNowMs := int64(9999)
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher,
+		app.WithWatchWavSaver(saver),
+		app.WithWatchNowFunc(func() time.Time { return time.UnixMilli(fixedNowMs) }),
+	)
+	params := app.WatchParams{
+		Paths:      []string{"/tmp/watch"},
+		SpeakerID:  3,
+		SaveWavDir: "/out",
+	}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(saver.savedPaths) != 1 {
+		t.Fatalf("expected 1 save call, got %d", len(saver.savedPaths))
+	}
+	wantPath := "/out/" + app.GenerateWavFilename("こんにちは", fixedNowMs)
+	if saver.savedPaths[0] != wantPath {
+		t.Errorf("saved path = %q, want %q", saver.savedPaths[0], wantPath)
+	}
+	if !bytes.Equal(saver.savedData[0], wavBytes) {
+		t.Errorf("saved data does not match wav bytes")
+	}
+}
+
+func TestWatchUsecase_Run_DoesNotSaveWav_WhenSaveWavDirEmpty(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "テスト", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{query: &entity.AudioQuery{}, wavData: []byte("w")}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+	saver := &mockWavSaverForWatch{}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher,
+		app.WithWatchWavSaver(saver),
+	)
+	params := app.WatchParams{
+		Paths:      []string{"/tmp/watch"},
+		SpeakerID:  3,
+		SaveWavDir: "",
+	}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(saver.savedPaths) != 0 {
+		t.Errorf("expected no save calls, got %d: %v", len(saver.savedPaths), saver.savedPaths)
+	}
+}
+
+func TestWatchUsecase_Run_DoesNotSaveWav_WhenDryRun(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "テスト", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{query: &entity.AudioQuery{}, wavData: []byte("w")}
+	player := &mockAudioPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+	saver := &mockWavSaverForWatch{}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher,
+		app.WithWatchWavSaver(saver),
+	)
+	params := app.WatchParams{
+		Paths:      []string{"/tmp/watch"},
+		SpeakerID:  3,
+		SaveWavDir: "/out",
+		DryRun:     true,
+	}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(saver.savedPaths) != 0 {
+		t.Errorf("expected no save calls during dry-run, got %d", len(saver.savedPaths))
+	}
+}
+
+func TestWatchUsecase_Run_DoesNotSaveWav_WhenSilent(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "テスト", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{query: &entity.AudioQuery{}, wavData: []byte("w")}
+	player := &recordingErrorPlayer{}
+	mover := &mockFileMover{}
+	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
+	saver := &mockWavSaverForWatch{}
+
+	uc := app.NewWatchUsecase(reader, client, player, mover, watcher,
+		app.WithWatchWavSaver(saver),
+		app.WithSilent(),
+	)
+	params := app.WatchParams{
+		Paths:      []string{"/tmp/watch"},
+		SpeakerID:  3,
+		SaveWavDir: "/out",
+	}
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(saver.savedPaths) != 0 {
+		t.Errorf("expected no save calls in silent mode, got %d", len(saver.savedPaths))
+	}
+}


### PR DESCRIPTION
## Summary

- `watch <dir> --save-wav-dir <out>` でローカル合成した WAV を `<out>` に保存する機能を追加
- ファイル名規則: `<UnixMs>_<text先頭20文字>.wav`（`/` `\` 制御文字は `_` に置換）
- 保存先ディレクトリが未作成なら自動作成（`os.MkdirAll`）
- 保存しても再生は通常通り行う
- viewer 送信経路（`WithSilent`）では保存しない
- `--dry-run` 時は保存しない
- 環境変数 `VOX_SAVE_WAV_DIR` でも同じ指定が可能
- `docs/reference/cli.md` の `watch` セクションにフラグ・環境変数を追記

## 実装詳細

- `internal/app/watch_usecase.go`: `GenerateWavFilename`、`WatchParams.SaveWavDir`、`WithWatchWavSaver`、`WithWatchNowFunc` を追加。`processFile` のローカル合成パスに wav 保存ロジックを差し込み
- `cmd/flags.go`: `registerSaveWavDirFlag`（`VOX_SAVE_WAV_DIR` 環境変数対応）を追加
- `cmd/watch.go`: フラグ登録 + `WithWatchWavSaver` の wiring を追加

## Test plan

- [ ] `go test ./internal/app/... -run "TestGenerateWavFilename|TestWatchUsecase_Run_SavesWav|TestWatchUsecase_Run_DoesNotSaveWav"` が全て PASS
- [ ] `go test ./cmd/... -run "TestWatchCmd.*SaveWav|TestRunWatch_SaveWavDir"` が全て PASS
- [ ] VOICEVOX 接続が必要な実機確認（CI 自動化不可）:
  - `vox-actor watch <dir> --save-wav-dir <out>` でファイルを配置すると `<out>` 配下に `.wav` が保存される
  - ファイル名が `<UnixMs>_<text先頭20文字>.wav` 形式になっている
  - `--dry-run` 付与時は `<out>` に何も書き出されない

Closes #536

---
🤖 Generated with [Claude Code](https://claude.ai/code)
