### PR TITLE
feat(viewer): 再生中はタイムライン履歴アイテムの「再生」ボタンを非表示にする

### DIFF
--- a/docs/acceptance/viewer/frontend/timeline-item.feature
+++ b/docs/acceptance/viewer/frontend/timeline-item.feature
@@ -91,12 +91,29 @@ Feature: TimelineItem の個別 UI 要素
 
   # ── TimelineItem: 再生ボタン ────────────────────────────────────
 
-  Scenario: clip アイテムに「再生」ボタンが表示される
+  Scenario: アイドル時は clip アイテムに「再生」ボタンが表示される
     Given viewer フロントエンドが起動している
     When ページを開く
     And clip イベントを受信する
     Then タイムラインアイテムに「再生」ボタンが表示される
     # test: frontend/test/e2e/timeline-item.spec.ts::"clip アイテムに「再生」ボタンが表示される"
+
+  Scenario: 再生中はすべての clip アイテムの「再生」ボタンが非表示になる
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And clip イベントを受信する
+    And クリップが再生中である
+    Then タイムラインアイテムに「再生」ボタンが表示されない
+    # test: frontend/src/components/TimelineItem.test.tsx::"anyPlaying=true のとき onReplay が渡されていても「再生」ボタンが表示されない"
+
+  Scenario: 再生が終わるとすべての clip アイテムの「再生」ボタンが再び表示される
+    Given viewer フロントエンドが起動している
+    When ページを開く
+    And clip イベントを受信する
+    And クリップが再生中である
+    And 再生が終わりアイドル状態に戻る
+    Then タイムラインアイテムに「再生」ボタンが表示される
+    # test: frontend/src/components/TimelineItem.test.tsx::"anyPlaying=false のとき onReplay が渡されていれば「再生」ボタンが表示される"
 
   Scenario: 「再生」ボタン押下で POST /api/preview-clip に正しい clip パラメータが送信される
     Given viewer フロントエンドが起動している

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -77,6 +77,7 @@ export function Timeline({
             showStyleName={isCharacterMode ? false : showStyleName}
             showTimestamp={isCharacterMode ? false : showTimestamp}
             highlightPlaying={!isCharacterMode}
+            anyPlaying={playingClipTimestamp !== null}
             onReplay={
               onReplay && entry.kind === "clip"
                 ? () => onReplay(entry)

--- a/frontend/src/components/TimelineItem.test.tsx
+++ b/frontend/src/components/TimelineItem.test.tsx
@@ -245,4 +245,10 @@ describe("TimelineItem - replay button", () => {
     render(<TimelineItem {...defaultProps} onReplay={onReplay} anyPlaying={false} />);
     expect(screen.getByRole("button", { name: "再生" })).toBeInTheDocument();
   });
+
+  it("anyPlaying=true のとき playing=true のハイライト（▶ と背景色）には影響しない", () => {
+    render(<TimelineItem {...defaultProps} playing={true} anyPlaying={true} />);
+    expect(screen.getByText("▶")).toBeInTheDocument();
+    expect(screen.getByRole("listitem")).toHaveClass("bg-ctp-overlay");
+  });
 });

--- a/frontend/src/components/TimelineItem.test.tsx
+++ b/frontend/src/components/TimelineItem.test.tsx
@@ -233,4 +233,16 @@ describe("TimelineItem - replay button", () => {
     render(<TimelineItem {...defaultProps} entry={errorEntry} onReplay={onReplay} />);
     expect(screen.queryByRole("button", { name: "再生" })).not.toBeInTheDocument();
   });
+
+  it("anyPlaying=true のとき onReplay が渡されていても「再生」ボタンが表示されない", () => {
+    const onReplay = vi.fn();
+    render(<TimelineItem {...defaultProps} onReplay={onReplay} anyPlaying={true} />);
+    expect(screen.queryByRole("button", { name: "再生" })).not.toBeInTheDocument();
+  });
+
+  it("anyPlaying=false のとき onReplay が渡されていれば「再生」ボタンが表示される", () => {
+    const onReplay = vi.fn();
+    render(<TimelineItem {...defaultProps} onReplay={onReplay} anyPlaying={false} />);
+    expect(screen.getByRole("button", { name: "再生" })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/TimelineItem.tsx
+++ b/frontend/src/components/TimelineItem.tsx
@@ -8,6 +8,7 @@ interface TimelineItemProps {
   showStyleName: boolean;
   showTimestamp: boolean;
   highlightPlaying?: boolean;
+  anyPlaying?: boolean;
   onReplay?: () => void;
 }
 
@@ -29,6 +30,7 @@ export function TimelineItem({
   showStyleName,
   showTimestamp,
   highlightPlaying = true,
+  anyPlaying = false,
   onReplay,
 }: TimelineItemProps) {
   const ref = useRef<HTMLLIElement>(null);
@@ -121,7 +123,7 @@ export function TimelineItem({
           {playing && highlightPlaying ? "▶" : ""}
         </span>
         <span>{entry.text}</span>
-        {onReplay && (
+        {onReplay && !anyPlaying && (
           <button
             type="button"
             onClick={onReplay}


### PR DESCRIPTION
## Summary

- `TimelineItem` コンポーネントに `anyPlaying?: boolean` prop を追加し、再生中はタイムライン履歴アイテムの「再生」ボタンを非表示にする
- `Timeline` から各 `TimelineItem` へ `anyPlaying={playingClipTimestamp !== null}` を渡す（`playingClipTimestamp` は既存の props として利用可能）
- 既存の再生ハイライト（▶ アイコン・`bg-ctp-overlay` 背景）は `anyPlaying` の影響を受けない

## Test plan

- [x] `anyPlaying=true` のとき「再生」ボタンが描画されないことをユニットテストで確認
- [x] `anyPlaying=false` のとき「再生」ボタンが描画されることをユニットテストで確認
- [x] `anyPlaying=true` かつ `playing=true` のとき再生ハイライト（▶ と背景色）が維持されることをユニットテストで確認
- [x] 全168ユニットテスト通過済み
- [ ] VOICEVOX を起動してクリップ再生中に「再生」ボタンが非表示になることを手動確認（CI 環境では外部サービス接続不可）

Closes #554

---
🤖 Generated with [Claude Code](https://claude.ai/code)
