### PR TITLE
feat(workflow-scripts): .tmp/memo/done のファイル数を監視して analyze-work-memo を自動実行する auto-analyze.sh を追加

### DIFF
--- a/workflow-scripts/auto-analyze.sh
+++ b/workflow-scripts/auto-analyze.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ $# -ne 1 ]] || ! [[ "$1" =~ ^[0-9]+$ ]] || [[ "$1" -eq 0 ]]; then
+  echo "Usage: $0 <min-count>" >&2
+  exit 1
+fi
+
+MIN_COUNT="$1"
+
+LOCK_DIR="${WORKSPACE_DIR}/.tmp/locks"
+mkdir -p "$LOCK_DIR"
+lock_file="${LOCK_DIR}/auto-analyze"
+
+exec 9>"$lock_file"
+if ! flock -n 9; then
+  echo "auto-analyze is already running"
+  exit 1
+fi
+
+trap 'echo ""; echo "Shutting down..."; exit 0' SIGINT SIGTERM
+
+MEMO_DONE_DIR="${WORKSPACE_DIR}/.tmp/memo/done"
+
+echo "Watching ${MEMO_DONE_DIR} (min-count: ${MIN_COUNT})..."
+
+PREV_STATE=""
+
+while true; do
+  if [[ -d "$MEMO_DONE_DIR" ]]; then
+    FILE_COUNT=$(( $(find "$MEMO_DONE_DIR" -maxdepth 1 -type f | wc -l) ))
+  else
+    FILE_COUNT=0
+  fi
+
+  if [[ "$FILE_COUNT" -ge "$MIN_COUNT" ]]; then
+    CURRENT_STATE="analyzing"
+    echo ""
+    echo "File count: ${FILE_COUNT} (>= ${MIN_COUNT}), starting analyze-work-memo..."
+
+    "${SCRIPT_DIR}/claude-stream.sh" -p "/base-tools:analyze-work-memo"
+  else
+    CURRENT_STATE="waiting"
+    if [[ "$PREV_STATE" != "$CURRENT_STATE" ]]; then
+      echo ""
+      echo "File count: ${FILE_COUNT} (< ${MIN_COUNT}), waiting..."
+    else
+      printf "."
+    fi
+  fi
+
+  PREV_STATE="$CURRENT_STATE"
+  sleep 60
+done


### PR DESCRIPTION
## Summary

- `workflow-scripts/auto-analyze.sh` を新規作成
- `.tmp/memo/done/` 直下のファイル数を60秒間隔で監視し、`<min-count>` 以上になると `claude-stream.sh -p "/base-tools:analyze-work-memo"` を同期実行する
- `flock` による多重起動防止、`SIGINT`/`SIGTERM` によるグレースフルシャットダウンを実装

## Test plan

- [ ] `./workflow-scripts/auto-analyze.sh` （引数なし）→ `Usage: ... <min-count>` が stderr に出力され exit 1
- [ ] `./workflow-scripts/auto-analyze.sh abc` → 同上
- [ ] `./workflow-scripts/auto-analyze.sh 0` → 同上
- [ ] `.tmp/memo/done/` のファイル数が閾値未満の間は `printf "."` のみ出力（`claude` 起動なし）
- [ ] `.tmp/memo/done/` に十分なファイルを配置すると `claude-stream.sh -p "/base-tools:analyze-work-memo"` が起動
- [ ] 同一ディレクトリで2プロセス起動すると2プロセス目が `auto-analyze is already running` と表示して exit 1
- [ ] `shellcheck workflow-scripts/auto-analyze.sh` が指摘なしでパス（CI確認）

Closes #539

---
🤖 Generated with [Claude Code](https://claude.ai/code)
