### PR TITLE
feat(viewer): --save-wav-dir フラグを追加して合成 clip の WAV を保存する

### DIFF
--- a/cmd/viewer.go
+++ b/cmd/viewer.go
@@ -99,6 +99,7 @@ func makeViewerCmd(deps *ViewerDeps) *cobra.Command {
 	registerBaseFlags(cmd)
 	cmd.Flags().String("host", "127.0.0.1", "HTTPサーバーのバインドホスト")
 	cmd.Flags().Int("port", 8080, "HTTPサーバーのバインドポート")
+	registerSaveWavDirFlag(cmd)
 
 	return cmd
 }
@@ -131,6 +132,7 @@ func runViewer(cmd *cobra.Command, deps *ViewerDeps) error {
 	host, _ := cmd.Flags().GetString("host")
 	port, _ := cmd.Flags().GetInt("port")
 	engineURL, _ := cmd.Flags().GetString("engine-url")
+	saveWavDir, _ := cmd.Flags().GetString("save-wav-dir")
 
 	if port < 1 || port > 65535 {
 		return fmt.Errorf("%w: invalid port: %d", ErrUsage, port)
@@ -151,7 +153,23 @@ func runViewer(cmd *cobra.Command, deps *ViewerDeps) error {
 		return fmt.Errorf("failed to create VoicevoxClient for %s", engineURL)
 	}
 
-	sp, silent, err := startStreamPlayer(ctx, addr, logger, client, deps.StreamPlayerFactory)
+	factory := deps.StreamPlayerFactory
+	if saveWavDir != "" {
+		saver := infra.NewWavSaver()
+		origFactory := deps.StreamPlayerFactory
+		factory = func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, orderedSpeakerIDs []int, client app.VoicevoxClient) (app.StreamPlayer, error) {
+			sp, err := origFactory(addr, logger, speakerLookup, orderedSpeakerIDs, client)
+			if err != nil {
+				return nil, err
+			}
+			if httpSP, ok := sp.(*infra.HTTPStreamPlayer); ok {
+				infra.WithSaveWavDir(saveWavDir, saver)(httpSP)
+			}
+			return sp, nil
+		}
+	}
+
+	sp, silent, err := startStreamPlayer(ctx, addr, logger, client, factory)
 	if err != nil {
 		return err
 	}

--- a/cmd/viewer.go
+++ b/cmd/viewer.go
@@ -156,9 +156,8 @@ func runViewer(cmd *cobra.Command, deps *ViewerDeps) error {
 	factory := deps.StreamPlayerFactory
 	if saveWavDir != "" {
 		saver := infra.NewWavSaver()
-		origFactory := deps.StreamPlayerFactory
 		factory = func(addr string, logger *slog.Logger, speakerLookup map[int]entity.SpeakerStyleInfo, orderedSpeakerIDs []int, client app.VoicevoxClient) (app.StreamPlayer, error) {
-			sp, err := origFactory(addr, logger, speakerLookup, orderedSpeakerIDs, client)
+			sp, err := deps.StreamPlayerFactory(addr, logger, speakerLookup, orderedSpeakerIDs, client)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/viewer_test.go
+++ b/cmd/viewer_test.go
@@ -355,6 +355,48 @@ func TestResolveViewerLockPath_IgnoresVoxActorWorkspaceEnv(t *testing.T) {
 	}
 }
 
+// --- #537 --save-wav-dir テスト ---
+// DONE: --save-wav-dir がヘルプに含まれる          → TestViewerCmd_HelpContainsSaveWavDir
+// DONE: --save-wav-dir デフォルトは空文字          → TestViewerCmd_SaveWavDirFlag_DefaultEmpty
+// DONE: VOX_SAVE_WAV_DIR が --save-wav-dir のデフォルトに反映される → TestViewerCmd_EnvVarVOXSaveWavDir
+
+func TestViewerCmd_HelpContainsSaveWavDir(t *testing.T) {
+	rootCmd := makeRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"viewer", "--help"})
+	_ = rootCmd.Execute()
+	if !strings.Contains(buf.String(), "--save-wav-dir") {
+		t.Errorf("expected help output to contain '--save-wav-dir'\noutput:\n%s", buf.String())
+	}
+}
+
+func TestViewerCmd_SaveWavDirFlag_DefaultEmpty(t *testing.T) {
+	t.Setenv("VOX_SAVE_WAV_DIR", "")
+	rootCmd := makeRootCmd()
+	viewerCmd := findViewerCmd(t, rootCmd)
+	val, err := viewerCmd.Flags().GetString("save-wav-dir")
+	if err != nil {
+		t.Fatalf("expected save-wav-dir flag to exist, got error: %v", err)
+	}
+	if val != "" {
+		t.Errorf("expected default save-wav-dir to be empty, got: %s", val)
+	}
+}
+
+func TestViewerCmd_EnvVarVOXSaveWavDir(t *testing.T) {
+	t.Setenv("VOX_SAVE_WAV_DIR", "/tmp/wav-out")
+	rootCmd := makeRootCmd()
+	viewerCmd := findViewerCmd(t, rootCmd)
+	val, err := viewerCmd.Flags().GetString("save-wav-dir")
+	if err != nil {
+		t.Fatalf("expected save-wav-dir flag to exist, got error: %v", err)
+	}
+	if val != "/tmp/wav-out" {
+		t.Errorf("expected save-wav-dir '/tmp/wav-out', got: %s", val)
+	}
+}
+
 func TestViewerCmd_AlreadyRunning_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, "viewer", "viewer.lock")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -247,7 +247,8 @@ vox-actor watch --queue --delete
 ```
 vox-actor viewer [--host <host>] [--port <port>] \
                  [--engine-url <url>] [--speaker <id>] \
-                 [--speed N] [--pitch N] [--intonation N] [--verbose]
+                 [--speed N] [--pitch N] [--intonation N] [--verbose] \
+                 [--save-wav-dir <dir>]
 ```
 
 HTTPサーバーとブラウザUIを起動し、SSE経由でブラウザに音声を配信する。ディレクトリ監視が必要な場合は `vox-actor watch` を別途起動してください。
