### PR TITLE
refactor(domain): 合成パラメータをSynthOverrides値オブジェクトに集約する

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -69,17 +69,19 @@ func actViaViewer(
 	speakerID int, speed, pitch, intonation float64,
 	logger *slog.Logger,
 ) error {
+	defaults := entity.SynthOverrides{Speed: &speed, Pitch: &pitch, Intonation: &intonation}
 	var clips []infra.ViewerClip
 	for _, script := range scripts {
 		if script.IsEmpty {
 			continue
 		}
+		resolved := script.ResolveOverrides(defaults)
 		clips = append(clips, infra.ViewerClip{
 			Text:       script.Text,
 			SpeakerID:  script.ResolveSpeakerID(speakerID),
-			Speed:      script.ResolveSpeed(&speed),
-			Pitch:      script.ResolvePitch(&pitch),
-			Intonation: script.ResolveIntonation(&intonation),
+			Speed:      resolved.Speed,
+			Pitch:      resolved.Pitch,
+			Intonation: resolved.Intonation,
 		})
 	}
 	if len(clips) == 0 {

--- a/cmd/script_append.go
+++ b/cmd/script_append.go
@@ -50,15 +50,15 @@ func runScriptAppend(cmd *cobra.Command, args []string, deps *ScriptAppendDeps) 
 	}
 	if cmd.Flags().Changed("speed") {
 		v, _ := cmd.Flags().GetFloat64("speed")
-		script.SpeedScale = &v
+		script.Overrides.Speed = &v
 	}
 	if cmd.Flags().Changed("pitch") {
 		v, _ := cmd.Flags().GetFloat64("pitch")
-		script.PitchScale = &v
+		script.Overrides.Pitch = &v
 	}
 	if cmd.Flags().Changed("intonation") {
 		v, _ := cmd.Flags().GetFloat64("intonation")
-		script.IntonationScale = &v
+		script.Overrides.Intonation = &v
 	}
 
 	logger := buildLoggerFromFlags(cmd)

--- a/cmd/script_append_test.go
+++ b/cmd/script_append_test.go
@@ -278,13 +278,13 @@ func TestScriptAppendCmd_FlagsPassedToWriter(t *testing.T) {
 	if s.SpeakerID == nil || *s.SpeakerID != 5 {
 		t.Errorf("expected SpeakerID=5, got: %v", s.SpeakerID)
 	}
-	if s.SpeedScale == nil || *s.SpeedScale != 1.2 {
-		t.Errorf("expected SpeedScale=1.2, got: %v", s.SpeedScale)
+	if s.Overrides.Speed == nil || *s.Overrides.Speed != 1.2 {
+		t.Errorf("expected Overrides.Speed=1.2, got: %v", s.Overrides.Speed)
 	}
-	if s.PitchScale == nil || *s.PitchScale != 0.05 {
-		t.Errorf("expected PitchScale=0.05, got: %v", s.PitchScale)
+	if s.Overrides.Pitch == nil || *s.Overrides.Pitch != 0.05 {
+		t.Errorf("expected Overrides.Pitch=0.05, got: %v", s.Overrides.Pitch)
 	}
-	if s.IntonationScale == nil || *s.IntonationScale != 1.5 {
-		t.Errorf("expected IntonationScale=1.5, got: %v", s.IntonationScale)
+	if s.Overrides.Intonation == nil || *s.Overrides.Intonation != 1.5 {
+		t.Errorf("expected Overrides.Intonation=1.5, got: %v", s.Overrides.Intonation)
 	}
 }

--- a/cmd/script_write.go
+++ b/cmd/script_write.go
@@ -65,12 +65,14 @@ func runScriptWrite(cmd *cobra.Command, args []string, deps *ScriptWriteDeps) er
 	scripts := make([]entity.Script, len(inputs))
 	for i, in := range inputs {
 		scripts[i] = entity.Script{
-			Text:            in.Text,
-			IsEmpty:         in.Text == "",
-			SpeakerID:       in.Speaker,
-			SpeedScale:      in.Speed,
-			PitchScale:      in.Pitch,
-			IntonationScale: in.Intonation,
+			Text:      in.Text,
+			IsEmpty:   in.Text == "",
+			SpeakerID: in.Speaker,
+			Overrides: entity.SynthOverrides{
+				Speed:      in.Speed,
+				Pitch:      in.Pitch,
+				Intonation: in.Intonation,
+			},
 		}
 	}
 

--- a/cmd/script_write_test.go
+++ b/cmd/script_write_test.go
@@ -190,14 +190,14 @@ func TestScriptWriteCmd_JsonFieldsMappedToScript(t *testing.T) {
 	if s.SpeakerID == nil || *s.SpeakerID != 3 {
 		t.Errorf("SpeakerID: expected 3, got %v", s.SpeakerID)
 	}
-	if s.SpeedScale == nil || *s.SpeedScale != 1.2 {
-		t.Errorf("SpeedScale: expected 1.2, got %v", s.SpeedScale)
+	if s.Overrides.Speed == nil || *s.Overrides.Speed != 1.2 {
+		t.Errorf("Overrides.Speed: expected 1.2, got %v", s.Overrides.Speed)
 	}
-	if s.PitchScale == nil || *s.PitchScale != 0.05 {
-		t.Errorf("PitchScale: expected 0.05, got %v", s.PitchScale)
+	if s.Overrides.Pitch == nil || *s.Overrides.Pitch != 0.05 {
+		t.Errorf("Overrides.Pitch: expected 0.05, got %v", s.Overrides.Pitch)
 	}
-	if s.IntonationScale == nil || *s.IntonationScale != 1.1 {
-		t.Errorf("IntonationScale: expected 1.1, got %v", s.IntonationScale)
+	if s.Overrides.Intonation == nil || *s.Overrides.Intonation != 1.1 {
+		t.Errorf("Overrides.Intonation: expected 1.1, got %v", s.Overrides.Intonation)
 	}
 }
 

--- a/internal/app/act_usecase.go
+++ b/internal/app/act_usecase.go
@@ -135,6 +135,7 @@ func (u *ActUsecase) Run(ctx context.Context, params ActParams) error {
 // runDryRun はDryRunモードのactユースケースを実行する。
 // VOICEVOXエンジン/音声再生は一切呼ばず、既存のログ互換性を保ったまま逐次出力する。
 func (u *ActUsecase) runDryRun(ctx context.Context, scripts []entity.Script, total int, params ActParams) error {
+	defaultOverrides := entity.SynthOverrides{Speed: params.Speed, Pitch: params.Pitch, Intonation: params.Intonation}
 	current := 0
 	for _, script := range scripts {
 		if ctx.Err() != nil {
@@ -148,14 +149,10 @@ func (u *ActUsecase) runDryRun(ctx context.Context, scripts []entity.Script, tot
 		u.logger.Info(fmt.Sprintf("[%d/%d] processing script", current, total), "path", script.Path)
 
 		speakerID := script.ResolveSpeakerID(params.SpeakerID)
-		overrides := script.ResolveOverrides(entity.SynthOverrides{
-			Speed:      params.Speed,
-			Pitch:      params.Pitch,
-			Intonation: params.Intonation,
-		})
+		overrides := script.ResolveOverrides(defaultOverrides)
 
 		u.logger.Info("synthesis completed", "path", script.Path, "wavSize", 0)
-		attrs := append([]any{"path", script.Path}, dryRunPlaybackAttrs(script.Text, speakerID, overrides.Speed, overrides.Pitch, overrides.Intonation)...)
+		attrs := append([]any{"path", script.Path}, dryRunPlaybackAttrs(script.Text, speakerID, overrides)...)
 		u.logger.Info("playback completed", attrs...)
 	}
 	u.logger.Info("all scripts processed")

--- a/internal/app/act_usecase.go
+++ b/internal/app/act_usecase.go
@@ -92,10 +92,12 @@ func (u *ActUsecase) Run(ctx context.Context, params ActParams) error {
 	}
 
 	cfg := synthPipelineConfig{
-		defaultSpeakerID:  params.SpeakerID,
-		defaultSpeed:      params.Speed,
-		defaultPitch:      params.Pitch,
-		defaultIntonation: params.Intonation,
+		defaultSpeakerID: params.SpeakerID,
+		defaultOverrides: entity.SynthOverrides{
+			Speed:      params.Speed,
+			Pitch:      params.Pitch,
+			Intonation: params.Intonation,
+		},
 		synthesisLogLevel: slog.LevelInfo,
 	}
 	ch := startSynthPipeline(ctx, u.client, u.logger, scripts, cfg)
@@ -146,12 +148,14 @@ func (u *ActUsecase) runDryRun(ctx context.Context, scripts []entity.Script, tot
 		u.logger.Info(fmt.Sprintf("[%d/%d] processing script", current, total), "path", script.Path)
 
 		speakerID := script.ResolveSpeakerID(params.SpeakerID)
-		speed := script.ResolveSpeed(params.Speed)
-		pitch := script.ResolvePitch(params.Pitch)
-		intonation := script.ResolveIntonation(params.Intonation)
+		overrides := script.ResolveOverrides(entity.SynthOverrides{
+			Speed:      params.Speed,
+			Pitch:      params.Pitch,
+			Intonation: params.Intonation,
+		})
 
 		u.logger.Info("synthesis completed", "path", script.Path, "wavSize", 0)
-		attrs := append([]any{"path", script.Path}, dryRunPlaybackAttrs(script.Text, speakerID, speed, pitch, intonation)...)
+		attrs := append([]any{"path", script.Path}, dryRunPlaybackAttrs(script.Text, speakerID, overrides.Speed, overrides.Pitch, overrides.Intonation)...)
 		u.logger.Info("playback completed", attrs...)
 	}
 	u.logger.Info("all scripts processed")

--- a/internal/app/act_usecase_test.go
+++ b/internal/app/act_usecase_test.go
@@ -885,12 +885,10 @@ func TestActUsecase_Run_ScriptEmotionParams(t *testing.T) {
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{
-				Path:            "script.json",
-				Text:            "感情込めて",
-				IsEmpty:         false,
-				SpeedScale:      &speed,
-				PitchScale:      &pitch,
-				IntonationScale: &intonation,
+				Path:      "script.json",
+				Text:      "感情込めて",
+				IsEmpty:   false,
+				Overrides: entity.SynthOverrides{Speed: &speed, Pitch: &pitch, Intonation: &intonation},
 			},
 		},
 	}
@@ -934,10 +932,10 @@ func TestActUsecase_Run_ScriptParamsOverrideGlobal(t *testing.T) {
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{
-				Path:       "script.json",
-				Text:       "ゆっくり",
-				IsEmpty:    false,
-				SpeedScale: &scriptSpeed,
+				Path:      "script.json",
+				Text:      "ゆっくり",
+				IsEmpty:   false,
+				Overrides: entity.SynthOverrides{Speed: &scriptSpeed},
 			},
 		},
 	}
@@ -1010,9 +1008,9 @@ func TestActUsecase_Run_MultipleScriptsWithDifferentParams(t *testing.T) {
 	speed2 := 1.5
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
-			{Path: "a.json", Text: "ゆっくり", IsEmpty: false, SpeakerID: &speaker5, SpeedScale: &speed1},
+			{Path: "a.json", Text: "ゆっくり", IsEmpty: false, SpeakerID: &speaker5, Overrides: entity.SynthOverrides{Speed: &speed1}},
 			{Path: "b.txt", Text: "普通", IsEmpty: false},
-			{Path: "c.json", Text: "はやく", IsEmpty: false, SpeedScale: &speed2},
+			{Path: "c.json", Text: "はやく", IsEmpty: false, Overrides: entity.SynthOverrides{Speed: &speed2}},
 		},
 	}
 	client := &mockVoicevoxClient{

--- a/internal/app/log_text.go
+++ b/internal/app/log_text.go
@@ -3,6 +3,8 @@ package app
 import (
 	"strconv"
 	"strings"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
 )
 
 // logTextMaxRunes はログ出力時にtextを切り詰めるrune数の上限。
@@ -38,12 +40,12 @@ func formatFloatPtr(v *float64) string {
 
 // dryRunPlaybackAttrs はdry-runモードの playback completed ログに付与する属性セットを返す。
 // 呼び出し側で path などの属性を前後に追加できるよう []any を返す。
-func dryRunPlaybackAttrs(text string, speakerID int, speed, pitch, intonation *float64) []any {
+func dryRunPlaybackAttrs(text string, speakerID int, overrides entity.SynthOverrides) []any {
 	return []any{
 		"text", truncateAndEscapeText(text),
 		"speaker", speakerID,
-		"speed", formatFloatPtr(speed),
-		"pitch", formatFloatPtr(pitch),
-		"intonation", formatFloatPtr(intonation),
+		"speed", formatFloatPtr(overrides.Speed),
+		"pitch", formatFloatPtr(overrides.Pitch),
+		"intonation", formatFloatPtr(overrides.Intonation),
 	}
 }

--- a/internal/app/say_usecase.go
+++ b/internal/app/say_usecase.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
 )
 
 // SayParams はsayユースケースのパラメータ。
@@ -92,7 +94,7 @@ func (u *SayUsecase) Run(ctx context.Context, params SayParams) error {
 	}
 	u.logger.Debug("query created")
 
-	q := query.WithOverrides(params.Speed, params.Pitch, params.Intonation)
+	q := query.WithOverrides(entity.SynthOverrides{Speed: params.Speed, Pitch: params.Pitch, Intonation: params.Intonation})
 	wavData, err := u.client.Synthesize(ctx, &q, params.SpeakerID)
 	if err != nil {
 		if ctx.Err() != nil {

--- a/internal/app/say_usecase.go
+++ b/internal/app/say_usecase.go
@@ -72,7 +72,7 @@ func (u *SayUsecase) Run(ctx context.Context, params SayParams) error {
 
 	if params.DryRun {
 		u.logger.Info("synthesis completed", "wavSize", 0)
-		attrs := dryRunPlaybackAttrs(params.Text, params.SpeakerID, params.Speed, params.Pitch, params.Intonation)
+		attrs := dryRunPlaybackAttrs(params.Text, params.SpeakerID, entity.SynthOverrides{Speed: params.Speed, Pitch: params.Pitch, Intonation: params.Intonation})
 		u.logger.Info("playback completed", attrs...)
 		return nil
 	}

--- a/internal/app/synth_pipeline.go
+++ b/internal/app/synth_pipeline.go
@@ -34,10 +34,8 @@ type synthResult struct {
 
 // synthPipelineConfig はstartSynthPipelineの設定。
 type synthPipelineConfig struct {
-	defaultSpeakerID  int
-	defaultSpeed      *float64
-	defaultPitch      *float64
-	defaultIntonation *float64
+	defaultSpeakerID int
+	defaultOverrides entity.SynthOverrides
 	// synthesisLogLevel は "synthesis completed" ログの出力レベル。
 	synthesisLogLevel slog.Level
 }
@@ -70,9 +68,7 @@ func startSynthPipeline(
 			index++
 
 			speakerID := script.ResolveSpeakerID(cfg.defaultSpeakerID)
-			speed := script.ResolveSpeed(cfg.defaultSpeed)
-			pitch := script.ResolvePitch(cfg.defaultPitch)
-			intonation := script.ResolveIntonation(cfg.defaultIntonation)
+			overrides := script.ResolveOverrides(cfg.defaultOverrides)
 
 			result := synthResult{script: script, index: index}
 
@@ -90,7 +86,7 @@ func startSynthPipeline(
 			}
 			logger.Debug("query created", "path", script.Path)
 
-			q := query.WithOverrides(speed, pitch, intonation)
+			q := query.WithOverrides(overrides)
 			wavData, err := client.Synthesize(ctx, &q, speakerID)
 			if err != nil {
 				if ctx.Err() != nil {

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -310,10 +310,12 @@ func (u *WatchUsecase) processFile(ctx context.Context, path string, params Watc
 	}
 
 	cfg := synthPipelineConfig{
-		defaultSpeakerID:  params.SpeakerID,
-		defaultSpeed:      params.Speed,
-		defaultPitch:      params.Pitch,
-		defaultIntonation: params.Intonation,
+		defaultSpeakerID: params.SpeakerID,
+		defaultOverrides: entity.SynthOverrides{
+			Speed:      params.Speed,
+			Pitch:      params.Pitch,
+			Intonation: params.Intonation,
+		},
 		synthesisLogLevel: slog.LevelDebug,
 	}
 	ch := startSynthPipeline(ctx, u.client, u.logger, scripts, cfg)
@@ -401,11 +403,13 @@ func (u *WatchUsecase) processScriptsDryRun(ctx context.Context, scripts []entit
 		current++
 
 		speakerID := script.ResolveSpeakerID(params.SpeakerID)
-		speed := script.ResolveSpeed(params.Speed)
-		pitch := script.ResolvePitch(params.Pitch)
-		intonation := script.ResolveIntonation(params.Intonation)
+		overrides := script.ResolveOverrides(entity.SynthOverrides{
+			Speed:      params.Speed,
+			Pitch:      params.Pitch,
+			Intonation: params.Intonation,
+		})
 
-		attrs := dryRunPlaybackAttrs(script.Text, speakerID, speed, pitch, intonation)
+		attrs := dryRunPlaybackAttrs(script.Text, speakerID, overrides.Speed, overrides.Pitch, overrides.Intonation)
 		u.logger.Info(fmt.Sprintf("[%d/%d] playback completed", current, total), attrs...)
 	}
 }

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -391,6 +391,7 @@ func (u *WatchUsecase) processScriptsSilent(ctx context.Context, scripts []entit
 // processScriptsDryRun はDryRunモードで1ファイル分のスクリプト群を処理する。
 // VOICEVOXエンジン/音声再生は一切呼ばず、既存のログ互換性を保ったまま逐次出力する。
 func (u *WatchUsecase) processScriptsDryRun(ctx context.Context, scripts []entity.Script, total int, params WatchParams) {
+	defaultOverrides := entity.SynthOverrides{Speed: params.Speed, Pitch: params.Pitch, Intonation: params.Intonation}
 	current := 0
 	for _, script := range scripts {
 		if ctx.Err() != nil {
@@ -403,13 +404,9 @@ func (u *WatchUsecase) processScriptsDryRun(ctx context.Context, scripts []entit
 		current++
 
 		speakerID := script.ResolveSpeakerID(params.SpeakerID)
-		overrides := script.ResolveOverrides(entity.SynthOverrides{
-			Speed:      params.Speed,
-			Pitch:      params.Pitch,
-			Intonation: params.Intonation,
-		})
+		overrides := script.ResolveOverrides(defaultOverrides)
 
-		attrs := dryRunPlaybackAttrs(script.Text, speakerID, overrides.Speed, overrides.Pitch, overrides.Intonation)
+		attrs := dryRunPlaybackAttrs(script.Text, speakerID, overrides)
 		u.logger.Info(fmt.Sprintf("[%d/%d] playback completed", current, total), attrs...)
 	}
 }

--- a/internal/app/watch_usecase_test.go
+++ b/internal/app/watch_usecase_test.go
@@ -358,11 +358,11 @@ func TestWatchUsecase_Run_ScriptParamsOverrideGlobal(t *testing.T) {
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{
-				Path:       "script.json",
-				Text:       "ゆっくり",
-				IsEmpty:    false,
-				SpeakerID:  &scriptSpeaker,
-				SpeedScale: &scriptSpeed,
+				Path:      "script.json",
+				Text:      "ゆっくり",
+				IsEmpty:   false,
+				SpeakerID: &scriptSpeaker,
+				Overrides: entity.SynthOverrides{Speed: &scriptSpeed},
 			},
 		},
 	}

--- a/internal/domain/entity/audio_query.go
+++ b/internal/domain/entity/audio_query.go
@@ -24,17 +24,17 @@ type AccentPhrase struct {
 	IsInterrogative bool   `json:"is_interrogative"`
 }
 
-// WithOverrides は指定されたパラメータでAudioQueryのフィールドを上書きした新しいAudioQueryを返す。
-// nilのパラメータは上書きしない。値レシーバのため元のAudioQueryは変更されない。
-func (q AudioQuery) WithOverrides(speed, pitch, intonation *float64) AudioQuery {
-	if speed != nil {
-		q.SpeedScale = *speed
+// WithOverrides はSynthOverridesのパラメータでAudioQueryのフィールドを上書きした新しいAudioQueryを返す。
+// nilフィールドは上書きしない。値レシーバのため元のAudioQueryは変更されない。
+func (q AudioQuery) WithOverrides(overrides SynthOverrides) AudioQuery {
+	if overrides.Speed != nil {
+		q.SpeedScale = *overrides.Speed
 	}
-	if pitch != nil {
-		q.PitchScale = *pitch
+	if overrides.Pitch != nil {
+		q.PitchScale = *overrides.Pitch
 	}
-	if intonation != nil {
-		q.IntonationScale = *intonation
+	if overrides.Intonation != nil {
+		q.IntonationScale = *overrides.Intonation
 	}
 	return q
 }

--- a/internal/domain/entity/audio_query_test.go
+++ b/internal/domain/entity/audio_query_test.go
@@ -13,7 +13,7 @@ func TestAudioQuery_WithOverrides_AllNil(t *testing.T) {
 		IntonationScale: 1.0,
 	}
 
-	result := q.WithOverrides(nil, nil, nil)
+	result := q.WithOverrides(entity.SynthOverrides{})
 
 	if result.SpeedScale != 1.0 {
 		t.Errorf("expected SpeedScale 1.0, got %f", result.SpeedScale)
@@ -33,8 +33,7 @@ func TestAudioQuery_WithOverrides_SpeedOnly(t *testing.T) {
 		IntonationScale: 1.0,
 	}
 
-	speed := 1.5
-	result := q.WithOverrides(&speed, nil, nil)
+	result := q.WithOverrides(entity.SynthOverrides{Speed: ptr(1.5)})
 
 	if result.SpeedScale != 1.5 {
 		t.Errorf("expected SpeedScale 1.5, got %f", result.SpeedScale)
@@ -54,8 +53,7 @@ func TestAudioQuery_WithOverrides_PitchOnly(t *testing.T) {
 		IntonationScale: 1.0,
 	}
 
-	pitch := 0.5
-	result := q.WithOverrides(nil, &pitch, nil)
+	result := q.WithOverrides(entity.SynthOverrides{Pitch: ptr(0.5)})
 
 	if result.SpeedScale != 1.0 {
 		t.Errorf("expected SpeedScale 1.0, got %f", result.SpeedScale)
@@ -75,8 +73,7 @@ func TestAudioQuery_WithOverrides_IntonationOnly(t *testing.T) {
 		IntonationScale: 1.0,
 	}
 
-	intonation := 2.0
-	result := q.WithOverrides(nil, nil, &intonation)
+	result := q.WithOverrides(entity.SynthOverrides{Intonation: ptr(2.0)})
 
 	if result.SpeedScale != 1.0 {
 		t.Errorf("expected SpeedScale 1.0, got %f", result.SpeedScale)
@@ -97,10 +94,7 @@ func TestAudioQuery_WithOverrides_AllParams(t *testing.T) {
 		VolumeScale:     1.0,
 	}
 
-	speed := 1.5
-	pitch := 0.5
-	intonation := 2.0
-	result := q.WithOverrides(&speed, &pitch, &intonation)
+	result := q.WithOverrides(entity.SynthOverrides{Speed: ptr(1.5), Pitch: ptr(0.5), Intonation: ptr(2.0)})
 
 	if result.SpeedScale != 1.5 {
 		t.Errorf("expected SpeedScale 1.5, got %f", result.SpeedScale)
@@ -124,10 +118,7 @@ func TestAudioQuery_WithOverrides_DoesNotModifyOriginal(t *testing.T) {
 		IntonationScale: 1.0,
 	}
 
-	speed := 1.5
-	pitch := 0.5
-	intonation := 2.0
-	_ = q.WithOverrides(&speed, &pitch, &intonation)
+	_ = q.WithOverrides(entity.SynthOverrides{Speed: ptr(1.5), Pitch: ptr(0.5), Intonation: ptr(2.0)})
 
 	// 元のAudioQueryが変更されていないことを確認
 	if q.SpeedScale != 1.0 {

--- a/internal/domain/entity/script.go
+++ b/internal/domain/entity/script.go
@@ -10,12 +10,8 @@ type Script struct {
 	IsEmpty bool
 	// SpeakerID はセリフ単位のキャラクターID（nilの場合はデフォルト値を使用）。
 	SpeakerID *int
-	// SpeedScale はセリフ単位の話速（nilの場合はデフォルト値を使用）。
-	SpeedScale *float64
-	// PitchScale はセリフ単位の音高（nilの場合はデフォルト値を使用）。
-	PitchScale *float64
-	// IntonationScale はセリフ単位の抑揚（nilの場合はデフォルト値を使用）。
-	IntonationScale *float64
+	// Overrides はセリフ単位の合成パラメータ（nilフィールドの場合はデフォルト値を使用）。
+	Overrides SynthOverrides
 }
 
 // ResolveSpeakerID はセリフ単位のSpeakerIDがあればそれを、なければデフォルト値を返す。
@@ -26,25 +22,7 @@ func (s Script) ResolveSpeakerID(defaultID int) int {
 	return defaultID
 }
 
-// resolveFloat64 はセリフ単位の値があればそれを、なければデフォルト値を返す。
-func resolveFloat64(scriptVal, defaultVal *float64) *float64 {
-	if scriptVal != nil {
-		return scriptVal
-	}
-	return defaultVal
-}
-
-// ResolveSpeed はセリフ単位のSpeedScaleがあればそれを、なければデフォルト値を返す。
-func (s Script) ResolveSpeed(defaultSpeed *float64) *float64 {
-	return resolveFloat64(s.SpeedScale, defaultSpeed)
-}
-
-// ResolvePitch はセリフ単位のPitchScaleがあればそれを、なければデフォルト値を返す。
-func (s Script) ResolvePitch(defaultPitch *float64) *float64 {
-	return resolveFloat64(s.PitchScale, defaultPitch)
-}
-
-// ResolveIntonation はセリフ単位のIntonationScaleがあればそれを、なければデフォルト値を返す。
-func (s Script) ResolveIntonation(defaultIntonation *float64) *float64 {
-	return resolveFloat64(s.IntonationScale, defaultIntonation)
+// ResolveOverrides はセリフ単位のOverridesを優先し、nilフィールドはdefaultsで補完した値を返す。
+func (s Script) ResolveOverrides(defaults SynthOverrides) SynthOverrides {
+	return s.Overrides.MergeWith(defaults)
 }

--- a/internal/domain/entity/script_test.go
+++ b/internal/domain/entity/script_test.go
@@ -1,0 +1,83 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+func TestScript_ResolveOverrides_ScriptTakesPrecedence(t *testing.T) {
+	s := entity.Script{
+		Overrides: entity.SynthOverrides{Speed: ptr(1.5), Pitch: ptr(0.1), Intonation: ptr(1.2)},
+	}
+	defaults := entity.SynthOverrides{Speed: ptr(1.0), Pitch: ptr(0.0), Intonation: ptr(1.0)}
+
+	got := s.ResolveOverrides(defaults)
+
+	if *got.Speed != 1.5 {
+		t.Errorf("Speed = %v, want 1.5", *got.Speed)
+	}
+	if *got.Pitch != 0.1 {
+		t.Errorf("Pitch = %v, want 0.1", *got.Pitch)
+	}
+	if *got.Intonation != 1.2 {
+		t.Errorf("Intonation = %v, want 1.2", *got.Intonation)
+	}
+}
+
+func TestScript_ResolveOverrides_NilScriptUsesDefaults(t *testing.T) {
+	s := entity.Script{}
+	defaults := entity.SynthOverrides{Speed: ptr(1.0), Pitch: ptr(0.0), Intonation: ptr(1.0)}
+
+	got := s.ResolveOverrides(defaults)
+
+	if *got.Speed != 1.0 {
+		t.Errorf("Speed = %v, want 1.0", *got.Speed)
+	}
+	if *got.Pitch != 0.0 {
+		t.Errorf("Pitch = %v, want 0.0", *got.Pitch)
+	}
+	if *got.Intonation != 1.0 {
+		t.Errorf("Intonation = %v, want 1.0", *got.Intonation)
+	}
+}
+
+func TestScript_ResolveOverrides_PartialOverride(t *testing.T) {
+	s := entity.Script{
+		Overrides: entity.SynthOverrides{Speed: ptr(1.5)},
+	}
+	defaults := entity.SynthOverrides{Speed: ptr(1.0), Pitch: ptr(0.0), Intonation: ptr(1.0)}
+
+	got := s.ResolveOverrides(defaults)
+
+	if *got.Speed != 1.5 {
+		t.Errorf("Speed = %v, want 1.5", *got.Speed)
+	}
+	if *got.Pitch != 0.0 {
+		t.Errorf("Pitch = %v, want 0.0", *got.Pitch)
+	}
+	if *got.Intonation != 1.0 {
+		t.Errorf("Intonation = %v, want 1.0", *got.Intonation)
+	}
+}
+
+func TestScript_ResolveSpeakerID_ScriptValueTakesPrecedence(t *testing.T) {
+	id := 5
+	s := entity.Script{SpeakerID: &id}
+
+	got := s.ResolveSpeakerID(3)
+
+	if got != 5 {
+		t.Errorf("got %d, want 5", got)
+	}
+}
+
+func TestScript_ResolveSpeakerID_NilUsesDefault(t *testing.T) {
+	s := entity.Script{}
+
+	got := s.ResolveSpeakerID(3)
+
+	if got != 3 {
+		t.Errorf("got %d, want 3", got)
+	}
+}

--- a/internal/domain/entity/synth_overrides.go
+++ b/internal/domain/entity/synth_overrides.go
@@ -1,0 +1,24 @@
+package entity
+
+// SynthOverrides はセリフ単位の合成パラメータを保持する値オブジェクト。
+// nilフィールドは「未指定（デフォルト値を使用）」を意味する。
+type SynthOverrides struct {
+	Speed      *float64
+	Pitch      *float64
+	Intonation *float64
+}
+
+// MergeWith はselfの値を優先し、nilフィールドはdefaultsの値を採用した新しいSynthOverridesを返す。
+func (o SynthOverrides) MergeWith(defaults SynthOverrides) SynthOverrides {
+	result := defaults
+	if o.Speed != nil {
+		result.Speed = o.Speed
+	}
+	if o.Pitch != nil {
+		result.Pitch = o.Pitch
+	}
+	if o.Intonation != nil {
+		result.Intonation = o.Intonation
+	}
+	return result
+}

--- a/internal/domain/entity/synth_overrides_test.go
+++ b/internal/domain/entity/synth_overrides_test.go
@@ -1,0 +1,91 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+func ptr(f float64) *float64 { return &f }
+
+func TestSynthOverrides_MergeWith_SelfTakesPrecedence(t *testing.T) {
+	self := entity.SynthOverrides{Speed: ptr(1.5), Pitch: ptr(0.1), Intonation: ptr(1.2)}
+	defaults := entity.SynthOverrides{Speed: ptr(1.0), Pitch: ptr(0.0), Intonation: ptr(1.0)}
+
+	got := self.MergeWith(defaults)
+
+	if *got.Speed != 1.5 {
+		t.Errorf("Speed = %v, want 1.5", *got.Speed)
+	}
+	if *got.Pitch != 0.1 {
+		t.Errorf("Pitch = %v, want 0.1", *got.Pitch)
+	}
+	if *got.Intonation != 1.2 {
+		t.Errorf("Intonation = %v, want 1.2", *got.Intonation)
+	}
+}
+
+func TestSynthOverrides_MergeWith_NilSelfUsesDefault(t *testing.T) {
+	self := entity.SynthOverrides{}
+	defaults := entity.SynthOverrides{Speed: ptr(1.0), Pitch: ptr(0.0), Intonation: ptr(1.0)}
+
+	got := self.MergeWith(defaults)
+
+	if *got.Speed != 1.0 {
+		t.Errorf("Speed = %v, want 1.0", *got.Speed)
+	}
+	if *got.Pitch != 0.0 {
+		t.Errorf("Pitch = %v, want 0.0", *got.Pitch)
+	}
+	if *got.Intonation != 1.0 {
+		t.Errorf("Intonation = %v, want 1.0", *got.Intonation)
+	}
+}
+
+func TestSynthOverrides_MergeWith_PartialSelfOverridesPartially(t *testing.T) {
+	self := entity.SynthOverrides{Speed: ptr(1.5)}
+	defaults := entity.SynthOverrides{Speed: ptr(1.0), Pitch: ptr(0.0), Intonation: ptr(1.0)}
+
+	got := self.MergeWith(defaults)
+
+	if *got.Speed != 1.5 {
+		t.Errorf("Speed = %v, want 1.5", *got.Speed)
+	}
+	if *got.Pitch != 0.0 {
+		t.Errorf("Pitch = %v, want 0.0", *got.Pitch)
+	}
+	if *got.Intonation != 1.0 {
+		t.Errorf("Intonation = %v, want 1.0", *got.Intonation)
+	}
+}
+
+func TestSynthOverrides_MergeWith_BothNilResultsInNil(t *testing.T) {
+	self := entity.SynthOverrides{}
+	defaults := entity.SynthOverrides{}
+
+	got := self.MergeWith(defaults)
+
+	if got.Speed != nil {
+		t.Errorf("Speed = %v, want nil", got.Speed)
+	}
+	if got.Pitch != nil {
+		t.Errorf("Pitch = %v, want nil", got.Pitch)
+	}
+	if got.Intonation != nil {
+		t.Errorf("Intonation = %v, want nil", got.Intonation)
+	}
+}
+
+func TestSynthOverrides_MergeWith_DoesNotModifyOriginal(t *testing.T) {
+	self := entity.SynthOverrides{Speed: ptr(1.5)}
+	defaults := entity.SynthOverrides{Speed: ptr(1.0), Pitch: ptr(0.0)}
+
+	_ = self.MergeWith(defaults)
+
+	if *self.Speed != 1.5 {
+		t.Errorf("self.Speed modified, got %v", *self.Speed)
+	}
+	if *defaults.Speed != 1.0 {
+		t.Errorf("defaults.Speed modified, got %v", *defaults.Speed)
+	}
+}

--- a/internal/infra/file_reader.go
+++ b/internal/infra/file_reader.go
@@ -39,13 +39,15 @@ type jsonScript struct {
 func (js *jsonScript) toScript(path string) entity.Script {
 	text := *js.Text
 	return entity.Script{
-		Path:            path,
-		Text:            text,
-		IsEmpty:         len(text) == 0,
-		SpeakerID:       js.Speaker,
-		SpeedScale:      js.SpeedScale,
-		PitchScale:      js.PitchScale,
-		IntonationScale: js.IntonationScale,
+		Path:      path,
+		Text:      text,
+		IsEmpty:   len(text) == 0,
+		SpeakerID: js.Speaker,
+		Overrides: entity.SynthOverrides{
+			Speed:      js.SpeedScale,
+			Pitch:      js.PitchScale,
+			Intonation: js.IntonationScale,
+		},
 	}
 }
 

--- a/internal/infra/file_reader_test.go
+++ b/internal/infra/file_reader_test.go
@@ -311,14 +311,14 @@ func TestFileReader_Read_JSONFile_TextOnly(t *testing.T) {
 	if s.SpeakerID != nil {
 		t.Errorf("expected SpeakerID nil, got %v", *s.SpeakerID)
 	}
-	if s.SpeedScale != nil {
-		t.Errorf("expected SpeedScale nil, got %v", *s.SpeedScale)
+	if s.Overrides.Speed != nil {
+		t.Errorf("expected Overrides.Speed nil, got %v", *s.Overrides.Speed)
 	}
-	if s.PitchScale != nil {
-		t.Errorf("expected PitchScale nil, got %v", *s.PitchScale)
+	if s.Overrides.Pitch != nil {
+		t.Errorf("expected Overrides.Pitch nil, got %v", *s.Overrides.Pitch)
 	}
-	if s.IntonationScale != nil {
-		t.Errorf("expected IntonationScale nil, got %v", *s.IntonationScale)
+	if s.Overrides.Intonation != nil {
+		t.Errorf("expected Overrides.Intonation nil, got %v", *s.Overrides.Intonation)
 	}
 }
 
@@ -349,14 +349,14 @@ func TestFileReader_Read_JSONFile_AllParams(t *testing.T) {
 	if s.SpeakerID == nil || *s.SpeakerID != 5 {
 		t.Errorf("expected SpeakerID 5, got %v", s.SpeakerID)
 	}
-	if s.SpeedScale == nil || *s.SpeedScale != 1.5 {
-		t.Errorf("expected SpeedScale 1.5, got %v", s.SpeedScale)
+	if s.Overrides.Speed == nil || *s.Overrides.Speed != 1.5 {
+		t.Errorf("expected Overrides.Speed 1.5, got %v", s.Overrides.Speed)
 	}
-	if s.PitchScale == nil || *s.PitchScale != 0.1 {
-		t.Errorf("expected PitchScale 0.1, got %v", s.PitchScale)
+	if s.Overrides.Pitch == nil || *s.Overrides.Pitch != 0.1 {
+		t.Errorf("expected Overrides.Pitch 0.1, got %v", s.Overrides.Pitch)
 	}
-	if s.IntonationScale == nil || *s.IntonationScale != 1.8 {
-		t.Errorf("expected IntonationScale 1.8, got %v", s.IntonationScale)
+	if s.Overrides.Intonation == nil || *s.Overrides.Intonation != 1.8 {
+		t.Errorf("expected Overrides.Intonation 1.8, got %v", s.Overrides.Intonation)
 	}
 }
 
@@ -537,14 +537,14 @@ func TestFileReader_Read_JSONLFile_TextOnly(t *testing.T) {
 	if s.SpeakerID != nil {
 		t.Errorf("expected SpeakerID nil, got %v", *s.SpeakerID)
 	}
-	if s.SpeedScale != nil {
-		t.Errorf("expected SpeedScale nil, got %v", *s.SpeedScale)
+	if s.Overrides.Speed != nil {
+		t.Errorf("expected Overrides.Speed nil, got %v", *s.Overrides.Speed)
 	}
-	if s.PitchScale != nil {
-		t.Errorf("expected PitchScale nil, got %v", *s.PitchScale)
+	if s.Overrides.Pitch != nil {
+		t.Errorf("expected Overrides.Pitch nil, got %v", *s.Overrides.Pitch)
 	}
-	if s.IntonationScale != nil {
-		t.Errorf("expected IntonationScale nil, got %v", *s.IntonationScale)
+	if s.Overrides.Intonation != nil {
+		t.Errorf("expected Overrides.Intonation nil, got %v", *s.Overrides.Intonation)
 	}
 }
 
@@ -575,14 +575,14 @@ func TestFileReader_Read_JSONLFile_AllParams(t *testing.T) {
 	if s.SpeakerID == nil || *s.SpeakerID != 5 {
 		t.Errorf("expected SpeakerID 5, got %v", s.SpeakerID)
 	}
-	if s.SpeedScale == nil || *s.SpeedScale != 1.5 {
-		t.Errorf("expected SpeedScale 1.5, got %v", s.SpeedScale)
+	if s.Overrides.Speed == nil || *s.Overrides.Speed != 1.5 {
+		t.Errorf("expected Overrides.Speed 1.5, got %v", s.Overrides.Speed)
 	}
-	if s.PitchScale == nil || *s.PitchScale != 0.1 {
-		t.Errorf("expected PitchScale 0.1, got %v", s.PitchScale)
+	if s.Overrides.Pitch == nil || *s.Overrides.Pitch != 0.1 {
+		t.Errorf("expected Overrides.Pitch 0.1, got %v", s.Overrides.Pitch)
 	}
-	if s.IntonationScale == nil || *s.IntonationScale != 1.8 {
-		t.Errorf("expected IntonationScale 1.8, got %v", s.IntonationScale)
+	if s.Overrides.Intonation == nil || *s.Overrides.Intonation != 1.8 {
+		t.Errorf("expected Overrides.Intonation 1.8, got %v", s.Overrides.Intonation)
 	}
 }
 

--- a/internal/infra/file_writer.go
+++ b/internal/infra/file_writer.go
@@ -123,13 +123,13 @@ func (w *FileWriter) warnUnsavedParams(path string, script entity.Script) {
 	if script.SpeakerID != nil {
 		dropped = append(dropped, "speaker")
 	}
-	if script.SpeedScale != nil {
+	if script.Overrides.Speed != nil {
 		dropped = append(dropped, "speed")
 	}
-	if script.PitchScale != nil {
+	if script.Overrides.Pitch != nil {
 		dropped = append(dropped, "pitch")
 	}
-	if script.IntonationScale != nil {
+	if script.Overrides.Intonation != nil {
 		dropped = append(dropped, "intonation")
 	}
 	if len(dropped) == 0 {
@@ -155,9 +155,9 @@ func toJSONScript(script entity.Script) jsonScriptOut {
 	return jsonScriptOut{
 		Text:            script.Text,
 		Speaker:         script.SpeakerID,
-		SpeedScale:      script.SpeedScale,
-		PitchScale:      script.PitchScale,
-		IntonationScale: script.IntonationScale,
+		SpeedScale:      script.Overrides.Speed,
+		PitchScale:      script.Overrides.Pitch,
+		IntonationScale: script.Overrides.Intonation,
 	}
 }
 

--- a/internal/infra/file_writer_test.go
+++ b/internal/infra/file_writer_test.go
@@ -80,11 +80,9 @@ func TestFileWriter_Write_JSON_AllParams(t *testing.T) {
 
 	w := infra.NewFileWriter()
 	script := entity.Script{
-		Text:            "感情込めて",
-		SpeakerID:       ptrInt(5),
-		SpeedScale:      ptrFloat64(1.5),
-		PitchScale:      ptrFloat64(0.1),
-		IntonationScale: ptrFloat64(1.8),
+		Text:      "感情込めて",
+		SpeakerID: ptrInt(5),
+		Overrides: entity.SynthOverrides{Speed: ptrFloat64(1.5), Pitch: ptrFloat64(0.1), Intonation: ptrFloat64(1.8)},
 	}
 	if _, err := w.Write(dest, script); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -410,9 +408,9 @@ func TestFileWriter_Write_DirectoryTarget_CreatesAutoNamedFile(t *testing.T) {
 
 	w := infra.NewFileWriter()
 	written, err := w.Write(outDir, entity.Script{
-		Text:       "ディレクトリ指定",
-		SpeakerID:  ptrInt(2),
-		SpeedScale: ptrFloat64(1.1),
+		Text:      "ディレクトリ指定",
+		SpeakerID: ptrInt(2),
+		Overrides: entity.SynthOverrides{Speed: ptrFloat64(1.1)},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -523,8 +521,8 @@ func TestFileWriter_WriteAll_MultipleScripts(t *testing.T) {
 
 	w := infra.NewFileWriter()
 	scripts := []entity.Script{
-		{Text: "おはようなのだ", SpeakerID: ptrInt(3), IntonationScale: ptrFloat64(1.1)},
-		{Text: "今日もがんばるのだ", SpeakerID: ptrInt(3), SpeedScale: ptrFloat64(1.0)},
+		{Text: "おはようなのだ", SpeakerID: ptrInt(3), Overrides: entity.SynthOverrides{Intonation: ptrFloat64(1.1)}},
+		{Text: "今日もがんばるのだ", SpeakerID: ptrInt(3), Overrides: entity.SynthOverrides{Speed: ptrFloat64(1.0)}},
 	}
 	written, err := w.WriteAll(dest, scripts)
 	if err != nil {

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -1063,7 +1063,7 @@ func (p *HTTPStreamPlayer) handleAPIPreviewClip(w http.ResponseWriter, r *http.R
 		http.Error(w, "synthesis failed", http.StatusBadGateway)
 		return
 	}
-	q := query.WithOverrides(req.Speed, req.Pitch, req.Intonation)
+	q := query.WithOverrides(entity.SynthOverrides{Speed: req.Speed, Pitch: req.Pitch, Intonation: req.Intonation})
 	wav, err := p.voicevoxClient.Synthesize(r.Context(), &q, req.SpeakerID)
 	if err != nil {
 		p.logger.Error("/api/preview-clip Synthesize failed", "speakerID", req.SpeakerID, "error", err)
@@ -1211,7 +1211,7 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 					nextSynthCh <- synthResult{err: err}
 					return
 				}
-				q2o := q2.WithOverrides(nextClip.Speed, nextClip.Pitch, nextClip.Intonation)
+				q2o := q2.WithOverrides(entity.SynthOverrides{Speed: nextClip.Speed, Pitch: nextClip.Pitch, Intonation: nextClip.Intonation})
 				w, err := p.voicevoxClient.Synthesize(ctx, &q2o, nextClip.SpeakerID)
 				nextSynthCh <- synthResult{wav: w, err: err}
 			}()
@@ -1253,7 +1253,7 @@ func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID str
 		return nil, err
 	}
 
-	q := query.WithOverrides(clip.Speed, clip.Pitch, clip.Intonation)
+	q := query.WithOverrides(entity.SynthOverrides{Speed: clip.Speed, Pitch: clip.Pitch, Intonation: clip.Intonation})
 	wav, err := p.voicevoxClient.Synthesize(ctx, &q, clip.SpeakerID)
 	if err != nil {
 		p.logger.Error("worker Synthesize failed", "playbackID", playbackID, "speakerID", clip.SpeakerID, "error", err)


### PR DESCRIPTION
## Summary

- `entity.SynthOverrides` 値オブジェクトを新設し、speed/pitch/intonation の3パラメータを一元管理
- `SynthOverrides.MergeWith(defaults SynthOverrides)` でデフォルト値合成を一箇所に集約
- `Script.{SpeedScale,PitchScale,IntonationScale}` を `Script.Overrides SynthOverrides` に置き換え
- `Script.{ResolveSpeed,ResolvePitch,ResolveIntonation}` を `Script.ResolveOverrides(defaults)` に統合
- `AudioQuery.WithOverrides` の引数を3つの `*float64` から `SynthOverrides` 一個に変更
- `synthPipelineConfig.defaultOverrides` に3フィールドを集約
- `dryRunPlaybackAttrs` の引数も `SynthOverrides` に変更し抽象境界を維持

## 仕様補足

infra層の `ClipPayload`/`EventMeta` JSON構造体はワイヤーフォーマットとして speed/pitch/intonation の3フィールドを維持。`entity.SynthOverrides` への変換は infra→entity 境界で行う。

## Test plan

- [x] `go test ./...` でユニットテスト・統合テストがすべてパスすることを確認
- [x] 新規テスト追加: `synth_overrides_test.go`, `script_test.go`
- [x] 既存テスト更新: `audio_query_test.go`, `synth_pipeline_test.go` ほか
- [x] `gofmt -l .` と `golangci-lint run` でフォーマット・lint クリーン確認
- ※ cmd の `TestRunWatch_AudioProbe_*` 2件は本PR変更前から失敗しているため対象外

Closes #557

---
🤖 Generated with [Claude Code](https://claude.ai/code)
