### PR TITLE
feat(viewer): 再生履歴にセリフパラメータ（speakerId/speed/pitch/intonation）を保持

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -392,13 +392,17 @@ viewer が起動する HTTP サーバーが提供するエンドポイントの�
       "text": "読み上げテキスト",
       "speakerName": "ずんだもん",
       "styleName": "ノーマル",
-      "timestamp": 1746316414387
+      "timestamp": 1746316414387,
+      "speakerId": 3,
+      "speed": 1.0,
+      "pitch": 0.0,
+      "intonation": 1.0
     }
   ]
 }
 ```
 
-`timestamp` は配信時刻の Unix ms（UTC）です。WAV URL は viewer 再起動で失効するため履歴には含まれません。
+`timestamp` は配信時刻の Unix ms（UTC）です。WAV URL は viewer 再起動で失効するため履歴には含まれません。`speed` / `pitch` / `intonation` は合成時に指定された場合のみ含まれます（省略時はフィールドなし）。旧形式の履歴エントリ（`speakerId` 欠落）はロード時に `speakerId: 0` として扱われます。
 
 #### GET /api/playback/{id}
 
@@ -524,7 +528,7 @@ Server-Sent Events ストリームです。ブラウザが接続し、再生ク�
 
 ```
 event: clip
-data: {"url":"/clips/1746316414387.wav","text":"読み上げテキスト","speakerName":"ずんだもん","styleName":"ノーマル","timestamp":1746316414387}
+data: {"url":"/clips/1746316414387.wav","text":"読み上げテキスト","speakerName":"ずんだもん","styleName":"ノーマル","timestamp":1746316414387,"speakerId":3}
 ```
 
 | フィールド | 説明 |
@@ -534,6 +538,10 @@ data: {"url":"/clips/1746316414387.wav","text":"読み上げテキスト","speak
 | `speakerName` | 話者名（エンジン未登録 ID は `話者#<ID>`） |
 | `styleName` | スタイル名（無音モード時は空文字） |
 | `timestamp` | 配信時刻の Unix ms（UTC） |
+| `speakerId` | VOICEVOX スタイル ID |
+| `speed` | 話速（合成時に指定した場合のみ） |
+| `pitch` | 音高（合成時に指定した場合のみ） |
+| `intonation` | 抑揚（合成時に指定した場合のみ） |
 
 `error` イベント（合成エラー等発生時）:
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -223,6 +223,10 @@ export function App() {
           speakerName: e.speakerName,
           styleName: e.styleName,
           timestamp: e.timestamp,
+          speakerId: e.speakerId,
+          speed: e.speed,
+          pitch: e.pitch,
+          intonation: e.intonation,
         }));
         setEntries(historyEntries);
       } catch (err) {

--- a/frontend/src/components/StreamPanel.test.tsx
+++ b/frontend/src/components/StreamPanel.test.tsx
@@ -11,6 +11,7 @@ const mockEntries: TimelineEntry[] = [
     speakerName: "話者A",
     styleName: "ノーマル",
     timestamp: 1700000000000,
+    speakerId: 0,
   },
 ];
 