@@ -262,6 +263,7 @@ HTTPサーバーとブラウザUIを起動し、SSE経由でブラウザに音�
 | `--pitch` | — | `0.0` | 音高 |
 | `--intonation` | — | `1.0` | 抑揚 |
 | `--verbose` | — | `false` | 詳細ログを出力 |
+| `--save-wav-dir` | `VOX_SAVE_WAV_DIR` | (未指定) | 合成した WAV を保存するディレクトリ。ファイル名は `<UnixMs>_<text先頭20文字>.wav`。保存先が存在しない場合は自動作成。 |
 
 ### 起動パターン
 

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -90,6 +90,11 @@ type HTTPStreamPlayer struct {
 	// workerCancel は worker goroutine と GC goroutine を停止するためのキャンセル関数。
 	workerCancel context.CancelFunc
 
+	// saveWavDir が空でない場合、Play() で合成した WAV をこのディレクトリに保存する。
+	saveWavDir string
+	// wavSaver は WAV ファイルの保存に使うインターフェース。saveWavDir が空でなければ必須。
+	wavSaver app.WavSaver
+
 	// prefetchLeadTime は次クリップを前倒し broadcast するリードタイム。
 	// 現クリップの推定再生時間残り prefetchLeadTime の段階で次クリップの clipEvent を送信する。
 	prefetchLeadTime time.Duration
@@ -291,6 +296,17 @@ func WithHistoryDir(dir string) HTTPStreamOption {
 	return func(p *HTTPStreamPlayer) {
 		if dir != "" {
 			p.historyDir = dir
+		}
+	}
+}
+
+// WithSaveWavDir は Play() で合成した WAV を保存するディレクトリと保存実装を設定するオプション。
+// dir が空文字の場合は WAV 保存を行わない。
+func WithSaveWavDir(dir string, saver app.WavSaver) HTTPStreamOption {
+	return func(p *HTTPStreamPlayer) {
+		if dir != "" && saver != nil {
+			p.saveWavDir = dir
+			p.wavSaver = saver
 		}
 	}
 }
@@ -566,6 +582,13 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 	payload, err := json.Marshal(ev)
 	if err != nil {
 		return fmt.Errorf("failed to marshal clip payload: %w", err)
+	}
+
+	if p.saveWavDir != "" && p.wavSaver != nil {
+		savePath := filepath.Join(p.saveWavDir, app.GenerateWavFilename(meta.Text, ts))
+		if err := p.wavSaver.Save(savePath, buf); err != nil {
+			p.logger.Warn("failed to save wav", "path", savePath, "error", err)
+		}
 	}
 
 	n, dropped := p.subscribers.broadcast(sseEventClip, payload)

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -92,8 +92,7 @@ type HTTPStreamPlayer struct {
 
 	// saveWavDir が空でない場合、Play() で合成した WAV をこのディレクトリに保存する。
 	saveWavDir string
-	// wavSaver は WAV ファイルの保存に使うインターフェース。saveWavDir が空でなければ必須。
-	wavSaver app.WavSaver
+	wavSaver   app.WavSaver
 
 	// prefetchLeadTime は次クリップを前倒し broadcast するリードタイム。
 	// 現クリップの推定再生時間残り prefetchLeadTime の段階で次クリップの clipEvent を送信する。
@@ -584,7 +583,7 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 		return fmt.Errorf("failed to marshal clip payload: %w", err)
 	}
 
-	if p.saveWavDir != "" && p.wavSaver != nil {
+	if p.saveWavDir != "" {
 		savePath := filepath.Join(p.saveWavDir, app.GenerateWavFilename(meta.Text, ts))
 		if err := p.wavSaver.Save(savePath, buf); err != nil {
 			p.logger.Warn("failed to save wav", "path", savePath, "error", err)

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -89,6 +89,10 @@ package infra
 // TODO: 当日ファイルなし時も正常起動                             → TestHTTPStreamPlayer_Start_NoHistoryFile
 // TODO: /api/history が当日末尾 50 件を返す                      → TestHTTPStreamPlayer_APIHistory_ReturnsTodaysEntries
 // TODO: /api/history がファイルなし時に空配列を返す              → TestHTTPStreamPlayer_APIHistory_EmptyWhenNoFile
+//
+// #537 --save-wav-dir:
+// DONE: WithSaveWavDir 設定時に Play() で WAV が saveWavDir に保存される   → TestHTTPStreamPlayer_Play_SavesWavWhenSaveWavDirSet
+// DONE: WithSaveWavDir 未設定時は Play() で WAV は保存されない             → TestHTTPStreamPlayer_Play_DoesNotSaveWavWhenSaveWavDirEmpty
 
 import (
 	"bufio"
@@ -3477,5 +3481,68 @@ func TestHTTPStreamPlayer_APIPlayback_TTLExpiry(t *testing.T) {
 	}
 	if result.Status != "unknown" {
 		t.Errorf("expected status=unknown after TTL expiry, got %q", result.Status)
+	}
+}
+
+// --- #537 --save-wav-dir テスト ---
+
+type stubWavSaverForStream struct {
+	mu    sync.Mutex
+	saved map[string][]byte
+}
+
+func (s *stubWavSaverForStream) Save(path string, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.saved == nil {
+		s.saved = make(map[string][]byte)
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	s.saved[path] = cp
+	return nil
+}
+
+func TestHTTPStreamPlayer_Play_SavesWavWhenSaveWavDirSet(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	saver := &stubWavSaverForStream{}
+	fixed := time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC)
+	p := newStartedPlayerWithOpts(t,
+		WithSaveWavDir(dir, saver),
+		withNowFunc(func() time.Time { return fixed }),
+	)
+
+	wav := []byte("RIFFwavdata")
+	if err := p.Play(context.Background(), wav, app.PlayMeta{Text: "テスト"}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	saver.mu.Lock()
+	defer saver.mu.Unlock()
+	if len(saver.saved) != 1 {
+		t.Fatalf("expected 1 saved file, got %d", len(saver.saved))
+	}
+	expectedFilename := app.GenerateWavFilename("テスト", fixed.UnixMilli())
+	expectedPath := filepath.Join(dir, expectedFilename)
+	if _, ok := saver.saved[expectedPath]; !ok {
+		t.Errorf("expected saved path %q, got paths: %v", expectedPath, saver.saved)
+	}
+}
+
+func TestHTTPStreamPlayer_Play_DoesNotSaveWavWhenSaveWavDirEmpty(t *testing.T) {
+	t.Parallel()
+	saver := &stubWavSaverForStream{}
+	p := newStartedPlayerWithOpts(t)
+
+	wav := []byte("RIFFwavdata")
+	if err := p.Play(context.Background(), wav, app.PlayMeta{Text: "テスト"}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	saver.mu.Lock()
+	defer saver.mu.Unlock()
+	if len(saver.saved) != 0 {
+		t.Errorf("expected no saved files, got %d", len(saver.saved))
 	}
 }

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -92,7 +92,7 @@ package infra
 //
 // #537 --save-wav-dir:
 // DONE: WithSaveWavDir 設定時に Play() で WAV が saveWavDir に保存される   → TestHTTPStreamPlayer_Play_SavesWavWhenSaveWavDirSet
-// DONE: WithSaveWavDir 未設定時は Play() で WAV は保存されない             → TestHTTPStreamPlayer_Play_DoesNotSaveWavWhenSaveWavDirEmpty
+// DONE: WithSaveWavDir 未設定時は Play() がパニックしない                   → TestHTTPStreamPlayer_Play_DoesNotPanicWhenSaveWavDirNotSet
 
 import (
 	"bufio"
@@ -3530,19 +3530,11 @@ func TestHTTPStreamPlayer_Play_SavesWavWhenSaveWavDirSet(t *testing.T) {
 	}
 }
 
-func TestHTTPStreamPlayer_Play_DoesNotSaveWavWhenSaveWavDirEmpty(t *testing.T) {
+func TestHTTPStreamPlayer_Play_DoesNotPanicWhenSaveWavDirNotSet(t *testing.T) {
 	t.Parallel()
-	saver := &stubWavSaverForStream{}
-	p := newStartedPlayerWithOpts(t)
-
+	p := newStartedPlayerWithOpts(t) // WithSaveWavDir 未設定
 	wav := []byte("RIFFwavdata")
 	if err := p.Play(context.Background(), wav, app.PlayMeta{Text: "テスト"}); err != nil {
 		t.Fatalf("Play: %v", err)
-	}
-
-	saver.mu.Lock()
-	defer saver.mu.Unlock()
-	if len(saver.saved) != 0 {
-		t.Errorf("expected no saved files, got %d", len(saver.saved))
 	}
 }


### PR DESCRIPTION
## Summary

- `vox-actor viewer` コマンドに `--save-wav-dir <dir>` フラグを追加
- viewer 内部で合成した全 clip の WAV を指定ディレクトリに保存できるようにした
- ファイル名規則: `<UnixMs>_<text先頭20文字>.wav`（先行 PR #538/#540 で導入済みの `app.GenerateWavFilename` を再利用）
- 保存先が未作成の場合は自動作成
- 環境変数 `VOX_SAVE_WAV_DIR` でも同じ指定が可能（`cmd/flags.go` の既存関数を共有）
- 配信・再生は従来通り継続

## 実装詳細

- `internal/infra/http_stream_player.go`
  - `HTTPStreamPlayer` に `saveWavDir`/`wavSaver` フィールドを追加
  - `WithSaveWavDir(dir string, saver app.WavSaver) HTTPStreamOption` を追加
  - `Play()` 内で `saveWavDir` が設定されていれば WAV を保存（WARN ログで失敗を通知、再生は継続）
- `cmd/viewer.go`
  - `registerSaveWavDirFlag(cmd)` を追加（`flags.go` の既存関数を共有）
  - `runViewer` で `saveWavDir` フラグを読み取り、factory ラッパーで `WithSaveWavDir` を適用
- `docs/reference/cli.md` の viewer セクションにフラグ・環境変数を追記

## Test plan

- [ ] `go test ./internal/infra/ -run TestHTTPStreamPlayer_Play_SavesWavWhenSaveWavDirSet` PASS
- [ ] `go test ./internal/infra/ -run TestHTTPStreamPlayer_Play_DoesNotPanicWhenSaveWavDirNotSet` PASS
- [ ] `go test ./cmd/ -run TestViewerCmd_HelpContainsSaveWavDir` PASS
- [ ] `go test ./cmd/ -run TestViewerCmd_SaveWavDirFlag_DefaultEmpty` PASS
- [ ] `go test ./cmd/ -run TestViewerCmd_EnvVarVOXSaveWavDir` PASS
- [ ] 手動確認: `vox-actor viewer --save-wav-dir /tmp/test-wav` を起動し `/api/play` で合成した WAV が `/tmp/test-wav/` に保存される（VOICEVOX 接続が必要）

Closes #537

---
🤖 Generated with [Claude Code](https://claude.ai/code)
