### PR TITLE
feat(workflow-scripts): claude-stream.sh の出力フィルターを拡充して処理状況を見やすくする

### DIFF
--- a/workflow-scripts/claude-stream.sh
+++ b/workflow-scripts/claude-stream.sh
@@ -1,7 +1,69 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-claude "$@" --output-format stream-json --verbose --include-partial-messages \
-  | jq -rj 'if .type == "text_delta" then .text elif .type == "result" then .result else empty end'
+claude "$@" --output-format stream-json --verbose --include-partial-messages -p \
+  | jq -nrj --unbuffered '
+    def oneline: gsub("\n"; " ⏎ ");
+    def trunc($n): if length > $n then .[0:$n] + "…" else . end;
+
+    foreach inputs as $x (
+      {ic: 0};
+
+      # state update: track cumulative tool-input bytes within a tool_use block
+      if   $x.type == "stream_event"
+           and $x.event.type == "content_block_start"
+           and $x.event.content_block.type == "tool_use" then .ic = 0
+      elif $x.type == "stream_event"
+           and ($x.event.delta.type // "") == "input_json_delta" then
+        .ic += ($x.event.delta.partial_json | length)
+      else . end;
+
+      . as $s |
+      ( if $x.type == "stream_event" then
+          $x.event as $e |
+          if $e.type == "content_block_start" then
+            $e.content_block as $cb |
+            if   $cb.type == "tool_use"  then "\n[tool_use: \($cb.name)] "
+            elif $cb.type == "thinking"  then "\n[thinking]"
+            elif $cb.type == "text"      then "\n[text]\n"
+            else "" end
+          elif $e.type == "content_block_delta" then
+            $e.delta as $d |
+            if   $d.type == "text_delta"     then $d.text
+            elif $d.type == "input_json_delta" then
+              ($s.ic - ($d.partial_json | length)) as $prev |
+              if $prev >= 80 then ""
+              else
+                ($d.partial_json | .[0 : 80 - $prev]) as $emit |
+                (if $s.ic > 80 and $prev < 80 then $emit + "…" else $emit end)
+              end
+            else "" end
+          elif $e.type == "content_block_stop" then ""
+          elif $e.type == "message_stop"       then ""
+          else "" end
+
+        elif $x.type == "user" then
+          ($x.message.content[0] // {}) as $c |
+          if $c.type == "tool_result" then
+            ( $c.content
+              | if   type == "string" then .
+                elif type == "array"  then map(.text // tostring) | join(" ")
+                else tostring end
+              | oneline | trunc(100)
+            ) as $body |
+            "\n[tool_result] \($body)"
+          else "" end
+
+        elif $x.type == "system" then
+          if   $x.subtype == "init"         then "[init session: \($x.model // "")]"
+          elif $x.subtype == "notification" then "\n[notification]"
+          else "" end
+
+        elif $x.type == "rate_limit_event" then "\n[rate_limit]"
+        elif $x.type == "result"           then "\n--- result ---\n" + ($x.result // "")
+        else "" end
+      )
+    )
+  '
 
 echo


### PR DESCRIPTION
## Summary

- `workflow-scripts/claude-stream.sh` の jq フィルターを拡張し、処理中の状況が把握できるようにした
- これまでは `text_delta` と `result` しか出力されておらず、ツール呼び出しや thinking の進行が見えなかった

## 出力に含まれるようになった項目

- `[init session: <model>]`
- `[thinking]` マーカー（本文は出さない）
- `[tool_use: <name>] <input先頭80字>…`（input_json_delta を累積80字で切り詰め）
- `[text]` マーカー＋本文
- `[tool_result] <先頭100字、改行は ⏎ に置換>`
- `[notification]` / `[rate_limit]` / `--- result ---`

## 除外しているノイズ

- `status:requesting`（API リクエスト毎に出る）
- `task started` / `task notify`（tool_use と重複しがち）
- `hook started` / `hook done`（セッション境界のみで頻出）
- `content_block_stop` / `message_stop` の空行（間延び防止）

## Test Plan

- [x] `shellcheck workflow-scripts/claude-stream.sh` がパスすること
- [x] サンプル JSONL を流し込み、各種ブロックが想定通り表示されること

---
🤖 Generated with [Claude Code](https://claude.ai/code)
