### PR TITLE
feat(viewer): 履歴「再生」ボタン押下時もキャラクターステージに該当キャラを表示する

### DIFF
--- a/docs/acceptance/viewer/frontend/character.feature
+++ b/docs/acceptance/viewer/frontend/character.feature
@@ -19,3 +19,22 @@ Feature: キャラ画像表示（配信タブ統合）
     When ページを開く
     Then 「キャラ画像」チェックボックスが表示されない
     # test: frontend/test/e2e/character.spec.ts::"charactersEnabled=false のとき「キャラ画像」チェックボックスが非表示になる"
+
+  Scenario: タイムライン履歴アイテムの「再生」ボタン押下でキャラクターがステージに表示される
+    Given viewer フロントエンドが起動している
+    And API のキャラクター設定が enabled=true で characters に1件登録されている
+    And 「キャラ画像」チェックボックスが有効になっている
+    And タイムラインに再生履歴アイテムが1件存在する
+    When タイムライン履歴アイテムの「再生」ボタンを押す
+    Then 再生中のみ該当キャラクターがステージに表示される
+    And 再生終了後に一定時間経過するとキャラクターがステージから消える
+    # test: frontend/src/hooks/useCharacterStage.test.ts::"preview 経由再生（timestamp あり）でのキャラクター表示"
+    # note: 単体テストで担保。E2Eはキャラクターステージ表示の視覚的確認が必要なため手動検証
+
+  Scenario: 「音量テスト」ボタン経由のプレビュー再生ではキャラクターがステージに表示されない
+    Given viewer フロントエンドが起動している
+    And API のキャラクター設定が enabled=true で characters に1件登録されている
+    And 「キャラ画像」チェックボックスが有効になっている
+    When 音声テストパネルの「音量テスト」ボタンを押す
+    Then キャラクターステージに何も表示されない
+    # note: 音量テストは固定テキストでキャラクター紐付けなし。手動検証

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -343,13 +343,16 @@ export function App() {
 
   const handleReplay = useCallback(
     (entry: ClipEvent & { kind: "clip" }): void => {
-      enqueuePreview({
-        text: entry.text,
-        speaker_id: entry.speakerId,
-        ...(entry.speed !== undefined && { speed: entry.speed }),
-        ...(entry.pitch !== undefined && { pitch: entry.pitch }),
-        ...(entry.intonation !== undefined && { intonation: entry.intonation }),
-      });
+      enqueuePreview(
+        {
+          text: entry.text,
+          speaker_id: entry.speakerId,
+          ...(entry.speed !== undefined && { speed: entry.speed }),
+          ...(entry.pitch !== undefined && { pitch: entry.pitch }),
+          ...(entry.intonation !== undefined && { intonation: entry.intonation }),
+        },
+        entry.timestamp,
+      );
     },
     [enqueuePreview],
   );

--- a/frontend/src/hooks/useCharacterStage.test.ts
+++ b/frontend/src/hooks/useCharacterStage.test.ts
@@ -834,4 +834,88 @@ describe("useCharacterStage", () => {
       expect(result.current.lastClipTimestamp).toBeNull();
     });
   });
+
+  describe("preview 経由再生（timestamp あり）でのキャラクター表示", () => {
+    it("playingClipTimestamp が entries に存在するタイムスタンプのとき、対応するキャラクターがスロットに表示される", async () => {
+      const charA = makeChar("キャラA");
+      const entry1 = makeClipEntry(1, "キャラA");
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipTimestamp,
+          entries,
+          characters,
+        }: {
+          playingClipTimestamp: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
+        {
+          initialProps: {
+            playingClipTimestamp: null,
+            entries: [entry1],
+            characters: [charA],
+          },
+        },
+      );
+
+      await act(async () => {
+        rerender({
+          playingClipTimestamp: entry1.timestamp as number,
+          entries: [entry1],
+          characters: [charA],
+        });
+      });
+
+      expect(result.current.slots[0]).toEqual({ character: charA });
+    });
+
+    it("playingClipTimestamp が null に戻るとキャラクターはステージから消えない（タイマー待ち）", async () => {
+      const charA = makeChar("キャラA");
+      const entry1 = makeClipEntry(1, "キャラA");
+
+      const { result, rerender } = renderHook(
+        ({
+          playingClipTimestamp,
+          entries,
+          characters,
+        }: {
+          playingClipTimestamp: number | null;
+          entries: TimelineEntry[];
+          characters: CharacterEntry[];
+        }) => useCharacterStage(playingClipTimestamp, entries, characters),
+        {
+          initialProps: {
+            playingClipTimestamp: null,
+            entries: [entry1],
+            characters: [charA],
+          },
+        },
+      );
+
+      await act(async () => {
+        rerender({
+          playingClipTimestamp: entry1.timestamp as number,
+          entries: [entry1],
+          characters: [charA],
+        });
+      });
+      expect(result.current.slots[0]).toEqual({ character: charA });
+
+      await act(async () => {
+        rerender({
+          playingClipTimestamp: null,
+          entries: [entry1],
+          characters: [charA],
+        });
+      });
+      // タイマー経過前はまだ表示
+      expect(result.current.slots[0]).toEqual({ character: charA });
+
+      await act(async () => {
+        vi.advanceTimersByTime(QUEUE_EMPTY_MS);
+      });
+      expect(result.current.slots[0]).toBeNull();
+    });
+  });
 });

--- a/frontend/src/hooks/usePlaybackQueue.test.ts
+++ b/frontend/src/hooks/usePlaybackQueue.test.ts
@@ -258,7 +258,7 @@ describe("usePlaybackQueue", () => {
     expect(result.current.playingClipTimestamp).toBeNull();
   });
 