@@ -129,6 +130,7 @@ describe("StreamPanel", () => {
         speakerName: "話者A",
         styleName: "ノーマル",
         timestamp: 1700000000000,
+        speakerId: 0,
       },
       {
         kind: "clip",
@@ -137,6 +139,7 @@ describe("StreamPanel", () => {
         speakerName: "話者A",
         styleName: "ノーマル",
         timestamp: 1700000001000,
+        speakerId: 0,
       },
     ];
     render(
@@ -160,6 +163,7 @@ describe("StreamPanel", () => {
         speakerName: "話者A",
         styleName: "ノーマル",
         timestamp: 1700000000000,
+        speakerId: 0,
       },
       {
         kind: "clip",
@@ -168,6 +172,7 @@ describe("StreamPanel", () => {
         speakerName: "話者A",
         styleName: "ノーマル",
         timestamp: 1700000001000,
+        speakerId: 0,
       },
     ];
     // showCharacters=true かつ characters が存在し playingClipTimestamp が設定されていると
@@ -196,6 +201,7 @@ describe("StreamPanel", () => {
         speakerName: "話者A",
         styleName: "ノーマル",
         timestamp: 1700000000000,
+        speakerId: 0,
       },
       {
         kind: "clip",
@@ -204,6 +210,7 @@ describe("StreamPanel", () => {
         speakerName: "話者A",
         styleName: "ノーマル",
         timestamp: 1700000001000,
+        speakerId: 0,
       },
     ];
     render(

--- a/frontend/src/components/Timeline.test.tsx
+++ b/frontend/src/components/Timeline.test.tsx
@@ -17,6 +17,7 @@ const clipEntry = (timestamp: number, text: string): TimelineEntry => ({
   speakerName: "話者A",
   styleName: "ノーマル",
   timestamp,
+  speakerId: 0,
 });
 
 describe("Timeline", () => {

--- a/frontend/src/components/TimelineItem.test.tsx
+++ b/frontend/src/components/TimelineItem.test.tsx
@@ -10,6 +10,7 @@ const clipEntry: TimelineEntry = {
   speakerName: "話者A",
   styleName: "スタイル1",
   timestamp: 1700000000000,
+  speakerId: 0,
 };
 
 const defaultProps = {

--- a/frontend/src/hooks/useCharacterStage.test.ts
+++ b/frontend/src/hooks/useCharacterStage.test.ts
@@ -25,6 +25,7 @@ function makeClipEntry(
     speakerName,
     styleName,
     timestamp: n * 1000,
+    speakerId: 0,
   };
 }
 

--- a/frontend/src/hooks/usePlaybackQueue.test.ts
+++ b/frontend/src/hooks/usePlaybackQueue.test.ts
@@ -10,6 +10,7 @@ function makeClip(n: number): ClipEvent {
     speakerName: "speaker",
     styleName: "normal",
     timestamp: n * 1000,
+    speakerId: 0,
   };
 }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -9,6 +9,10 @@ export interface ClipEvent {
   styleName: string;
   // Unix ms (UTC)。セッション跨ぎでも単調増加するため再起動後の衝突が発生しない。
   timestamp: number;
+  speakerId: number;
+  speed?: number;
+  pitch?: number;
+  intonation?: number;
 }
 
 // ErrorEventPayload は SSE "error" イベントで届くサーバー側エラーのペイロード。
@@ -45,18 +49,30 @@ declare global {
   }
 }
 
+function hasValidSpeechParams(v: Record<string, unknown>): boolean {
+  return (
+    (v.speed === undefined || typeof v.speed === "number") &&
+    (v.pitch === undefined || typeof v.pitch === "number") &&
+    (v.intonation === undefined || typeof v.intonation === "number")
+  );
+}
+
 export function isClipEvent(value: unknown): value is ClipEvent {
   if (typeof value !== "object" || value === null) {
     return false;
   }
   const v = value as Record<string, unknown>;
-  return (
-    typeof v.url === "string" &&
-    typeof v.text === "string" &&
-    typeof v.speakerName === "string" &&
-    typeof v.styleName === "string" &&
-    typeof v.timestamp === "number"
-  );
+  if (
+    typeof v.url !== "string" ||
+    typeof v.text !== "string" ||
+    typeof v.speakerName !== "string" ||
+    typeof v.styleName !== "string" ||
+    typeof v.timestamp !== "number" ||
+    typeof v.speakerId !== "number"
+  ) {
+    return false;
+  }
+  return hasValidSpeechParams(v);
 }
 
 export function isErrorEventPayload(
@@ -173,6 +189,10 @@ export interface HistoryEntry {
   speakerName: string;
   styleName: string;
   timestamp: number;
+  speakerId: number;
+  speed?: number;
+  pitch?: number;
+  intonation?: number;
 }
 
 export interface ApiHistory {
@@ -184,12 +204,16 @@ export function isHistoryEntry(value: unknown): value is HistoryEntry {
     return false;
   }
   const v = value as Record<string, unknown>;
-  return (
-    typeof v.text === "string" &&
-    typeof v.speakerName === "string" &&
-    typeof v.styleName === "string" &&
-    typeof v.timestamp === "number"
-  );
+  if (
+    typeof v.text !== "string" ||
+    typeof v.speakerName !== "string" ||
+    typeof v.styleName !== "string" ||
+    typeof v.timestamp !== "number" ||
+    typeof v.speakerId !== "number"
+  ) {
+    return false;
+  }
+  return hasValidSpeechParams(v);
 }
 
 export function isApiHistory(value: unknown): value is ApiHistory {

--- a/frontend/test/stub-server.mjs
+++ b/frontend/test/stub-server.mjs
@@ -162,7 +162,11 @@ async function handleStubClip(req, res) {
       typeof body.speakerName === "string" ? body.speakerName : "ずんだもん",
     styleName: typeof body.styleName === "string" ? body.styleName : "ノーマル",
     timestamp,
+    speakerId: typeof body.speakerId === "number" ? body.speakerId : 0,
   };
+  if (typeof body.speed === "number") payload.speed = body.speed;
+  if (typeof body.pitch === "number") payload.pitch = body.pitch;
+  if (typeof body.intonation === "number") payload.intonation = body.intonation;
   broadcast("clip", payload);
   writeJSON(res, 200, { ok: true, payload });
 }
@@ -227,9 +231,13 @@ async function handleStubApiCharacters(req, res) {
 
 async function handleStubApiHistory(req, res) {
   const body = await readJSON(req);
-  apiHistory = {
-    entries: Array.isArray(body.entries) ? body.entries : [],
-  };
+  const entries = Array.isArray(body.entries)
+    ? body.entries.map((e) => ({
+        speakerId: 0,
+        ...e,
+      }))
+    : [];
+  apiHistory = { entries };
   writeJSON(res, 200, { ok: true, apiHistory });
 }
 

--- a/internal/app/player.go
+++ b/internal/app/player.go
@@ -41,6 +41,11 @@ type PlayMeta struct {
 	// SpeakerID は再生に使ったVOICEVOXのスタイルID（解決後の値）。
 	// HTTPStreamPlayer では話者名/スタイル名の解決キーとして利用される。
 	SpeakerID int
+	// Speed / Pitch / Intonation は合成パラメータ（省略可）。
+	// 再合成時に元のパラメータを復元できるよう履歴に保持される。
+	Speed      *float64
+	Pitch      *float64
+	Intonation *float64
 }
 
 // AudioPlayer はWAVバイト列を再生するインターフェース。

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -178,11 +178,16 @@ var (
 
 // historyRecord は履歴ファイル（YYYY-MM-DD.jsonl）の 1 行スキーマ。
 // WAV URL は viewer 再起動で失効するため含めない。
+// 旧形式（SpeakerID/Speed/Pitch/Intonation なし）は json.Unmarshal でゼロ値・nil として読み込まれる。
 type historyRecord struct {
-	Text        string `json:"text"`
-	SpeakerName string `json:"speakerName"`
-	StyleName   string `json:"styleName"`
-	Timestamp   int64  `json:"timestamp"`
+	Text        string   `json:"text"`
+	SpeakerName string   `json:"speakerName"`
+	StyleName   string   `json:"styleName"`
+	Timestamp   int64    `json:"timestamp"`
+	SpeakerID   int      `json:"speakerId"`
+	Speed       *float64 `json:"speed,omitempty"`
+	Pitch       *float64 `json:"pitch,omitempty"`
+	Intonation  *float64 `json:"intonation,omitempty"`
 }
 
 // apiHistoryResponse は GET /api/history のレスポンスペイロード。
@@ -198,7 +203,11 @@ type clipEvent struct {
 	StyleName   string `json:"styleName"`
 	// Timestamp は配信時刻の Unix ms（UTC）。ブラウザ側で HH:MM:SS に整形する。
 	// セッション跨ぎで単調増加するため再起動後も timestamp が衝突しない。
-	Timestamp int64 `json:"timestamp"`
+	Timestamp  int64    `json:"timestamp"`
+	SpeakerID  int      `json:"speakerId"`
+	Speed      *float64 `json:"speed,omitempty"`
+	Pitch      *float64 `json:"pitch,omitempty"`
+	Intonation *float64 `json:"intonation,omitempty"`
 }
 
 // errorEvent は SSE で配信する error イベントのペイロード。
@@ -491,6 +500,33 @@ func (p *HTTPStreamPlayer) SetSilent(reason string) {
 	p.silentReason = reason
 }
 
+// clipToPlayMeta は ViewerClip を app.PlayMeta に変換する。
+func clipToPlayMeta(clip ViewerClip) app.PlayMeta {
+	return app.PlayMeta{
+		Text:       clip.Text,
+		SpeakerID:  clip.SpeakerID,
+		Speed:      clip.Speed,
+		Pitch:      clip.Pitch,
+		Intonation: clip.Intonation,
+	}
+}
+
+// newClipEvent は meta と ts から clipEvent を構築する。url は呼び出し元が指定する。
+func (p *HTTPStreamPlayer) newClipEvent(meta app.PlayMeta, ts int64, url string) clipEvent {
+	speakerName, styleName := p.resolveSpeaker(meta.SpeakerID)
+	return clipEvent{
+		URL:         url,
+		Text:        meta.Text,
+		SpeakerName: speakerName,
+		StyleName:   styleName,
+		Timestamp:   ts,
+		SpeakerID:   meta.SpeakerID,
+		Speed:       meta.Speed,
+		Pitch:       meta.Pitch,
+		Intonation:  meta.Intonation,
+	}
+}
+
 // PlayText は WAV 合成を伴わないテキストのみの SSE 配信を行う。
 // clipEvent.url は空文字で配信され、ブラウザ側は再生をスキップする。
 // 配信後は固定 silentInterval だけブロックして backpressure として働く。
@@ -509,14 +545,7 @@ func (p *HTTPStreamPlayer) PlayText(ctx context.Context, meta app.PlayMeta) erro
 	}
 
 	ts := p.nowFunc().UnixMilli()
-	speakerName, styleName := p.resolveSpeaker(meta.SpeakerID)
-	ev := clipEvent{
-		URL:         "",
-		Text:        meta.Text,
-		SpeakerName: speakerName,
-		StyleName:   styleName,
-		Timestamp:   ts,
-	}
+	ev := p.newClipEvent(meta, ts, "")
 	payload, err := json.Marshal(ev)
 	if err != nil {
 		return fmt.Errorf("failed to marshal clip payload: %w", err)
@@ -570,14 +599,7 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 	copy(buf, wavData)
 	p.clips.put(ts, buf)
 
-	speakerName, styleName := p.resolveSpeaker(meta.SpeakerID)
-	ev := clipEvent{
-		URL:         clipPathPrefix + strconv.FormatInt(ts, 10) + clipPathSuffix,
-		Text:        meta.Text,
-		SpeakerName: speakerName,
-		StyleName:   styleName,
-		Timestamp:   ts,
-	}
+	ev := p.newClipEvent(meta, ts, clipPathPrefix+strconv.FormatInt(ts, 10)+clipPathSuffix)
 	payload, err := json.Marshal(ev)
 	if err != nil {
 		return fmt.Errorf("failed to marshal clip payload: %w", err)
@@ -1219,8 +1241,7 @@ func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID str
 		return nil, err
 	}
 
-	meta := app.PlayMeta{Text: clip.Text, SpeakerID: clip.SpeakerID}
-	if pErr := p.Play(ctx, wav, meta); pErr != nil {
+	if pErr := p.Play(ctx, wav, clipToPlayMeta(clip)); pErr != nil {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
@@ -1260,8 +1281,7 @@ func (p *HTTPStreamPlayer) prefetchSleep(ctx context.Context, playbackID string,
 			p.setPlaybackStatus(playbackID, playbackStatusFailed, result.err.Error())
 			return nil, result.err
 		}
-		nextMeta := app.PlayMeta{Text: nextClip.Text, SpeakerID: nextClip.SpeakerID}
-		if pErr := p.Play(ctx, result.wav, nextMeta); pErr != nil {
+		if pErr := p.Play(ctx, result.wav, clipToPlayMeta(nextClip)); pErr != nil {
 			if !remainTimer.Stop() {
 				<-remainTimer.C
 			}
@@ -1405,6 +1425,10 @@ func (p *HTTPStreamPlayer) appendHistory(ev clipEvent) {
 		SpeakerName: ev.SpeakerName,
 		StyleName:   ev.StyleName,
 		Timestamp:   ev.Timestamp,
+		SpeakerID:   ev.SpeakerID,
+		Speed:       ev.Speed,
+		Pitch:       ev.Pitch,
+		Intonation:  ev.Intonation,
 	}
 	data, err := json.Marshal(record)
 	if err != nil {

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -3538,3 +3538,248 @@ func TestHTTPStreamPlayer_Play_DoesNotPanicWhenSaveWavDirNotSet(t *testing.T) {
 		t.Fatalf("Play: %v", err)
 	}
 }
+
+// --- History params tests (Issue #545) ---
+
+func TestHTTPStreamPlayer_History_WritesParamsOnPlay(t *testing.T) {
+	historyDir := t.TempDir()
+	fixedNow := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+	lookup := map[int]entity.SpeakerStyleInfo{
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return fixedNow }),
+		WithSpeakerLookup(lookup),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	speed := 1.2
+	pitch := 0.05
+	intonation := 1.3
+	if err := p.Play(context.Background(), []byte("RIFFwavdata"), app.PlayMeta{
+		Text: "パラメータテスト", SpeakerID: 3,
+		Speed: &speed, Pitch: &pitch, Intonation: &intonation,
+	}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	filePath := filepath.Join(historyDir, "2026-04-28.jsonl")
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("expected history file at %s: %v", filePath, err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	var rec historyRecord
+	if err := json.Unmarshal([]byte(lines[0]), &rec); err != nil {
+		t.Fatalf("failed to parse history line: %v", err)
+	}
+	if rec.SpeakerID != 3 {
+		t.Errorf("expected SpeakerID=3, got %d", rec.SpeakerID)
+	}
+	if rec.Speed == nil || *rec.Speed != speed {
+		t.Errorf("expected Speed=%v, got %v", speed, rec.Speed)
+	}
+	if rec.Pitch == nil || *rec.Pitch != pitch {
+		t.Errorf("expected Pitch=%v, got %v", pitch, rec.Pitch)
+	}
+	if rec.Intonation == nil || *rec.Intonation != intonation {
+		t.Errorf("expected Intonation=%v, got %v", intonation, rec.Intonation)
+	}
+}
+
+func TestHTTPStreamPlayer_History_WritesParamsOnPlayText(t *testing.T) {
+	historyDir := t.TempDir()
+	fixedNow := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+	lookup := map[int]entity.SpeakerStyleInfo{
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return fixedNow }),
+		WithSpeakerLookup(lookup),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+	p.silentInterval = 1 * time.Millisecond
+
+	speed := 0.9
+	pitch := -0.05
+	intonation := 0.8
+	if err := p.PlayText(context.Background(), app.PlayMeta{
+		Text: "サイレントパラメータ", SpeakerID: 3,
+		Speed: &speed, Pitch: &pitch, Intonation: &intonation,
+	}); err != nil {
+		t.Fatalf("PlayText: %v", err)
+	}
+
+	filePath := filepath.Join(historyDir, "2026-04-28.jsonl")
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("expected history file at %s: %v", filePath, err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	var rec historyRecord
+	if err := json.Unmarshal([]byte(lines[0]), &rec); err != nil {
+		t.Fatalf("failed to parse history line: %v", err)
+	}
+	if rec.SpeakerID != 3 {
+		t.Errorf("expected SpeakerID=3, got %d", rec.SpeakerID)
+	}
+	if rec.Speed == nil || *rec.Speed != speed {
+		t.Errorf("expected Speed=%v, got %v", speed, rec.Speed)
+	}
+	if rec.Pitch == nil || *rec.Pitch != pitch {
+		t.Errorf("expected Pitch=%v, got %v", pitch, rec.Pitch)
+	}
+	if rec.Intonation == nil || *rec.Intonation != intonation {
+		t.Errorf("expected Intonation=%v, got %v", intonation, rec.Intonation)
+	}
+}
+
+func TestHTTPStreamPlayer_History_BackwardCompatMissingParams(t *testing.T) {
+	historyDir := t.TempDir()
+	fixedNow := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+
+	// 旧形式（speakerId/speed/pitch/intonation なし）のエントリをファイルに書く。
+	oldJSON := `{"text":"旧形式エントリ","speakerName":"ずんだもん","styleName":"ノーマル","timestamp":1745820000000}`
+	filePath := filepath.Join(historyDir, "2026-04-28.jsonl")
+	if err := os.WriteFile(filePath, []byte(oldJSON+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return fixedNow }),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/history")
+	if err != nil {
+		t.Fatalf("GET /api/history: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var result apiHistoryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result.Entries))
+	}
+	entry := result.Entries[0]
+	if entry.Text != "旧形式エントリ" {
+		t.Errorf("expected Text=%q, got %q", "旧形式エントリ", entry.Text)
+	}
+	if entry.SpeakerID != 0 {
+		t.Errorf("expected SpeakerID=0 for old record, got %d", entry.SpeakerID)
+	}
+	if entry.Speed != nil {
+		t.Errorf("expected Speed=nil for old record, got %v", entry.Speed)
+	}
+	if entry.Pitch != nil {
+		t.Errorf("expected Pitch=nil for old record, got %v", entry.Pitch)
+	}
+	if entry.Intonation != nil {
+		t.Errorf("expected Intonation=nil for old record, got %v", entry.Intonation)
+	}
+}
+
+func TestHTTPStreamPlayer_APIHistory_IncludesParams(t *testing.T) {
+	historyDir := t.TempDir()
+	fixedNow := time.Date(2026, 4, 28, 10, 0, 0, 0, time.Local)
+	lookup := map[int]entity.SpeakerStyleInfo{
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	p, err := NewHTTPStreamPlayer("127.0.0.1:0", newTestStreamAssets(),
+		WithHistoryDir(historyDir),
+		withNowFunc(func() time.Time { return fixedNow }),
+		WithSpeakerLookup(lookup),
+	)
+	if err != nil {
+		t.Fatalf("NewHTTPStreamPlayer: %v", err)
+	}
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	speed := 1.1
+	intonation := 1.4
+	if err := p.Play(context.Background(), []byte("RIFFwavdata"), app.PlayMeta{
+		Text: "APIレスポンステスト", SpeakerID: 3,
+		Speed: &speed, Intonation: &intonation,
+	}); err != nil {
+		t.Fatalf("Play: %v", err)
+	}
+
+	resp, err := http.Get("http://" + p.Addr() + "/api/history")
+	if err != nil {
+		t.Fatalf("GET /api/history: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var result apiHistoryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result.Entries))
+	}
+	entry := result.Entries[0]
+	if entry.SpeakerID != 3 {
+		t.Errorf("expected SpeakerID=3, got %d", entry.SpeakerID)
+	}
+	if entry.Speed == nil || *entry.Speed != speed {
+		t.Errorf("expected Speed=%v, got %v", speed, entry.Speed)
+	}
+	if entry.Pitch != nil {
+		t.Errorf("expected Pitch=nil (omitted), got %v", entry.Pitch)
+	}
+	if entry.Intonation == nil || *entry.Intonation != intonation {
+		t.Errorf("expected Intonation=%v, got %v", intonation, entry.Intonation)
+	}
+}


### PR DESCRIPTION
## Summary

- `historyRecord` / `clipEvent` に `speakerId`（必須 int）・`speed` / `pitch` / `intonation`（任意 *float64）を追加
- `PlayMeta` に `Speed` / `Pitch` / `Intonation` を追加し、`synthesizeAndPlay` / `prefetchSleep` → `Play()` / `PlayText()` → `appendHistory` まで一貫してパラメータを伝播
- 旧形式 JSONL エントリ（`speakerId` 欠落）はロード時に `SpeakerID=0`・`Speed/Pitch/Intonation=nil` として後方互換処理
- フロントエンド `ClipEvent` / `HistoryEntry` 型に同フィールドを追加（`isClipEvent` / `isHistoryEntry` type guard も更新）
- `docs/reference/cli.md` の `/api/history` レスポンス・SSE `clip` イベントスキーマを更新

## リファクタリング（simplify で検出）

- `clipToPlayMeta()` ヘルパー追加（`ViewerClip` → `app.PlayMeta` 変換の重複を解消）
- `newClipEvent()` メソッド追加（`Play()` / `PlayText()` での `clipEvent` 構築の重複を解消）
- `hasValidSpeechParams()` ヘルパー追加（`isClipEvent` / `isHistoryEntry` の optional フィールド検証重複を解消）

## Test plan

- [x] Go: `go test ./internal/...` 全件 PASS（新規 4 テスト含む）
  - `TestHTTPStreamPlayer_History_WritesParamsOnPlay`
  - `TestHTTPStreamPlayer_History_WritesParamsOnPlayText`
  - `TestHTTPStreamPlayer_History_BackwardCompatMissingParams`
  - `TestHTTPStreamPlayer_APIHistory_IncludesParams`
- [x] TypeScript: `npm run typecheck` PASS
- [x] `gofmt -l .` / `golangci-lint run` 0 issues
- [ ] VOICEVOX 接続環境での手動確認（`vox-actor viewer` 起動 → `vox-actor say` でセリフ再生 → `~/.vox-actor/viewer/history/*.jsonl` に `speakerId`/`speed` 等が記録されることを確認）

Closes #545

---
🤖 Generated with [Claude Code](https://claude.ai/code)