-  it("timeline と preview を混在キューに積んだ場合、順次再生され timeline のみ playingClipTimestamp が更新される", async () => {
+  it("timeline と timestamp なし preview を混在キューに積んだ場合、順次再生され timeline のみ playingClipTimestamp が更新される", async () => {
     const { result } = renderHook(() => usePlaybackQueue(audioRef));
     // timeline → preview → timeline の順でキューに積む
     await act(async () => {
@@ -341,5 +341,27 @@ describe("usePlaybackQueue", () => {
       unmount();
     });
     expect(mockPause).toHaveBeenCalled();
+  });
+
+  it("enqueuePreview with timestamp: playingClipTimestamp が指定した値に設定される", async () => {
+    const { result } = renderHook(() => usePlaybackQueue(audioRef));
+    await act(async () => {
+      result.current.enqueuePreview(makePreviewBody(1), 9000);
+    });
+    expect(mockPlay).toHaveBeenCalled();
+    expect(result.current.playingClipTimestamp).toBe(9000);
+  });
+
+  it("enqueuePreview with timestamp: 再生終了後に playingClipTimestamp が null に戻る", async () => {
+    const { result } = renderHook(() => usePlaybackQueue(audioRef));
+    await act(async () => {
+      result.current.enqueuePreview(makePreviewBody(1), 9000);
+    });
+    expect(result.current.playingClipTimestamp).toBe(9000);
+    setAudioEnded(audio, true);
+    await act(async () => {
+      audio.dispatchEvent(new Event("timeupdate"));
+    });
+    expect(result.current.playingClipTimestamp).toBeNull();
   });
 });

--- a/frontend/src/hooks/usePlaybackQueue.ts
+++ b/frontend/src/hooks/usePlaybackQueue.ts
@@ -17,12 +17,17 @@ export interface PreviewBody {
 
 type QueueItem =
   | { kind: "timeline"; clip: ClipEvent }
-  | { kind: "preview"; body: PreviewBody };
+  | { kind: "preview"; body: PreviewBody; timestamp?: number };
+
+function resolveTimestamp(item: QueueItem): number | null {
+  if (item.kind === "timeline") return item.clip.timestamp;
+  return item.timestamp ?? null;
+}
 
 interface PlaybackQueue {
   playingClipTimestamp: number | null;
   enqueue: (clip: ClipEvent) => void;
-  enqueuePreview: (body: PreviewBody) => void;
+  enqueuePreview: (body: PreviewBody, timestamp?: number) => void;
 }
 
 interface ReadyItem {
@@ -80,7 +85,7 @@ export function usePlaybackQueue(
           playingObjUrlRef.current = null;
         }
         isPlayingRef.current = false;
-        if (item.kind === "timeline") {
+        if (resolveTimestamp(item) !== null) {
           setPlayingClipTimestamp(null);
         }
         startNextRef.current();
@@ -109,8 +114,9 @@ export function usePlaybackQueue(
       if (oldUrl) URL.revokeObjectURL(oldUrl);
       playingObjUrlRef.current = ready.objectUrl;
       isPlayingRef.current = true;
-      if (ready.item.kind === "timeline") {
-        setPlayingClipTimestamp(ready.item.clip.timestamp);
+      const ts = resolveTimestamp(ready.item);
+      if (ts !== null) {
+        setPlayingClipTimestamp(ts);
       }
       audio.src = ready.objectUrl;
       audio.play().catch((err: unknown) => {
@@ -121,7 +127,7 @@ export function usePlaybackQueue(
         }
         clearWatchdog();
         isPlayingRef.current = false;
-        if (ready.item.kind === "timeline") {
+        if (resolveTimestamp(ready.item) !== null) {
           setPlayingClipTimestamp(null);
         }
         startNextRef.current();
@@ -188,8 +194,8 @@ export function usePlaybackQueue(
   );
 
   const enqueuePreview = useCallback(
-    (body: PreviewBody): void => {
-      waitingRef.current.push({ kind: "preview", body });
+    (body: PreviewBody, timestamp?: number): void => {
+      waitingRef.current.push({ kind: "preview", body, timestamp });
       startNext();
     },
     [startNext],


### PR DESCRIPTION
## 概要

履歴「再生」ボタン経由のプレビュー再生でも、SSE 由来の通常再生と同様にキャラクターステージへ該当キャラを表示する。

## 変更内容

- `usePlaybackQueue.ts`: preview キューアイテムに `timestamp?: number` を追加。`resolveTimestamp` ヘルパーを抽出して重複した判定条件を一元化。`enqueuePreview` シグネチャを `(body, timestamp?)` に拡張
- `App.tsx`: `handleReplay` で `entry.timestamp` を `enqueuePreview` に渡すよう修正（「音量テスト」は渡さないため従来通り非表示）
- `usePlaybackQueue.test.ts`: timestamp あり preview の動作テスト追加
- `useCharacterStage.test.ts`: preview 経由再生でのキャラ表示テスト追加
- `docs/acceptance/viewer/frontend/character.feature`: 再生ボタン/音量テストのキャラ表示差異シナリオ追加

## Test plan

- [x] `npm run test:unit` — 173件全て通過
- [x] `npm run typecheck` — エラーなし
- [ ] 手動確認: キャラ画像有効状態で履歴「再生」ボタンを押してキャラがステージに表示される（VOICEVOX 接続必要）
- [ ] 手動確認: 「音量テスト」ボタンではキャラが表示されないこと

Closes #555

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
