### PR TITLE
refactor(domain): SpeakerID を値オブジェクト化する

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -66,7 +66,7 @@ func actViaViewer(
 	cmd *cobra.Command,
 	vc *infra.ViewerAPIClient,
 	scripts []entity.Script,
-	speakerID int, speed, pitch, intonation float64,
+	speakerID entity.SpeakerID, speed, pitch, intonation float64,
 	logger *slog.Logger,
 ) error {
 	defaults := entity.SynthOverrides{Speed: &speed, Pitch: &pitch, Intonation: &intonation}
@@ -78,7 +78,7 @@ func actViaViewer(
 		resolved := script.ResolveOverrides(defaults)
 		clips = append(clips, infra.ViewerClip{
 			Text:       script.Text,
-			SpeakerID:  script.ResolveSpeakerID(speakerID),
+			SpeakerID:  script.ResolveSpeakerID(speakerID).Value(),
 			Speed:      resolved.Speed,
 			Pitch:      resolved.Pitch,
 			Intonation: resolved.Intonation,
@@ -118,11 +118,16 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 	defer stop()
 
 	engineURL, _ := cmd.Flags().GetString("engine-url")
-	speakerID, _ := cmd.Flags().GetInt("speaker")
+	speakerIDInt, _ := cmd.Flags().GetInt("speaker")
 	speed, _ := cmd.Flags().GetFloat64("speed")
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	speakerID, err := entity.NewSpeakerID(speakerIDInt)
+	if err != nil {
+		return fmt.Errorf("%w: --speaker: %v", ErrUsage, err)
+	}
 
 	var logger *slog.Logger
 	if deps.Logger != nil {

--- a/cmd/act_test.go
+++ b/cmd/act_test.go
@@ -470,10 +470,10 @@ func TestActCmd_WatchDeleteFlag_ReturnsMigrationError(t *testing.T) {
 type mockActClient struct{}
 
 func (c *mockActClient) HealthCheck(_ context.Context) error { return nil }
-func (c *mockActClient) CreateQuery(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+func (c *mockActClient) CreateQuery(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 	return &entity.AudioQuery{}, nil
 }
-func (c *mockActClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+func (c *mockActClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 	return []byte("RIFFx"), nil
 }
 func (c *mockActClient) GetSpeakers(_ context.Context) ([]entity.Speaker, error) { return nil, nil }

--- a/cmd/say.go
+++ b/cmd/say.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
 	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
@@ -84,14 +85,19 @@ func runSay(cmd *cobra.Command, args []string, deps *SayDeps) error {
 
 	engineURL, _ := cmd.Flags().GetString("engine-url")
 	viewerURL, _ := cmd.Flags().GetString("viewer-url")
-	speakerID, _ := cmd.Flags().GetInt("speaker")
+	speakerIDInt, _ := cmd.Flags().GetInt("speaker")
 	speed, _ := cmd.Flags().GetFloat64("speed")
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
 
+	speakerID, err := entity.NewSpeakerID(speakerIDInt)
+	if err != nil {
+		return fmt.Errorf("%w: --speaker: %v", ErrUsage, err)
+	}
+
 	clip := infra.ViewerClip{
 		Text:       args[0],
-		SpeakerID:  speakerID,
+		SpeakerID:  speakerIDInt,
 		Speed:      &speed,
 		Pitch:      &pitch,
 		Intonation: &intonation,

--- a/cmd/say_test.go
+++ b/cmd/say_test.go
@@ -207,10 +207,10 @@ func TestSayCmd_VerboseFlag_DefaultFalse(t *testing.T) {
 type noopClient struct{}
 
 func (n *noopClient) HealthCheck(_ context.Context) error { return errors.New("must not be called") }
-func (n *noopClient) CreateQuery(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+func (n *noopClient) CreateQuery(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 	return nil, errors.New("must not be called")
 }
-func (n *noopClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+func (n *noopClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 	return nil, errors.New("must not be called")
 }
 func (n *noopClient) GetSpeakers(_ context.Context) ([]entity.Speaker, error) {
@@ -383,10 +383,10 @@ func (p *trackingPlayer) Play(_ context.Context, _ []byte, _ app.PlayMeta) error
 type mockSayClient struct{}
 
 func (c *mockSayClient) HealthCheck(_ context.Context) error { return nil }
-func (c *mockSayClient) CreateQuery(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+func (c *mockSayClient) CreateQuery(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 	return &entity.AudioQuery{}, nil
 }
-func (c *mockSayClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+func (c *mockSayClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 	return []byte("RIFFx"), nil
 }
 func (c *mockSayClient) GetSpeakers(_ context.Context) ([]entity.Speaker, error) { return nil, nil }

--- a/cmd/script_append.go
+++ b/cmd/script_append.go
@@ -45,8 +45,12 @@ func runScriptAppend(cmd *cobra.Command, args []string, deps *ScriptAppendDeps) 
 
 	script := entity.Script{Text: text, IsEmpty: text == ""}
 	if cmd.Flags().Changed("speaker") {
-		v, _ := cmd.Flags().GetInt("speaker")
-		script.SpeakerID = &v
+		vInt, _ := cmd.Flags().GetInt("speaker")
+		id, err := entity.NewSpeakerID(vInt)
+		if err != nil {
+			return fmt.Errorf("%w: --speaker: %v", ErrUsage, err)
+		}
+		script.SpeakerID = &id
 	}
 	if cmd.Flags().Changed("speed") {
 		v, _ := cmd.Flags().GetFloat64("speed")

--- a/cmd/script_append_test.go
+++ b/cmd/script_append_test.go
@@ -275,7 +275,7 @@ func TestScriptAppendCmd_FlagsPassedToWriter(t *testing.T) {
 		t.Fatalf("expected 1 Write call, got: %d", len(writer.calls))
 	}
 	s := writer.calls[0].script
-	if s.SpeakerID == nil || *s.SpeakerID != 5 {
+	if s.SpeakerID == nil || s.SpeakerID.Value() != 5 {
 		t.Errorf("expected SpeakerID=5, got: %v", s.SpeakerID)
 	}
 	if s.Overrides.Speed == nil || *s.Overrides.Speed != 1.2 {

--- a/cmd/script_write.go
+++ b/cmd/script_write.go
@@ -64,10 +64,18 @@ func runScriptWrite(cmd *cobra.Command, args []string, deps *ScriptWriteDeps) er
 
 	scripts := make([]entity.Script, len(inputs))
 	for i, in := range inputs {
+		var speakerID *entity.SpeakerID
+		if in.Speaker != nil {
+			id, err := entity.NewSpeakerID(*in.Speaker)
+			if err != nil {
+				return fmt.Errorf("%w: inputs[%d].speaker: %v", ErrUsage, i, err)
+			}
+			speakerID = &id
+		}
 		scripts[i] = entity.Script{
 			Text:      in.Text,
 			IsEmpty:   in.Text == "",
-			SpeakerID: in.Speaker,
+			SpeakerID: speakerID,
 			Overrides: entity.SynthOverrides{
 				Speed:      in.Speed,
 				Pitch:      in.Pitch,

--- a/cmd/script_write_test.go
+++ b/cmd/script_write_test.go
@@ -187,7 +187,7 @@ func TestScriptWriteCmd_JsonFieldsMappedToScript(t *testing.T) {
 	if s.Text != "セリフ" {
 		t.Errorf("Text: expected 'セリフ', got %q", s.Text)
 	}
-	if s.SpeakerID == nil || *s.SpeakerID != 3 {
+	if s.SpeakerID == nil || s.SpeakerID.Value() != 3 {
 		t.Errorf("SpeakerID: expected 3, got %v", s.SpeakerID)
 	}
 	if s.Overrides.Speed == nil || *s.Overrides.Speed != 1.2 {

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/canpok1/vox-actor/internal/app"
+	"github.com/canpok1/vox-actor/internal/domain/entity"
 	"github.com/canpok1/vox-actor/internal/infra"
 	"github.com/spf13/cobra"
 )
@@ -94,7 +95,7 @@ func (p *viewerWatchPlayer) playViaViewer(ctx context.Context, meta app.PlayMeta
 	_, err := p.vc.Play(ctx, infra.ViewerPlayRequest{
 		Clips: []infra.ViewerClip{{
 			Text:       meta.Text,
-			SpeakerID:  meta.SpeakerID,
+			SpeakerID:  meta.SpeakerID.Value(),
 			Speed:      p.speed,
 			Pitch:      p.pitch,
 			Intonation: p.intonation,
@@ -165,12 +166,17 @@ func runWatch(cmd *cobra.Command, args []string, deps *WatchDeps) error {
 
 	deleteMode, _ := cmd.Flags().GetBool("delete")
 	engineURL, _ := cmd.Flags().GetString("engine-url")
-	speakerID, _ := cmd.Flags().GetInt("speaker")
+	speakerIDInt, _ := cmd.Flags().GetInt("speaker")
 	speed, _ := cmd.Flags().GetFloat64("speed")
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	saveWavDir, _ := cmd.Flags().GetString("save-wav-dir")
+
+	speakerID, err := entity.NewSpeakerID(speakerIDInt)
+	if err != nil {
+		return fmt.Errorf("%w: --speaker: %v", ErrUsage, err)
+	}
 
 	if deps == nil || deps.ClientFactory == nil || deps.Reader == nil || deps.Player == nil || deps.Mover == nil || deps.DirWatcherFactory == nil {
 		return fmt.Errorf("watch command dependencies are not initialized")

--- a/cmd/watch_test.go
+++ b/cmd/watch_test.go
@@ -240,10 +240,10 @@ type stubVoicevoxClient struct {
 }
 
 func (c *stubVoicevoxClient) HealthCheck(_ context.Context) error { return c.healthCheckErr }
-func (c *stubVoicevoxClient) CreateQuery(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+func (c *stubVoicevoxClient) CreateQuery(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 	return nil, nil
 }
-func (c *stubVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+func (c *stubVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 	return nil, nil
 }
 func (c *stubVoicevoxClient) GetSpeakers(_ context.Context) ([]entity.Speaker, error) {

--- a/internal/app/act_usecase.go
+++ b/internal/app/act_usecase.go
@@ -12,7 +12,7 @@ import (
 // ActParams はactユースケースのパラメータ。
 type ActParams struct {
 	Path       string
-	SpeakerID  int
+	SpeakerID  entity.SpeakerID
 	Speed      *float64
 	Pitch      *float64
 	Intonation *float64

--- a/internal/app/act_usecase_test.go
+++ b/internal/app/act_usecase_test.go
@@ -61,15 +61,15 @@ func (m *mockVoicevoxClient) HealthCheck(_ context.Context) error {
 	return m.healthCheckErr
 }
 
-func (m *mockVoicevoxClient) CreateQuery(_ context.Context, _ string, speakerID int) (*entity.AudioQuery, error) {
+func (m *mockVoicevoxClient) CreateQuery(_ context.Context, _ string, speakerID entity.SpeakerID) (*entity.AudioQuery, error) {
 	m.createQueryCalls++
-	m.createQueryCallArgs = append(m.createQueryCallArgs, createQueryCallArgs{speakerID: speakerID})
+	m.createQueryCallArgs = append(m.createQueryCallArgs, createQueryCallArgs{speakerID: speakerID.Value()})
 	return m.query, m.createQueryErr
 }
 
-func (m *mockVoicevoxClient) Synthesize(_ context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error) {
+func (m *mockVoicevoxClient) Synthesize(_ context.Context, query *entity.AudioQuery, speakerID entity.SpeakerID) ([]byte, error) {
 	m.synthesizeCalls++
-	m.synthesizeArgs = append(m.synthesizeArgs, synthesizeCallArgs{query: query, speakerID: speakerID})
+	m.synthesizeArgs = append(m.synthesizeArgs, synthesizeCallArgs{query: query, speakerID: speakerID.Value()})
 	return m.wavData, m.synthesizeErr
 }
 
@@ -106,7 +106,7 @@ func TestActUsecase_Run_PlayReceivesScriptText(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "scripts/", SpeakerID: 3}
+	params := app.ActParams{Path: "scripts/", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -118,13 +118,13 @@ func TestActUsecase_Run_PlayReceivesScriptText(t *testing.T) {
 	if player.playMetas[0].Text != "おはようなのだ" || player.playMetas[1].Text != "さようならなのだ" {
 		t.Errorf("expected PlayMeta.Text in script order, got: %+v", player.playMetas)
 	}
-	if player.playMetas[0].SpeakerID != 3 || player.playMetas[1].SpeakerID != 3 {
+	if player.playMetas[0].SpeakerID.Value() != 3 || player.playMetas[1].SpeakerID.Value() != 3 {
 		t.Errorf("expected PlayMeta.SpeakerID=3 for both calls (default), got: %+v", player.playMetas)
 	}
 }
 
 func TestActUsecase_Run_PlayReceivesScriptResolvedSpeakerID(t *testing.T) {
-	overrideID := 7
+	overrideID := entity.MustNewSpeakerID(7)
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{Path: "a.txt", Text: "default", IsEmpty: false},
@@ -138,7 +138,7 @@ func TestActUsecase_Run_PlayReceivesScriptResolvedSpeakerID(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "scripts/", SpeakerID: 3}
+	params := app.ActParams{Path: "scripts/", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -147,10 +147,10 @@ func TestActUsecase_Run_PlayReceivesScriptResolvedSpeakerID(t *testing.T) {
 	if len(player.playMetas) != 2 {
 		t.Fatalf("expected 2 Play calls, got: %d", len(player.playMetas))
 	}
-	if player.playMetas[0].SpeakerID != 3 {
+	if player.playMetas[0].SpeakerID.Value() != 3 {
 		t.Errorf("expected first PlayMeta.SpeakerID=3 (default), got: %d", player.playMetas[0].SpeakerID)
 	}
-	if player.playMetas[1].SpeakerID != 7 {
+	if player.playMetas[1].SpeakerID.Value() != 7 {
 		t.Errorf("expected second PlayMeta.SpeakerID=7 (script override), got: %d", player.playMetas[1].SpeakerID)
 	}
 }
@@ -170,7 +170,7 @@ func TestActUsecase_Run_SingleScript_Success(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:      "test.txt",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -196,7 +196,7 @@ func TestActUsecase_Run_MultipleScripts_Success(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:      "scripts/",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -228,7 +228,7 @@ func TestActUsecase_Run_EmptyScript_Skipped(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "empty.txt", SpeakerID: 3}
+	params := app.ActParams{Path: "empty.txt", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err != nil {
@@ -258,7 +258,7 @@ func TestActUsecase_Run_MixedEmptyAndNonEmpty(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "scripts/", SpeakerID: 3}
+	params := app.ActParams{Path: "scripts/", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err != nil {
@@ -292,7 +292,7 @@ func TestActUsecase_Run_WithOptions(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:       "test.txt",
-		SpeakerID:  3,
+		SpeakerID:  entity.MustNewSpeakerID(3),
 		Speed:      &speed,
 		Pitch:      &pitch,
 		Intonation: &intonation,
@@ -327,7 +327,7 @@ func TestActUsecase_Run_HealthCheckError(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "test.txt", SpeakerID: 3}
+	params := app.ActParams{Path: "test.txt", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -343,7 +343,7 @@ func TestActUsecase_Run_ReadError(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "notexist.txt", SpeakerID: 3}
+	params := app.ActParams{Path: "notexist.txt", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -363,7 +363,7 @@ func TestActUsecase_Run_CreateQueryError(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "test.txt", SpeakerID: 3}
+	params := app.ActParams{Path: "test.txt", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -387,7 +387,7 @@ func TestActUsecase_Run_SynthesizeError(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "test.txt", SpeakerID: 3}
+	params := app.ActParams{Path: "test.txt", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -413,7 +413,7 @@ func TestActUsecase_Run_PlayError(t *testing.T) {
 	}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "test.txt", SpeakerID: 3}
+	params := app.ActParams{Path: "test.txt", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -445,7 +445,7 @@ func TestActUsecase_Run_CancelledContext_SkipsRemainingScripts(t *testing.T) {
 	}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "scripts/", SpeakerID: 3}
+	params := app.ActParams{Path: "scripts/", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(ctx, params)
 
@@ -479,7 +479,7 @@ func TestActUsecase_Run_CancelDuringCreateQuery_ReturnsNil(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewActUsecase(reader, client, player)
-	params := app.ActParams{Path: "scripts/", SpeakerID: 3}
+	params := app.ActParams{Path: "scripts/", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(ctx, params)
 
@@ -507,7 +507,7 @@ func (m *cancellingVoicevoxClient) HealthCheck(_ context.Context) error {
 	return nil
 }
 
-func (m *cancellingVoicevoxClient) CreateQuery(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+func (m *cancellingVoicevoxClient) CreateQuery(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 	m.createQueryCalls++
 	if m.createQueryCalls > m.cancelAfterCreateQuery {
 		m.cancelFunc()
@@ -516,7 +516,7 @@ func (m *cancellingVoicevoxClient) CreateQuery(_ context.Context, _ string, _ in
 	return m.query, nil
 }
 
-func (m *cancellingVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+func (m *cancellingVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 	return m.wavData, nil
 }
 
@@ -557,7 +557,7 @@ func TestActUsecase_Run_LogsProcessingStatus(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
 	params := app.ActParams{
 		Path:      "test.txt",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -591,7 +591,7 @@ func TestActUsecase_Run_VerboseLogsDebugInfo(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
 	params := app.ActParams{
 		Path:      "test.txt",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		Speed:     &speed,
 	}
 
@@ -623,7 +623,7 @@ func TestActUsecase_Run_NilLogger_NoPanic(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:      "test.txt",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -648,7 +648,7 @@ func TestActUsecase_Run_SynthesisCompletedLoggedAtInfoLevel(t *testing.T) {
 	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
-	params := app.ActParams{Path: "test.txt", SpeakerID: 3}
+	params := app.ActParams{Path: "test.txt", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err != nil {
@@ -681,7 +681,7 @@ func TestActUsecase_Run_LogsProgressCounter(t *testing.T) {
 	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
-	params := app.ActParams{Path: "scripts/", SpeakerID: 3}
+	params := app.ActParams{Path: "scripts/", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err != nil {
@@ -717,7 +717,7 @@ func TestActUsecase_Run_WithNilLogger_NoPanic(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(nil))
 	params := app.ActParams{
 		Path:      "test.txt",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -752,7 +752,7 @@ func TestActUsecase_Run_DryRun_SkipsClientAndPlayerAndLogs(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player, app.WithLogger(logger))
 	params := app.ActParams{
 		Path:      "scripts/",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		DryRun:    true,
 	}
 
@@ -819,7 +819,7 @@ func TestActUsecase_Run_DryRun_NoHealthCheck(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:      "scripts/",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		DryRun:    true,
 	}
 
@@ -838,7 +838,7 @@ func TestActUsecase_Run_DryRun_NoHealthCheck(t *testing.T) {
 // DONE: 複数スクリプトでパラメータが異なる場合、それぞれのスクリプトに対応するパラメータが使われる
 
 func TestActUsecase_Run_ScriptSpeakerID(t *testing.T) {
-	scriptSpeaker := 7
+	scriptSpeaker := entity.MustNewSpeakerID(7)
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{Path: "script.json", Text: "こんにちは", IsEmpty: false, SpeakerID: &scriptSpeaker},
@@ -853,7 +853,7 @@ func TestActUsecase_Run_ScriptSpeakerID(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:      "script.json",
-		SpeakerID: 3, // デフォルトは3だがスクリプトで7が指定されている
+		SpeakerID: entity.MustNewSpeakerID(3), // デフォルトは3だがスクリプトで7が指定されている
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -902,7 +902,7 @@ func TestActUsecase_Run_ScriptEmotionParams(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:      "script.json",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -948,7 +948,7 @@ func TestActUsecase_Run_ScriptParamsOverrideGlobal(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:      "script.json",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		Speed:     &globalSpeed,
 	}
 
@@ -983,7 +983,7 @@ func TestActUsecase_Run_ScriptNoParams_UsesGlobal(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:      "script.txt",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		Speed:     &globalSpeed,
 	}
 
@@ -1003,7 +1003,7 @@ func TestActUsecase_Run_ScriptNoParams_UsesGlobal(t *testing.T) {
 }
 
 func TestActUsecase_Run_MultipleScriptsWithDifferentParams(t *testing.T) {
-	speaker5 := 5
+	speaker5 := entity.MustNewSpeakerID(5)
 	speed1 := 0.8
 	speed2 := 1.5
 	reader := &mockScriptReader{
@@ -1022,7 +1022,7 @@ func TestActUsecase_Run_MultipleScriptsWithDifferentParams(t *testing.T) {
 	uc := app.NewActUsecase(reader, client, player)
 	params := app.ActParams{
 		Path:      "scripts/",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)

--- a/internal/app/log_text.go
+++ b/internal/app/log_text.go
@@ -40,10 +40,10 @@ func formatFloatPtr(v *float64) string {
 
 // dryRunPlaybackAttrs はdry-runモードの playback completed ログに付与する属性セットを返す。
 // 呼び出し側で path などの属性を前後に追加できるよう []any を返す。
-func dryRunPlaybackAttrs(text string, speakerID int, overrides entity.SynthOverrides) []any {
+func dryRunPlaybackAttrs(text string, speakerID entity.SpeakerID, overrides entity.SynthOverrides) []any {
 	return []any{
 		"text", truncateAndEscapeText(text),
-		"speaker", speakerID,
+		"speaker", speakerID.Value(),
 		"speed", formatFloatPtr(overrides.Speed),
 		"pitch", formatFloatPtr(overrides.Pitch),
 		"intonation", formatFloatPtr(overrides.Intonation),

--- a/internal/app/player.go
+++ b/internal/app/player.go
@@ -1,6 +1,10 @@
 package app
 
-import "context"
+import (
+	"context"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
 
 // StreamErrorCategory は配信画面に表示するサーバー側エラーの種別。
 type StreamErrorCategory string
@@ -23,7 +27,7 @@ type StreamError struct {
 	Message   string
 	Path      string
 	Text      string
-	SpeakerID int
+	SpeakerID entity.SpeakerID
 }
 
 // ErrorBroadcaster は配信画面向けにサーバー側エラーをブロードキャストする。
@@ -40,7 +44,7 @@ type PlayMeta struct {
 	Text string
 	// SpeakerID は再生に使ったVOICEVOXのスタイルID（解決後の値）。
 	// HTTPStreamPlayer では話者名/スタイル名の解決キーとして利用される。
-	SpeakerID int
+	SpeakerID entity.SpeakerID
 	// Speed / Pitch / Intonation は合成パラメータ（省略可）。
 	// 再合成時に元のパラメータを復元できるよう履歴に保持される。
 	Speed      *float64

--- a/internal/app/port.go
+++ b/internal/app/port.go
@@ -66,10 +66,10 @@ type VoicevoxClient interface {
 	HealthCheck(ctx context.Context) error
 
 	// CreateQuery はテキストから音声合成用クエリを生成する。
-	CreateQuery(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error)
+	CreateQuery(ctx context.Context, text string, speakerID entity.SpeakerID) (*entity.AudioQuery, error)
 
 	// Synthesize は音声合成を実行し、WAV形式のバイト列を返す。
-	Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error)
+	Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID entity.SpeakerID) ([]byte, error)
 
 	// GetSpeakers はエンジンに登録された話者一覧（話者名・スタイルID・スタイル名）を取得する。
 	GetSpeakers(ctx context.Context) ([]entity.Speaker, error)

--- a/internal/app/say_usecase.go
+++ b/internal/app/say_usecase.go
@@ -11,7 +11,7 @@ import (
 // SayParams はsayユースケースのパラメータ。
 type SayParams struct {
 	Text       string
-	SpeakerID  int
+	SpeakerID  entity.SpeakerID
 	Speed      *float64
 	Pitch      *float64
 	Intonation *float64

--- a/internal/app/say_usecase_test.go
+++ b/internal/app/say_usecase_test.go
@@ -33,7 +33,7 @@ func TestSayUsecase_Run_Success(t *testing.T) {
 	uc := app.NewSayUsecase(client, player)
 	params := app.SayParams{
 		Text:      "こんにちは",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -60,7 +60,7 @@ func TestSayUsecase_Run_PlayReceivesText(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewSayUsecase(client, player)
-	params := app.SayParams{Text: "こんにちはなのだ", SpeakerID: 3}
+	params := app.SayParams{Text: "こんにちはなのだ", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -69,7 +69,7 @@ func TestSayUsecase_Run_PlayReceivesText(t *testing.T) {
 	if len(player.playMetas) != 1 || player.playMetas[0].Text != "こんにちはなのだ" {
 		t.Errorf("expected PlayMeta.Text=%q, got: %+v", "こんにちはなのだ", player.playMetas)
 	}
-	if player.playMetas[0].SpeakerID != 3 {
+	if player.playMetas[0].SpeakerID.Value() != 3 {
 		t.Errorf("expected PlayMeta.SpeakerID=3, got: %d", player.playMetas[0].SpeakerID)
 	}
 }
@@ -88,7 +88,7 @@ func TestSayUsecase_Run_WithParams(t *testing.T) {
 	uc := app.NewSayUsecase(client, player)
 	params := app.SayParams{
 		Text:       "こんにちは",
-		SpeakerID:  5,
+		SpeakerID:  entity.MustNewSpeakerID(5),
 		Speed:      &speed,
 		Pitch:      &pitch,
 		Intonation: &intonation,
@@ -125,7 +125,7 @@ func TestSayUsecase_Run_HealthCheckError(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewSayUsecase(client, player)
-	params := app.SayParams{Text: "こんにちは", SpeakerID: 3}
+	params := app.SayParams{Text: "こんにちは", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -140,7 +140,7 @@ func TestSayUsecase_Run_CreateQueryError(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewSayUsecase(client, player)
-	params := app.SayParams{Text: "こんにちは", SpeakerID: 3}
+	params := app.SayParams{Text: "こんにちは", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -156,7 +156,7 @@ func TestSayUsecase_Run_SynthesizeError(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewSayUsecase(client, player)
-	params := app.SayParams{Text: "こんにちは", SpeakerID: 3}
+	params := app.SayParams{Text: "こんにちは", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -174,7 +174,7 @@ func TestSayUsecase_Run_PlayError(t *testing.T) {
 	}
 
 	uc := app.NewSayUsecase(client, player)
-	params := app.SayParams{Text: "こんにちは", SpeakerID: 3}
+	params := app.SayParams{Text: "こんにちは", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -191,7 +191,7 @@ func TestWithSayLogger_Nil_NoPanic(t *testing.T) {
 
 	// WithSayLogger(nil) でpanicしないことを確認
 	uc := app.NewSayUsecase(client, player, app.WithSayLogger(nil))
-	params := app.SayParams{Text: "こんにちは", SpeakerID: 3}
+	params := app.SayParams{Text: "こんにちは", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err != nil {
@@ -220,7 +220,7 @@ func TestSayUsecase_Run_DryRun_SkipsClientAndPlayerAndLogs(t *testing.T) {
 	uc := app.NewSayUsecase(client, player, app.WithSayLogger(logger))
 	params := app.SayParams{
 		Text:       "こんにちは",
-		SpeakerID:  3,
+		SpeakerID:  entity.MustNewSpeakerID(3),
 		Speed:      &speed,
 		Pitch:      &pitch,
 		Intonation: &intonation,
@@ -275,7 +275,7 @@ func TestSayUsecase_Run_DryRun_NoHealthCheck(t *testing.T) {
 	uc := app.NewSayUsecase(client, player)
 	params := app.SayParams{
 		Text:      "こんにちは",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		DryRun:    true,
 	}
 
@@ -295,7 +295,7 @@ func TestSayUsecase_Run_CancelledContext_ReturnsNil(t *testing.T) {
 	player := &mockAudioPlayer{}
 
 	uc := app.NewSayUsecase(client, player)
-	params := app.SayParams{Text: "こんにちは", SpeakerID: 3}
+	params := app.SayParams{Text: "こんにちは", SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(ctx, params)
 	// キャンセル済みcontextの場合、グレースフルシャットダウンとしてnilを返すべき
@@ -336,7 +336,7 @@ func TestSayUsecase_Run_SaveWav_SavesFile(t *testing.T) {
 	uc := app.NewSayUsecase(client, player, app.WithWavSaver(saver))
 	params := app.SayParams{
 		Text:        "こんにちは",
-		SpeakerID:   3,
+		SpeakerID:   entity.MustNewSpeakerID(3),
 		SaveWavPath: "/tmp/test.wav",
 	}
 
@@ -369,7 +369,7 @@ func TestSayUsecase_Run_SaveWav_EmptyPath_NotSaved(t *testing.T) {
 	uc := app.NewSayUsecase(client, player, app.WithWavSaver(saver))
 	params := app.SayParams{
 		Text:        "こんにちは",
-		SpeakerID:   3,
+		SpeakerID:   entity.MustNewSpeakerID(3),
 		SaveWavPath: "",
 	}
 
@@ -392,7 +392,7 @@ func TestSayUsecase_Run_SaveWav_DryRun_NotSaved(t *testing.T) {
 	uc := app.NewSayUsecase(client, player, app.WithWavSaver(saver))
 	params := app.SayParams{
 		Text:        "こんにちは",
-		SpeakerID:   3,
+		SpeakerID:   entity.MustNewSpeakerID(3),
 		SaveWavPath: "/tmp/test.wav",
 		DryRun:      true,
 	}
@@ -416,7 +416,7 @@ func TestSayUsecase_Run_SaveWav_SaveError_ReturnsError(t *testing.T) {
 	uc := app.NewSayUsecase(client, player, app.WithWavSaver(saver))
 	params := app.SayParams{
 		Text:        "こんにちは",
-		SpeakerID:   3,
+		SpeakerID:   entity.MustNewSpeakerID(3),
 		SaveWavPath: "/tmp/test.wav",
 	}
 

--- a/internal/app/synth_pipeline.go
+++ b/internal/app/synth_pipeline.go
@@ -34,7 +34,7 @@ type synthResult struct {
 
 // synthPipelineConfig はstartSynthPipelineの設定。
 type synthPipelineConfig struct {
-	defaultSpeakerID int
+	defaultSpeakerID entity.SpeakerID
 	defaultOverrides entity.SynthOverrides
 	// synthesisLogLevel は "synthesis completed" ログの出力レベル。
 	synthesisLogLevel slog.Level

--- a/internal/app/synth_pipeline_test.go
+++ b/internal/app/synth_pipeline_test.go
@@ -41,10 +41,10 @@ type pipelineMockClient struct {
 
 func (m *pipelineMockClient) HealthCheck(_ context.Context) error { return nil }
 
-func (m *pipelineMockClient) CreateQuery(_ context.Context, text string, speakerID int) (*entity.AudioQuery, error) {
+func (m *pipelineMockClient) CreateQuery(_ context.Context, text string, speakerID entity.SpeakerID) (*entity.AudioQuery, error) {
 	m.mu.Lock()
 	callIndex := len(m.createQueryCalls)
-	m.createQueryCalls = append(m.createQueryCalls, pipelineCreateQueryArgs{text: text, speakerID: speakerID})
+	m.createQueryCalls = append(m.createQueryCalls, pipelineCreateQueryArgs{text: text, speakerID: speakerID.Value()})
 	err := m.createQueryErrs[callIndex]
 	m.mu.Unlock()
 
@@ -54,10 +54,10 @@ func (m *pipelineMockClient) CreateQuery(_ context.Context, text string, speaker
 	return &entity.AudioQuery{}, nil
 }
 
-func (m *pipelineMockClient) Synthesize(_ context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error) {
+func (m *pipelineMockClient) Synthesize(_ context.Context, query *entity.AudioQuery, speakerID entity.SpeakerID) ([]byte, error) {
 	m.mu.Lock()
 	callIndex := len(m.synthesizeCalls)
-	m.synthesizeCalls = append(m.synthesizeCalls, pipelineSynthesizeArgs{query: query, speakerID: speakerID})
+	m.synthesizeCalls = append(m.synthesizeCalls, pipelineSynthesizeArgs{query: query, speakerID: speakerID.Value()})
 	delay := m.synthesizeDelay
 	err := m.synthesizeErrs[callIndex]
 	m.mu.Unlock()
@@ -82,7 +82,7 @@ func TestStartSynthPipeline_ForwardsScriptsInOrder(t *testing.T) {
 		{Path: "b.txt", Text: "B", IsEmpty: false},
 		{Path: "c.txt", Text: "C", IsEmpty: false},
 	}
-	cfg := synthPipelineConfig{defaultSpeakerID: 3, synthesisLogLevel: slog.LevelInfo}
+	cfg := synthPipelineConfig{defaultSpeakerID: entity.MustNewSpeakerID(3), synthesisLogLevel: slog.LevelInfo}
 
 	ch := startSynthPipeline(context.Background(), client, discardLogger(), scripts, cfg)
 
@@ -117,7 +117,7 @@ func TestStartSynthPipeline_SkipsEmptyScripts_IndexCountsNonEmptyOnly(t *testing
 		{Path: "empty.txt", Text: "", IsEmpty: true},
 		{Path: "b.txt", Text: "B", IsEmpty: false},
 	}
-	cfg := synthPipelineConfig{defaultSpeakerID: 3, synthesisLogLevel: slog.LevelInfo}
+	cfg := synthPipelineConfig{defaultSpeakerID: entity.MustNewSpeakerID(3), synthesisLogLevel: slog.LevelInfo}
 
 	ch := startSynthPipeline(context.Background(), client, discardLogger(), scripts, cfg)
 
@@ -149,7 +149,7 @@ func TestStartSynthPipeline_PropagatesCreateQueryError(t *testing.T) {
 		{Path: "a.txt", Text: "A", IsEmpty: false},
 		{Path: "b.txt", Text: "B", IsEmpty: false},
 	}
-	cfg := synthPipelineConfig{defaultSpeakerID: 3, synthesisLogLevel: slog.LevelInfo}
+	cfg := synthPipelineConfig{defaultSpeakerID: entity.MustNewSpeakerID(3), synthesisLogLevel: slog.LevelInfo}
 
 	ch := startSynthPipeline(context.Background(), client, discardLogger(), scripts, cfg)
 
@@ -180,7 +180,7 @@ func TestStartSynthPipeline_PropagatesSynthesizeError(t *testing.T) {
 	scripts := []entity.Script{
 		{Path: "a.txt", Text: "A", IsEmpty: false},
 	}
-	cfg := synthPipelineConfig{defaultSpeakerID: 3, synthesisLogLevel: slog.LevelInfo}
+	cfg := synthPipelineConfig{defaultSpeakerID: entity.MustNewSpeakerID(3), synthesisLogLevel: slog.LevelInfo}
 
 	ch := startSynthPipeline(context.Background(), client, discardLogger(), scripts, cfg)
 
@@ -208,7 +208,7 @@ func TestStartSynthPipeline_ContextCancel_ExitsProducerWithoutLeak(t *testing.T)
 		{Path: "b.txt", Text: "B", IsEmpty: false},
 		{Path: "c.txt", Text: "C", IsEmpty: false},
 	}
-	cfg := synthPipelineConfig{defaultSpeakerID: 3, synthesisLogLevel: slog.LevelInfo}
+	cfg := synthPipelineConfig{defaultSpeakerID: entity.MustNewSpeakerID(3), synthesisLogLevel: slog.LevelInfo}
 
 	goroutinesBefore := runtime.NumGoroutine()
 
@@ -249,7 +249,7 @@ func TestStartSynthPipeline_ContextAlreadyCancelled_ClosesChannelImmediately(t *
 	scripts := []entity.Script{
 		{Path: "a.txt", Text: "A", IsEmpty: false},
 	}
-	cfg := synthPipelineConfig{defaultSpeakerID: 3, synthesisLogLevel: slog.LevelInfo}
+	cfg := synthPipelineConfig{defaultSpeakerID: entity.MustNewSpeakerID(3), synthesisLogLevel: slog.LevelInfo}
 
 	ch := startSynthPipeline(ctx, client, discardLogger(), scripts, cfg)
 
@@ -275,7 +275,7 @@ func TestStartSynthPipeline_LogsSynthesisCompletedAtConfiguredLevel(t *testing.T
 	scripts := []entity.Script{
 		{Path: "a.txt", Text: "A", IsEmpty: false},
 	}
-	cfg := synthPipelineConfig{defaultSpeakerID: 3, synthesisLogLevel: slog.LevelInfo}
+	cfg := synthPipelineConfig{defaultSpeakerID: entity.MustNewSpeakerID(3), synthesisLogLevel: slog.LevelInfo}
 
 	ch := startSynthPipeline(context.Background(), client, logger, scripts, cfg)
 	drainPipeline(ch)
@@ -295,7 +295,7 @@ func TestStartSynthPipeline_MultipleInvocations_NoGoroutineLeak(t *testing.T) {
 	goroutinesBefore := runtime.NumGoroutine()
 
 	client := &pipelineMockClient{}
-	cfg := synthPipelineConfig{defaultSpeakerID: 3, synthesisLogLevel: slog.LevelDebug}
+	cfg := synthPipelineConfig{defaultSpeakerID: entity.MustNewSpeakerID(3), synthesisLogLevel: slog.LevelDebug}
 
 	for range 20 {
 		scripts := []entity.Script{

--- a/internal/app/watch_usecase.go
+++ b/internal/app/watch_usecase.go
@@ -35,7 +35,7 @@ func GenerateWavFilename(text string, nowMs int64) string {
 // WatchParams はWatchUsecaseのパラメータ。
 type WatchParams struct {
 	Paths      []string
-	SpeakerID  int
+	SpeakerID  entity.SpeakerID
 	Speed      *float64
 	Pitch      *float64
 	Intonation *float64
@@ -102,7 +102,7 @@ func (u *WatchUsecase) broadcastError(e StreamError) {
 }
 
 // broadcastSynthesisError は synthesis カテゴリのエラーを対象スクリプト情報付きで配信する。
-func (u *WatchUsecase) broadcastSynthesisError(script entity.Script, speakerID int, err error) {
+func (u *WatchUsecase) broadcastSynthesisError(script entity.Script, speakerID entity.SpeakerID, err error) {
 	u.broadcastError(StreamError{
 		Category:  StreamErrorCategorySynthesis,
 		Message:   err.Error(),

--- a/internal/app/watch_usecase_test.go
+++ b/internal/app/watch_usecase_test.go
@@ -82,7 +82,7 @@ func TestWatchUsecase_Run_ProcessesFilesFromWatcher(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -96,13 +96,13 @@ func TestWatchUsecase_Run_ProcessesFilesFromWatcher(t *testing.T) {
 	if player.playCalls != 1 {
 		t.Errorf("expected 1 Play call, got: %d", player.playCalls)
 	}
-	if len(player.playMetas) != 1 || player.playMetas[0].SpeakerID != 3 {
+	if len(player.playMetas) != 1 || player.playMetas[0].SpeakerID.Value() != 3 {
 		t.Errorf("expected PlayMeta.SpeakerID=3 (default), got: %+v", player.playMetas)
 	}
 }
 
 func TestWatchUsecase_Run_PlayReceivesScriptResolvedSpeakerID(t *testing.T) {
-	overrideID := 11
+	overrideID := entity.MustNewSpeakerID(11)
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{Path: "a.txt", Text: "default", IsEmpty: false},
@@ -120,7 +120,7 @@ func TestWatchUsecase_Run_PlayReceivesScriptResolvedSpeakerID(t *testing.T) {
 	}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -129,10 +129,10 @@ func TestWatchUsecase_Run_PlayReceivesScriptResolvedSpeakerID(t *testing.T) {
 	if len(player.playMetas) != 2 {
 		t.Fatalf("expected 2 Play calls, got: %d", len(player.playMetas))
 	}
-	if player.playMetas[0].SpeakerID != 3 {
+	if player.playMetas[0].SpeakerID.Value() != 3 {
 		t.Errorf("expected first PlayMeta.SpeakerID=3 (default), got: %d", player.playMetas[0].SpeakerID)
 	}
-	if player.playMetas[1].SpeakerID != 11 {
+	if player.playMetas[1].SpeakerID.Value() != 11 {
 		t.Errorf("expected second PlayMeta.SpeakerID=11 (script override), got: %d", player.playMetas[1].SpeakerID)
 	}
 }
@@ -156,7 +156,7 @@ func TestWatchUsecase_Run_MovesFileToDoneAfterProcessing(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -190,7 +190,7 @@ func TestWatchUsecase_Run_EmptyFileSkippedAndMovedToDone(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -224,7 +224,7 @@ func TestWatchUsecase_Run_ReadError_SkipsAndMovesToDone(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	// 不正ファイルはスキップしてエラーにならない
@@ -259,7 +259,7 @@ func TestWatchUsecase_Run_MultipleFiles_ProcessedInOrder(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -298,7 +298,7 @@ func TestWatchUsecase_Run_HealthCheckError(t *testing.T) {
 	watcher := &mockDirWatcher{}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err == nil {
@@ -327,7 +327,7 @@ func TestWatchUsecase_Run_ContextCancelled_StopsProcessing(t *testing.T) {
 	mover := &mockFileMover{}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, customWatcher)
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -351,7 +351,7 @@ func TestWatchUsecase_Run_ContextCancelled_StopsProcessing(t *testing.T) {
 }
 
 func TestWatchUsecase_Run_ScriptParamsOverrideGlobal(t *testing.T) {
-	scriptSpeaker := 7
+	scriptSpeaker := entity.MustNewSpeakerID(7)
 	scriptSpeed := 0.5
 	globalSpeed := 2.0
 
@@ -379,7 +379,7 @@ func TestWatchUsecase_Run_ScriptParamsOverrideGlobal(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		Speed:     &globalSpeed,
 	}
 
@@ -431,7 +431,7 @@ func TestWatchUsecase_Run_ScriptNoParams_UsesGlobal(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		Speed:     &globalSpeed,
 	}
 
@@ -473,7 +473,7 @@ func TestWatchUsecase_Run_DeleteMode_DeletesFileInsteadOfMove(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithDeleteMode())
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -513,7 +513,7 @@ func TestWatchUsecase_Run_DefaultMode_MovesToDoneNotDelete(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -550,7 +550,7 @@ func TestWatchUsecase_Run_DeleteMode_FileDeletedSuppressedAtInfoLevel(t *testing
 	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithDeleteMode(), app.WithWatchLogger(logger))
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err != nil {
@@ -583,7 +583,7 @@ func TestWatchUsecase_Run_DeleteMode_FileDeletedAppearsAtDebugLevel(t *testing.T
 	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelDebug, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithDeleteMode(), app.WithWatchLogger(logger))
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err != nil {
@@ -622,7 +622,7 @@ func TestWatchUsecase_Run_DryRun_SkipsClientAndPlayerAndMovesToDone(t *testing.T
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		DryRun:    true,
 	}
 
@@ -692,7 +692,7 @@ func TestWatchUsecase_Run_DryRun_NoHealthCheck(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		DryRun:    true,
 	}
 
@@ -721,7 +721,7 @@ func TestWatchUsecase_Run_DryRun_DeleteModeStillDeletes(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithDeleteMode())
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 		DryRun:    true,
 	}
 
@@ -768,7 +768,7 @@ func TestWatchUsecase_Run_FileMovedToDoneSuppressedAtInfoLevel(t *testing.T) {
 	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err != nil {
@@ -801,7 +801,7 @@ func TestWatchUsecase_Run_SynthesisCompletedSuppressedAtInfoLevel(t *testing.T) 
 	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	err := uc.Run(context.Background(), params)
 	if err != nil {
@@ -835,7 +835,7 @@ func TestWatchUsecase_Run_PlayReceivesScriptText(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -870,7 +870,7 @@ func TestWatchUsecase_Run_PlaybackCompletedAtInfoIncludesProgressAndText(t *test
 	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -906,7 +906,7 @@ func TestWatchUsecase_Run_PlaybackCompletedTruncatesLongTextAndEscapesNewlines(t
 	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -941,7 +941,7 @@ func TestWatchUsecase_Run_PlaybackCompletedSkipsEmptyAndNumeratesContiguously(t 
 	logger := slog.New(logging.NewHumanHandler(&buf, &logging.HumanHandlerOptions{Level: slog.LevelInfo, NoColor: true}))
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -977,7 +977,7 @@ func TestWatchUsecase_Run_LogsProcessingStatus(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -1017,7 +1017,7 @@ func TestWatchUsecase_Run_WatcherError_LoggedViaLogger(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, customWatcher, app.WithWatchLogger(logger))
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	err := uc.Run(context.Background(), params)
@@ -1099,7 +1099,7 @@ func TestWatchUsecase_Run_MultiplePaths_FanIn(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/a", "/tmp/b"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -1148,7 +1148,7 @@ func TestWatchUsecase_Run_DuplicatePaths_LogsWarningAndMerges(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/a", "/tmp/a"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -1194,7 +1194,7 @@ func TestWatchUsecase_Run_OneWatcherError_OthersContinue(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithWatchLogger(logger))
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/a", "/tmp/b"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -1239,7 +1239,7 @@ func (p *silentModePlayer) PlayText(_ context.Context, meta app.PlayMeta) error 
 }
 
 func TestWatchUsecase_Run_SilentMode_SkipsSynthAndCallsPlayText(t *testing.T) {
-	overrideID := 11
+	overrideID := entity.MustNewSpeakerID(11)
 	reader := &mockScriptReader{
 		scripts: []entity.Script{
 			{Path: "a.txt", Text: "default", IsEmpty: false},
@@ -1259,7 +1259,7 @@ func TestWatchUsecase_Run_SilentMode_SkipsSynthAndCallsPlayText(t *testing.T) {
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithSilent())
 	params := app.WatchParams{
 		Paths:     []string{"/tmp/watch"},
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	}
 
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -1281,10 +1281,10 @@ func TestWatchUsecase_Run_SilentMode_SkipsSynthAndCallsPlayText(t *testing.T) {
 	if player.playTextCalls != 2 {
 		t.Fatalf("expected 2 PlayText calls, got: %d", player.playTextCalls)
 	}
-	if player.playTextMetas[0].SpeakerID != 3 || player.playTextMetas[0].Text != "default" {
+	if player.playTextMetas[0].SpeakerID.Value() != 3 || player.playTextMetas[0].Text != "default" {
 		t.Errorf("unexpected meta[0]: %+v", player.playTextMetas[0])
 	}
-	if player.playTextMetas[1].SpeakerID != 11 || player.playTextMetas[1].Text != "override" {
+	if player.playTextMetas[1].SpeakerID.Value() != 11 || player.playTextMetas[1].Text != "override" {
 		t.Errorf("unexpected meta[1]: %+v", player.playTextMetas[1])
 	}
 	// done/ 移動も従来通り行われる
@@ -1306,7 +1306,7 @@ func TestWatchUsecase_Run_SilentMode_SkipsHealthCheck(t *testing.T) {
 	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithSilent())
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("expected no error in silent mode even with HealthCheck error, got: %v", err)
@@ -1329,7 +1329,7 @@ func TestWatchUsecase_Run_SilentMode_EmptyScriptsSkipped(t *testing.T) {
 	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithSilent())
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
@@ -1397,7 +1397,7 @@ func TestWatchUsecase_Run_BroadcastsFileError_OnReadFailure(t *testing.T) {
 	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -1426,7 +1426,7 @@ func TestWatchUsecase_Run_BroadcastsFileError_OnMoveFailure(t *testing.T) {
 	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -1454,7 +1454,7 @@ func TestWatchUsecase_Run_BroadcastsFileError_OnDeleteFailure(t *testing.T) {
 	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithDeleteMode())
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -1479,7 +1479,7 @@ func TestWatchUsecase_Run_BroadcastsSynthesisError_OnCreateQueryFailure(t *testi
 	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -1495,7 +1495,7 @@ func TestWatchUsecase_Run_BroadcastsSynthesisError_OnCreateQueryFailure(t *testi
 	if e.Text != "hi" {
 		t.Errorf("expected text=hi, got %q", e.Text)
 	}
-	if e.SpeakerID != 3 {
+	if e.SpeakerID.Value() != 3 {
 		t.Errorf("expected speakerID=3, got %d", e.SpeakerID)
 	}
 	if !strings.Contains(e.Message, "bad query") {
@@ -1513,7 +1513,7 @@ func TestWatchUsecase_Run_BroadcastsSynthesisError_OnSynthesizeFailure(t *testin
 	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -1538,7 +1538,7 @@ func TestWatchUsecase_Run_BroadcastsSynthesisError_OnPlayFailure(t *testing.T) {
 	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -1563,7 +1563,7 @@ func TestWatchUsecase_Run_BroadcastsSynthesisError_OnSilentPlayTextFailure(t *te
 	watcher := &mockDirWatcher{files: []string{"/tmp/watch/a.txt"}}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher, app.WithSilent())
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 	if err := uc.Run(context.Background(), params); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -1586,7 +1586,7 @@ func TestWatchUsecase_Run_BroadcastsConnectionError_OnHealthCheckFailure(t *test
 	watcher := &mockDirWatcher{}
 
 	uc := app.NewWatchUsecase(reader, client, player, mover, watcher)
-	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: 3}
+	params := app.WatchParams{Paths: []string{"/tmp/watch"}, SpeakerID: entity.MustNewSpeakerID(3)}
 
 	if err := uc.Run(context.Background(), params); err == nil {
 		t.Fatal("expected error from HealthCheck, got nil")
@@ -1694,7 +1694,7 @@ func TestWatchUsecase_Run_SavesWav_WhenSaveWavDirSet(t *testing.T) {
 	)
 	params := app.WatchParams{
 		Paths:      []string{"/tmp/watch"},
-		SpeakerID:  3,
+		SpeakerID:  entity.MustNewSpeakerID(3),
 		SaveWavDir: "/out",
 	}
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -1730,7 +1730,7 @@ func TestWatchUsecase_Run_DoesNotSaveWav_WhenSaveWavDirEmpty(t *testing.T) {
 	)
 	params := app.WatchParams{
 		Paths:      []string{"/tmp/watch"},
-		SpeakerID:  3,
+		SpeakerID:  entity.MustNewSpeakerID(3),
 		SaveWavDir: "",
 	}
 	if err := uc.Run(context.Background(), params); err != nil {
@@ -1759,7 +1759,7 @@ func TestWatchUsecase_Run_DoesNotSaveWav_WhenDryRun(t *testing.T) {
 	)
 	params := app.WatchParams{
 		Paths:      []string{"/tmp/watch"},
-		SpeakerID:  3,
+		SpeakerID:  entity.MustNewSpeakerID(3),
 		SaveWavDir: "/out",
 		DryRun:     true,
 	}
@@ -1790,7 +1790,7 @@ func TestWatchUsecase_Run_DoesNotSaveWav_WhenSilent(t *testing.T) {
 	)
 	params := app.WatchParams{
 		Paths:      []string{"/tmp/watch"},
-		SpeakerID:  3,
+		SpeakerID:  entity.MustNewSpeakerID(3),
 		SaveWavDir: "/out",
 	}
 	if err := uc.Run(context.Background(), params); err != nil {

--- a/internal/domain/entity/script.go
+++ b/internal/domain/entity/script.go
@@ -9,13 +9,13 @@ type Script struct {
 	// IsEmpty はファイルが空であるかを示す。
 	IsEmpty bool
 	// SpeakerID はセリフ単位のキャラクターID（nilの場合はデフォルト値を使用）。
-	SpeakerID *int
+	SpeakerID *SpeakerID
 	// Overrides はセリフ単位の合成パラメータ（nilフィールドの場合はデフォルト値を使用）。
 	Overrides SynthOverrides
 }
 
 // ResolveSpeakerID はセリフ単位のSpeakerIDがあればそれを、なければデフォルト値を返す。
-func (s Script) ResolveSpeakerID(defaultID int) int {
+func (s Script) ResolveSpeakerID(defaultID SpeakerID) SpeakerID {
 	if s.SpeakerID != nil {
 		return *s.SpeakerID
 	}

--- a/internal/domain/entity/script_test.go
+++ b/internal/domain/entity/script_test.go
@@ -62,22 +62,24 @@ func TestScript_ResolveOverrides_PartialOverride(t *testing.T) {
 }
 
 func TestScript_ResolveSpeakerID_ScriptValueTakesPrecedence(t *testing.T) {
-	id := 5
+	id := entity.MustNewSpeakerID(5)
 	s := entity.Script{SpeakerID: &id}
+	defaultID := entity.MustNewSpeakerID(3)
 
-	got := s.ResolveSpeakerID(3)
+	got := s.ResolveSpeakerID(defaultID)
 
-	if got != 5 {
-		t.Errorf("got %d, want 5", got)
+	if got.Value() != 5 {
+		t.Errorf("got %d, want 5", got.Value())
 	}
 }
 
 func TestScript_ResolveSpeakerID_NilUsesDefault(t *testing.T) {
 	s := entity.Script{}
+	defaultID := entity.MustNewSpeakerID(3)
 
-	got := s.ResolveSpeakerID(3)
+	got := s.ResolveSpeakerID(defaultID)
 
-	if got != 3 {
-		t.Errorf("got %d, want 3", got)
+	if got.Value() != 3 {
+		t.Errorf("got %d, want 3", got.Value())
 	}
 }

--- a/internal/domain/entity/speaker_id.go
+++ b/internal/domain/entity/speaker_id.go
@@ -1,0 +1,30 @@
+package entity
+
+import "fmt"
+
+// SpeakerID はVOICEVOXのスタイルIDを表す値オブジェクト。非負を保証する。
+type SpeakerID struct {
+	value int
+}
+
+// NewSpeakerID はSpeakerIDを生成する。負値の場合はエラーを返す。
+func NewSpeakerID(v int) (SpeakerID, error) {
+	if v < 0 {
+		return SpeakerID{}, fmt.Errorf("speakerID must be non-negative, got %d", v)
+	}
+	return SpeakerID{value: v}, nil
+}
+
+// MustNewSpeakerID はSpeakerIDを生成する。負値の場合はパニックする。
+func MustNewSpeakerID(v int) SpeakerID {
+	id, err := NewSpeakerID(v)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+// Value は内部の整数値を返す。
+func (id SpeakerID) Value() int {
+	return id.value
+}

--- a/internal/domain/entity/speaker_id_test.go
+++ b/internal/domain/entity/speaker_id_test.go
@@ -1,0 +1,46 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+func TestNewSpeakerID_Valid(t *testing.T) {
+	cases := []struct {
+		name  string
+		value int
+	}{
+		{"zero", 0},
+		{"positive", 3},
+		{"large", 9999},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := entity.NewSpeakerID(tc.value)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id.Value() != tc.value {
+				t.Errorf("Value() = %d, want %d", id.Value(), tc.value)
+			}
+		})
+	}
+}
+
+func TestNewSpeakerID_Negative(t *testing.T) {
+	_, err := entity.NewSpeakerID(-1)
+	if err == nil {
+		t.Error("expected error for negative value, got nil")
+	}
+}
+
+func TestSpeakerID_Value(t *testing.T) {
+	id, err := entity.NewSpeakerID(5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Value() != 5 {
+		t.Errorf("Value() = %d, want 5", id.Value())
+	}
+}

--- a/internal/infra/file_reader.go
+++ b/internal/infra/file_reader.go
@@ -41,7 +41,9 @@ func (js *jsonScript) toScript(path string) entity.Script {
 	var speakerID *entity.SpeakerID
 	if js.Speaker != nil {
 		id, err := entity.NewSpeakerID(*js.Speaker)
-		if err == nil {
+		if err != nil {
+			slog.Warn("invalid speaker in script file, using default", "path", path, "speaker", *js.Speaker)
+		} else {
 			speakerID = &id
 		}
 	}

--- a/internal/infra/file_reader.go
+++ b/internal/infra/file_reader.go
@@ -38,11 +38,18 @@ type jsonScript struct {
 // toScript は jsonScript を entity.Script に変換する。
 func (js *jsonScript) toScript(path string) entity.Script {
 	text := *js.Text
+	var speakerID *entity.SpeakerID
+	if js.Speaker != nil {
+		id, err := entity.NewSpeakerID(*js.Speaker)
+		if err == nil {
+			speakerID = &id
+		}
+	}
 	return entity.Script{
 		Path:      path,
 		Text:      text,
 		IsEmpty:   len(text) == 0,
-		SpeakerID: js.Speaker,
+		SpeakerID: speakerID,
 		Overrides: entity.SynthOverrides{
 			Speed:      js.SpeedScale,
 			Pitch:      js.PitchScale,

--- a/internal/infra/file_reader_test.go
+++ b/internal/infra/file_reader_test.go
@@ -346,7 +346,7 @@ func TestFileReader_Read_JSONFile_AllParams(t *testing.T) {
 	if s.Text != "感情込めて" {
 		t.Errorf("expected text %q, got %q", "感情込めて", s.Text)
 	}
-	if s.SpeakerID == nil || *s.SpeakerID != 5 {
+	if s.SpeakerID == nil || s.SpeakerID.Value() != 5 {
 		t.Errorf("expected SpeakerID 5, got %v", s.SpeakerID)
 	}
 	if s.Overrides.Speed == nil || *s.Overrides.Speed != 1.5 {
@@ -572,7 +572,7 @@ func TestFileReader_Read_JSONLFile_AllParams(t *testing.T) {
 	if s.Text != "感情込めて" {
 		t.Errorf("expected text %q, got %q", "感情込めて", s.Text)
 	}
-	if s.SpeakerID == nil || *s.SpeakerID != 5 {
+	if s.SpeakerID == nil || s.SpeakerID.Value() != 5 {
 		t.Errorf("expected SpeakerID 5, got %v", s.SpeakerID)
 	}
 	if s.Overrides.Speed == nil || *s.Overrides.Speed != 1.5 {

--- a/internal/infra/file_writer.go
+++ b/internal/infra/file_writer.go
@@ -152,9 +152,14 @@ type jsonScriptOut struct {
 }
 
 func toJSONScript(script entity.Script) jsonScriptOut {
+	var speaker *int
+	if script.SpeakerID != nil {
+		v := script.SpeakerID.Value()
+		speaker = &v
+	}
 	return jsonScriptOut{
 		Text:            script.Text,
-		Speaker:         script.SpeakerID,
+		Speaker:         speaker,
 		SpeedScale:      script.Overrides.Speed,
 		PitchScale:      script.Overrides.Pitch,
 		IntonationScale: script.Overrides.Intonation,

--- a/internal/infra/file_writer_test.go
+++ b/internal/infra/file_writer_test.go
@@ -30,6 +30,10 @@ import (
 
 func ptrInt(v int) *int             { return &v }
 func ptrFloat64(v float64) *float64 { return &v }
+func ptrSpeakerID(v int) *entity.SpeakerID {
+	id := entity.MustNewSpeakerID(v)
+	return &id
+}
 
 func TestFileWriter_Write_JSON_TextOnly(t *testing.T) {
 	t.Parallel()
@@ -81,7 +85,7 @@ func TestFileWriter_Write_JSON_AllParams(t *testing.T) {
 	w := infra.NewFileWriter()
 	script := entity.Script{
 		Text:      "感情込めて",
-		SpeakerID: ptrInt(5),
+		SpeakerID: ptrSpeakerID(5),
 		Overrides: entity.SynthOverrides{Speed: ptrFloat64(1.5), Pitch: ptrFloat64(0.1), Intonation: ptrFloat64(1.8)},
 	}
 	if _, err := w.Write(dest, script); err != nil {
@@ -122,7 +126,7 @@ func TestFileWriter_Write_JSON_OmitNilFields(t *testing.T) {
 	w := infra.NewFileWriter()
 	script := entity.Script{
 		Text:      "部分指定",
-		SpeakerID: ptrInt(2),
+		SpeakerID: ptrSpeakerID(2),
 	}
 	if _, err := w.Write(dest, script); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -157,7 +161,7 @@ func TestFileWriter_Write_JSONL_SingleLine(t *testing.T) {
 	w := infra.NewFileWriter()
 	script := entity.Script{
 		Text:      "JSONL出力",
-		SpeakerID: ptrInt(3),
+		SpeakerID: ptrSpeakerID(3),
 	}
 	if _, err := w.Write(dest, script); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -234,7 +238,7 @@ func TestFileWriter_Write_Txt_WithSpeaker_LogsWarn(t *testing.T) {
 	w := infra.NewFileWriter(infra.WithFileWriterLogger(logger))
 	script := entity.Script{
 		Text:      "本文",
-		SpeakerID: ptrInt(5),
+		SpeakerID: ptrSpeakerID(5),
 	}
 	if _, err := w.Write(dest, script); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -409,7 +413,7 @@ func TestFileWriter_Write_DirectoryTarget_CreatesAutoNamedFile(t *testing.T) {
 	w := infra.NewFileWriter()
 	written, err := w.Write(outDir, entity.Script{
 		Text:      "ディレクトリ指定",
-		SpeakerID: ptrInt(2),
+		SpeakerID: ptrSpeakerID(2),
 		Overrides: entity.SynthOverrides{Speed: ptrFloat64(1.1)},
 	})
 	if err != nil {
@@ -521,8 +525,8 @@ func TestFileWriter_WriteAll_MultipleScripts(t *testing.T) {
 
 	w := infra.NewFileWriter()
 	scripts := []entity.Script{
-		{Text: "おはようなのだ", SpeakerID: ptrInt(3), Overrides: entity.SynthOverrides{Intonation: ptrFloat64(1.1)}},
-		{Text: "今日もがんばるのだ", SpeakerID: ptrInt(3), Overrides: entity.SynthOverrides{Speed: ptrFloat64(1.0)}},
+		{Text: "おはようなのだ", SpeakerID: ptrSpeakerID(3), Overrides: entity.SynthOverrides{Intonation: ptrFloat64(1.1)}},
+		{Text: "今日もがんばるのだ", SpeakerID: ptrSpeakerID(3), Overrides: entity.SynthOverrides{Speed: ptrFloat64(1.0)}},
 	}
 	written, err := w.WriteAll(dest, scripts)
 	if err != nil {

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -987,6 +987,10 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 			http.Error(w, fmt.Sprintf("clips[%d].text must not be empty", i), http.StatusBadRequest)
 			return
 		}
+		if _, err := entity.NewSpeakerID(clip.SpeakerID); err != nil {
+			http.Error(w, fmt.Sprintf("clips[%d].speaker_id: %v", i, err), http.StatusBadRequest)
+			return
+		}
 	}
 
 	playbackID, err := newUUIDv4()

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -485,7 +485,7 @@ func (p *HTTPStreamPlayer) SetSilent(reason string) {
 func clipToPlayMeta(clip ViewerClip) app.PlayMeta {
 	return app.PlayMeta{
 		Text:       clip.Text,
-		SpeakerID:  clip.SpeakerID,
+		SpeakerID:  entity.MustNewSpeakerID(clip.SpeakerID),
 		Speed:      clip.Speed,
 		Pitch:      clip.Pitch,
 		Intonation: clip.Intonation,
@@ -494,14 +494,14 @@ func clipToPlayMeta(clip ViewerClip) app.PlayMeta {
 
 // newClipEvent は meta と ts から clipEvent を構築する。url は呼び出し元が指定する。
 func (p *HTTPStreamPlayer) newClipEvent(meta app.PlayMeta, ts int64, url string) clipEvent {
-	speakerName, styleName := p.resolveSpeaker(meta.SpeakerID)
+	speakerName, styleName := p.resolveSpeaker(meta.SpeakerID.Value())
 	return clipEvent{
 		URL:         url,
 		Text:        meta.Text,
 		SpeakerName: speakerName,
 		StyleName:   styleName,
 		Timestamp:   ts,
-		SpeakerID:   meta.SpeakerID,
+		SpeakerID:   meta.SpeakerID.Value(),
 		Speed:       meta.Speed,
 		Pitch:       meta.Pitch,
 		Intonation:  meta.Intonation,
@@ -618,7 +618,7 @@ func (p *HTTPStreamPlayer) BroadcastError(e app.StreamError) {
 	case app.StreamErrorCategorySynthesis:
 		ev.Path = e.Path
 		ev.Text = e.Text
-		ev.SpeakerName, ev.StyleName = p.resolveSpeaker(e.SpeakerID)
+		ev.SpeakerName, ev.StyleName = p.resolveSpeaker(e.SpeakerID.Value())
 	case app.StreamErrorCategoryFile:
 		ev.Path = e.Path
 	case app.StreamErrorCategoryConnection:
@@ -1057,14 +1057,20 @@ func (p *HTTPStreamPlayer) handleAPIPreviewClip(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	query, err := p.voicevoxClient.CreateQuery(r.Context(), req.Text, req.SpeakerID)
+	speakerID, err := entity.NewSpeakerID(req.SpeakerID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid speaker_id: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	query, err := p.voicevoxClient.CreateQuery(r.Context(), req.Text, speakerID)
 	if err != nil {
 		p.logger.Error("/api/preview-clip CreateQuery failed", "speakerID", req.SpeakerID, "error", err)
 		http.Error(w, "synthesis failed", http.StatusBadGateway)
 		return
 	}
 	q := query.WithOverrides(entity.SynthOverrides{Speed: req.Speed, Pitch: req.Pitch, Intonation: req.Intonation})
-	wav, err := p.voicevoxClient.Synthesize(r.Context(), &q, req.SpeakerID)
+	wav, err := p.voicevoxClient.Synthesize(r.Context(), &q, speakerID)
 	if err != nil {
 		p.logger.Error("/api/preview-clip Synthesize failed", "speakerID", req.SpeakerID, "error", err)
 		http.Error(w, "synthesis failed", http.StatusBadGateway)
@@ -1206,13 +1212,14 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 			nextClip := batch.clips[i+1]
 			nextSynthCh = make(chan synthResult, 1)
 			go func() {
-				q2, err := p.voicevoxClient.CreateQuery(ctx, nextClip.Text, nextClip.SpeakerID)
+				nextSpeakerID := entity.MustNewSpeakerID(nextClip.SpeakerID)
+				q2, err := p.voicevoxClient.CreateQuery(ctx, nextClip.Text, nextSpeakerID)
 				if err != nil {
 					nextSynthCh <- synthResult{err: err}
 					return
 				}
 				q2o := q2.WithOverrides(entity.SynthOverrides{Speed: nextClip.Speed, Pitch: nextClip.Pitch, Intonation: nextClip.Intonation})
-				w, err := p.voicevoxClient.Synthesize(ctx, &q2o, nextClip.SpeakerID)
+				w, err := p.voicevoxClient.Synthesize(ctx, &q2o, nextSpeakerID)
 				nextSynthCh <- synthResult{wav: w, err: err}
 			}()
 		}
@@ -1246,7 +1253,8 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 // synthesizeAndPlay は clip を合成して Play() でブロードキャストする。
 // エラー時は playback を failed に遷移させて error を返す。
 func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID string, clip ViewerClip) ([]byte, error) {
-	query, err := p.voicevoxClient.CreateQuery(ctx, clip.Text, clip.SpeakerID)
+	clipSpeakerID := entity.MustNewSpeakerID(clip.SpeakerID)
+	query, err := p.voicevoxClient.CreateQuery(ctx, clip.Text, clipSpeakerID)
 	if err != nil {
 		p.logger.Error("worker CreateQuery failed", "playbackID", playbackID, "speakerID", clip.SpeakerID, "error", err)
 		p.setPlaybackStatus(playbackID, playbackStatusFailed, err.Error())
@@ -1254,7 +1262,7 @@ func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID str
 	}
 
 	q := query.WithOverrides(entity.SynthOverrides{Speed: clip.Speed, Pitch: clip.Pitch, Intonation: clip.Intonation})
-	wav, err := p.voicevoxClient.Synthesize(ctx, &q, clip.SpeakerID)
+	wav, err := p.voicevoxClient.Synthesize(ctx, &q, clipSpeakerID)
 	if err != nil {
 		p.logger.Error("worker Synthesize failed", "playbackID", playbackID, "speakerID", clip.SpeakerID, "error", err)
 		p.setPlaybackStatus(playbackID, playbackStatusFailed, err.Error())

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -676,7 +676,7 @@ func TestHTTPStreamPlayer_Play_ClipEventResolvesSpeakerName(t *testing.T) {
 	events := subscribeSSE(t, baseURL)
 	time.Sleep(50 * time.Millisecond)
 
-	if err := p.Play(context.Background(), []byte("RIFFx"), app.PlayMeta{Text: "やっほー", SpeakerID: 3}); err != nil {
+	if err := p.Play(context.Background(), []byte("RIFFx"), app.PlayMeta{Text: "やっほー", SpeakerID: entity.MustNewSpeakerID(3)}); err != nil {
 		t.Fatalf("Play: %v", err)
 	}
 
@@ -708,7 +708,7 @@ func TestHTTPStreamPlayer_Play_ClipEventFallbackForUnknownSpeaker(t *testing.T) 
 	events := subscribeSSE(t, baseURL)
 	time.Sleep(50 * time.Millisecond)
 
-	if err := p.Play(context.Background(), []byte("RIFFx"), app.PlayMeta{Text: "未知", SpeakerID: 999}); err != nil {
+	if err := p.Play(context.Background(), []byte("RIFFx"), app.PlayMeta{Text: "未知", SpeakerID: entity.MustNewSpeakerID(999)}); err != nil {
 		t.Fatalf("Play: %v", err)
 	}
 
@@ -788,7 +788,7 @@ func TestHTTPStreamPlayer_Play_ClipEventNoLookup(t *testing.T) {
 	events := subscribeSSE(t, baseURL)
 	time.Sleep(50 * time.Millisecond)
 
-	if err := p.Play(context.Background(), []byte("RIFFx"), app.PlayMeta{SpeakerID: 3}); err != nil {
+	if err := p.Play(context.Background(), []byte("RIFFx"), app.PlayMeta{SpeakerID: entity.MustNewSpeakerID(3)}); err != nil {
 		t.Fatalf("Play: %v", err)
 	}
 
@@ -1159,7 +1159,7 @@ func TestHTTPStreamPlayer_PlayText_EmptyURLAndSilentInterval(t *testing.T) {
 	time.Sleep(50 * time.Millisecond) // 購読確立待ち
 
 	start := time.Now()
-	if err := p.PlayText(context.Background(), app.PlayMeta{Text: "こんにちは", SpeakerID: 3}); err != nil {
+	if err := p.PlayText(context.Background(), app.PlayMeta{Text: "こんにちは", SpeakerID: entity.MustNewSpeakerID(3)}); err != nil {
 		t.Fatalf("PlayText: %v", err)
 	}
 	elapsed := time.Since(start)
@@ -1194,7 +1194,7 @@ func TestHTTPStreamPlayer_PlayText_CtxCancelled(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := p.PlayText(ctx, app.PlayMeta{Text: "x", SpeakerID: 3}); err == nil {
+	if err := p.PlayText(ctx, app.PlayMeta{Text: "x", SpeakerID: entity.MustNewSpeakerID(3)}); err == nil {
 		t.Fatal("expected error for cancelled ctx")
 	}
 }
@@ -1231,7 +1231,7 @@ func TestHTTPStreamPlayer_PlayText_UnknownSpeakerFallback(t *testing.T) {
 	baseURL := "http://" + p.Addr()
 	events := subscribeSSE(t, baseURL)
 	time.Sleep(50 * time.Millisecond)
-	if err := p.PlayText(context.Background(), app.PlayMeta{Text: "hello", SpeakerID: 42}); err != nil {
+	if err := p.PlayText(context.Background(), app.PlayMeta{Text: "hello", SpeakerID: entity.MustNewSpeakerID(42)}); err != nil {
 		t.Fatalf("PlayText: %v", err)
 	}
 	select {
@@ -1268,11 +1268,11 @@ type testVoicevoxClient struct {
 }
 
 func (c *testVoicevoxClient) HealthCheck(_ context.Context) error { return nil }
-func (c *testVoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error) {
+func (c *testVoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID entity.SpeakerID) (*entity.AudioQuery, error) {
 	c.mu.Lock()
 	c.createQueryCall++
 	c.capturedText = text
-	c.capturedSpeaker = speakerID
+	c.capturedSpeaker = speakerID.Value()
 	block := c.createQueryBlock
 	c.mu.Unlock()
 	if block != nil {
@@ -1290,7 +1290,7 @@ func (c *testVoicevoxClient) CreateQuery(ctx context.Context, text string, speak
 	}
 	return &entity.AudioQuery{}, nil
 }
-func (c *testVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+func (c *testVoicevoxClient) Synthesize(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 	c.mu.Lock()
 	c.synthesizeCall++
 	n := c.synthesizeCall
@@ -1329,7 +1329,7 @@ func TestHTTPStreamPlayer_BroadcastError_SynthesisCategory(t *testing.T) {
 		Message:   "synthesize failed",
 		Path:      "/tmp/script.txt",
 		Text:      "こんにちは",
-		SpeakerID: 3,
+		SpeakerID: entity.MustNewSpeakerID(3),
 	})
 
 	select {
@@ -2175,7 +2175,7 @@ func TestHTTPStreamPlayer_History_WritesClipOnPlay(t *testing.T) {
 	})
 
 	if err := p.Play(context.Background(), []byte("RIFFwavdata"), app.PlayMeta{
-		Text: "テストセリフ", SpeakerID: 3,
+		Text: "テストセリフ", SpeakerID: entity.MustNewSpeakerID(3),
 	}); err != nil {
 		t.Fatalf("Play: %v", err)
 	}
@@ -2232,7 +2232,7 @@ func TestHTTPStreamPlayer_History_WritesClipOnPlayText(t *testing.T) {
 	p.silentInterval = 1 * time.Millisecond
 
 	if err := p.PlayText(context.Background(), app.PlayMeta{
-		Text: "サイレントセリフ", SpeakerID: 3,
+		Text: "サイレントセリフ", SpeakerID: entity.MustNewSpeakerID(3),
 	}); err != nil {
 		t.Fatalf("PlayText: %v", err)
 	}
@@ -3441,7 +3441,7 @@ func TestHTTPStreamPlayer_History_WritesParamsOnPlay(t *testing.T) {
 	pitch := 0.05
 	intonation := 1.3
 	if err := p.Play(context.Background(), []byte("RIFFwavdata"), app.PlayMeta{
-		Text: "パラメータテスト", SpeakerID: 3,
+		Text: "パラメータテスト", SpeakerID: entity.MustNewSpeakerID(3),
 		Speed: &speed, Pitch: &pitch, Intonation: &intonation,
 	}); err != nil {
 		t.Fatalf("Play: %v", err)
@@ -3502,7 +3502,7 @@ func TestHTTPStreamPlayer_History_WritesParamsOnPlayText(t *testing.T) {
 	pitch := -0.05
 	intonation := 0.8
 	if err := p.PlayText(context.Background(), app.PlayMeta{
-		Text: "サイレントパラメータ", SpeakerID: 3,
+		Text: "サイレントパラメータ", SpeakerID: entity.MustNewSpeakerID(3),
 		Speed: &speed, Pitch: &pitch, Intonation: &intonation,
 	}); err != nil {
 		t.Fatalf("PlayText: %v", err)
@@ -3621,7 +3621,7 @@ func TestHTTPStreamPlayer_APIHistory_IncludesParams(t *testing.T) {
 	speed := 1.1
 	intonation := 1.4
 	if err := p.Play(context.Background(), []byte("RIFFwavdata"), app.PlayMeta{
-		Text: "APIレスポンステスト", SpeakerID: 3,
+		Text: "APIレスポンステスト", SpeakerID: entity.MustNewSpeakerID(3),
 		Speed: &speed, Intonation: &intonation,
 	}); err != nil {
 		t.Fatalf("Play: %v", err)

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -2800,6 +2800,21 @@ func TestHTTPStreamPlayer_APIPlay_EmptyClipTextRejected(t *testing.T) {
 	}
 }
 
+func TestHTTPStreamPlayer_APIPlay_NegativeSpeakerIDRejected(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	body := bytes.NewBufferString(`{"clips":[{"text":"hello","speaker_id":-1}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for negative speaker_id, got %d", resp.StatusCode)
+	}
+}
+
 func TestHTTPStreamPlayer_APIPlay_QueueFull(t *testing.T) {
 	t.Parallel()
 	block := make(chan struct{})

--- a/internal/infra/retryable_voicevox_client.go
+++ b/internal/infra/retryable_voicevox_client.go
@@ -144,7 +144,7 @@ func (c *RetryableVoicevoxClient) HealthCheck(ctx context.Context) error {
 }
 
 // CreateQuery はテキストから音声合成用クエリを生成する。失敗時は指数バックオフでリトライを行う。
-func (c *RetryableVoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error) {
+func (c *RetryableVoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID entity.SpeakerID) (*entity.AudioQuery, error) {
 	var result *entity.AudioQuery
 	err := c.retryWithBackoff(ctx, func() error {
 		var err error
@@ -155,7 +155,7 @@ func (c *RetryableVoicevoxClient) CreateQuery(ctx context.Context, text string, 
 }
 
 // Synthesize は音声合成を実行し、WAV形式のバイト列を返す。失敗時は指数バックオフでリトライを行う。
-func (c *RetryableVoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error) {
+func (c *RetryableVoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID entity.SpeakerID) ([]byte, error) {
 	var result []byte
 	err := c.retryWithBackoff(ctx, func() error {
 		var err error

--- a/internal/infra/retryable_voicevox_client_test.go
+++ b/internal/infra/retryable_voicevox_client_test.go
@@ -22,8 +22,8 @@ func (e *mockNetError) Temporary() bool { return true }
 // mockVoicevoxClient はテスト用のVoicevoxClientモック。
 type mockVoicevoxClient struct {
 	healthCheckFunc func(ctx context.Context) error
-	createQueryFunc func(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error)
-	synthesizeFunc  func(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error)
+	createQueryFunc func(ctx context.Context, text string, speakerID entity.SpeakerID) (*entity.AudioQuery, error)
+	synthesizeFunc  func(ctx context.Context, query *entity.AudioQuery, speakerID entity.SpeakerID) ([]byte, error)
 	getSpeakersFunc func(ctx context.Context) ([]entity.Speaker, error)
 	callCounts      map[string]int
 }
@@ -42,7 +42,7 @@ func (m *mockVoicevoxClient) HealthCheck(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockVoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error) {
+func (m *mockVoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID entity.SpeakerID) (*entity.AudioQuery, error) {
 	m.callCounts["CreateQuery"]++
 	if m.createQueryFunc != nil {
 		return m.createQueryFunc(ctx, text, speakerID)
@@ -50,7 +50,7 @@ func (m *mockVoicevoxClient) CreateQuery(ctx context.Context, text string, speak
 	return &entity.AudioQuery{}, nil
 }
 
-func (m *mockVoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error) {
+func (m *mockVoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID entity.SpeakerID) ([]byte, error) {
 	m.callCounts["Synthesize"]++
 	if m.synthesizeFunc != nil {
 		return m.synthesizeFunc(ctx, query, speakerID)
@@ -144,7 +144,7 @@ func TestRetryableVoicevoxClient_CreateQuery_RetrySuccess(t *testing.T) {
 	mock := newMockVoicevoxClient()
 	callCount := 0
 	expectedQuery := &entity.AudioQuery{SpeedScale: 1.0}
-	mock.createQueryFunc = func(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	mock.createQueryFunc = func(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 		callCount++
 		if callCount == 1 {
 			return nil, &mockNetError{msg: "connection refused"}
@@ -155,7 +155,7 @@ func TestRetryableVoicevoxClient_CreateQuery_RetrySuccess(t *testing.T) {
 	noopSleep := func(_ context.Context, _ time.Duration) error { return nil }
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
-	query, err := client.CreateQuery(context.Background(), "test", 1)
+	query, err := client.CreateQuery(context.Background(), "test", entity.MustNewSpeakerID(1))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -171,14 +171,14 @@ func TestRetryableVoicevoxClient_CreateQuery_RetrySuccess(t *testing.T) {
 func TestRetryableVoicevoxClient_CreateQuery_Success(t *testing.T) {
 	mock := newMockVoicevoxClient()
 	expectedQuery := &entity.AudioQuery{SpeedScale: 1.0}
-	mock.createQueryFunc = func(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	mock.createQueryFunc = func(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 		return expectedQuery, nil
 	}
 
 	noopSleep := func(_ context.Context, _ time.Duration) error { return nil }
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
-	query, err := client.CreateQuery(context.Background(), "test", 1)
+	query, err := client.CreateQuery(context.Background(), "test", entity.MustNewSpeakerID(1))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -194,7 +194,7 @@ func TestRetryableVoicevoxClient_CreateQuery_Success(t *testing.T) {
 func TestRetryableVoicevoxClient_Synthesize_Success(t *testing.T) {
 	mock := newMockVoicevoxClient()
 	expectedWAV := []byte("wav data")
-	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 		return expectedWAV, nil
 	}
 
@@ -202,7 +202,7 @@ func TestRetryableVoicevoxClient_Synthesize_Success(t *testing.T) {
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
 	query := &entity.AudioQuery{SpeedScale: 1.0}
-	wav, err := client.Synthesize(context.Background(), query, 1)
+	wav, err := client.Synthesize(context.Background(), query, entity.MustNewSpeakerID(1))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -219,7 +219,7 @@ func TestRetryableVoicevoxClient_Synthesize_RetrySuccess(t *testing.T) {
 	mock := newMockVoicevoxClient()
 	callCount := 0
 	expectedWAV := []byte("wav data")
-	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 		callCount++
 		if callCount == 1 {
 			return nil, &mockNetError{msg: "connection refused"}
@@ -231,7 +231,7 @@ func TestRetryableVoicevoxClient_Synthesize_RetrySuccess(t *testing.T) {
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
 	query := &entity.AudioQuery{SpeedScale: 1.0}
-	wav, err := client.Synthesize(context.Background(), query, 1)
+	wav, err := client.Synthesize(context.Background(), query, entity.MustNewSpeakerID(1))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -246,14 +246,14 @@ func TestRetryableVoicevoxClient_Synthesize_RetrySuccess(t *testing.T) {
 // リトライ上限超過: CreateQueryが最大3回リトライしても失敗する場合エラーを返す
 func TestRetryableVoicevoxClient_CreateQuery_MaxRetriesExceeded(t *testing.T) {
 	mock := newMockVoicevoxClient()
-	mock.createQueryFunc = func(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	mock.createQueryFunc = func(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 		return nil, &mockNetError{msg: "connection refused"}
 	}
 
 	noopSleep := func(_ context.Context, _ time.Duration) error { return nil }
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
-	query, err := client.CreateQuery(context.Background(), "test", 1)
+	query, err := client.CreateQuery(context.Background(), "test", entity.MustNewSpeakerID(1))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -269,7 +269,7 @@ func TestRetryableVoicevoxClient_CreateQuery_MaxRetriesExceeded(t *testing.T) {
 // リトライ上限超過: Synthesizeが最大3回リトライしても失敗する場合エラーを返す
 func TestRetryableVoicevoxClient_Synthesize_MaxRetriesExceeded(t *testing.T) {
 	mock := newMockVoicevoxClient()
-	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 		return nil, &mockNetError{msg: "connection refused"}
 	}
 
@@ -277,7 +277,7 @@ func TestRetryableVoicevoxClient_Synthesize_MaxRetriesExceeded(t *testing.T) {
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
 	query := &entity.AudioQuery{SpeedScale: 1.0}
-	wav, err := client.Synthesize(context.Background(), query, 1)
+	wav, err := client.Synthesize(context.Background(), query, entity.MustNewSpeakerID(1))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -293,7 +293,7 @@ func TestRetryableVoicevoxClient_Synthesize_MaxRetriesExceeded(t *testing.T) {
 // 指数バックオフ: リトライ間隔が1秒→2秒→4秒で増加する
 func TestRetryableVoicevoxClient_ExponentialBackoff(t *testing.T) {
 	mock := newMockVoicevoxClient()
-	mock.createQueryFunc = func(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	mock.createQueryFunc = func(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 		return nil, &mockNetError{msg: "connection refused"}
 	}
 
@@ -304,7 +304,7 @@ func TestRetryableVoicevoxClient_ExponentialBackoff(t *testing.T) {
 	}
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(recordingSleep))
 
-	_, _ = client.CreateQuery(context.Background(), "test", 1)
+	_, _ = client.CreateQuery(context.Background(), "test", entity.MustNewSpeakerID(1))
 
 	// 3回のリトライ → 3回のスリープ
 	expectedDurations := []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
@@ -321,7 +321,7 @@ func TestRetryableVoicevoxClient_ExponentialBackoff(t *testing.T) {
 // バックオフ上限: 指数バックオフの上限が30秒である
 func TestRetryableVoicevoxClient_BackoffMaxInterval(t *testing.T) {
 	mock := newMockVoicevoxClient()
-	mock.createQueryFunc = func(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	mock.createQueryFunc = func(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 		return nil, &mockNetError{msg: "connection refused"}
 	}
 
@@ -341,7 +341,7 @@ func TestRetryableVoicevoxClient_BackoffMaxInterval(t *testing.T) {
 		}),
 	)
 
-	_, _ = client.CreateQuery(context.Background(), "test", 1)
+	_, _ = client.CreateQuery(context.Background(), "test", entity.MustNewSpeakerID(1))
 
 	// 16秒 → 30秒（32秒が上限30秒でクリップ） → 30秒
 	expectedDurations := []time.Duration{16 * time.Second, 30 * time.Second, 30 * time.Second}
@@ -358,14 +358,14 @@ func TestRetryableVoicevoxClient_BackoffMaxInterval(t *testing.T) {
 // 非リトライエラー: HTTPステータスエラー（非net.Error）はリトライせず即座にエラーを返す
 func TestRetryableVoicevoxClient_CreateQuery_NonRetryableError(t *testing.T) {
 	mock := newMockVoicevoxClient()
-	mock.createQueryFunc = func(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	mock.createQueryFunc = func(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 		return nil, errors.New("create query failed: status 400")
 	}
 
 	noopSleep := func(_ context.Context, _ time.Duration) error { return nil }
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
-	_, err := client.CreateQuery(context.Background(), "test", 1)
+	_, err := client.CreateQuery(context.Background(), "test", entity.MustNewSpeakerID(1))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -378,7 +378,7 @@ func TestRetryableVoicevoxClient_CreateQuery_NonRetryableError(t *testing.T) {
 // 非リトライエラー: Synthesizeで非net.Errorはリトライせず即座にエラーを返す
 func TestRetryableVoicevoxClient_Synthesize_NonRetryableError(t *testing.T) {
 	mock := newMockVoicevoxClient()
-	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ int) ([]byte, error) {
+	mock.synthesizeFunc = func(_ context.Context, _ *entity.AudioQuery, _ entity.SpeakerID) ([]byte, error) {
 		return nil, errors.New("synthesis failed: status 500")
 	}
 
@@ -386,7 +386,7 @@ func TestRetryableVoicevoxClient_Synthesize_NonRetryableError(t *testing.T) {
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(noopSleep))
 
 	query := &entity.AudioQuery{SpeedScale: 1.0}
-	_, err := client.Synthesize(context.Background(), query, 1)
+	_, err := client.Synthesize(context.Background(), query, entity.MustNewSpeakerID(1))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -420,7 +420,7 @@ func TestRetryableVoicevoxClient_ConfigNormalization(t *testing.T) {
 // コンテキストキャンセル: リトライ中にコンテキストがキャンセルされた場合エラーを返す
 func TestRetryableVoicevoxClient_ContextCancelled(t *testing.T) {
 	mock := newMockVoicevoxClient()
-	mock.createQueryFunc = func(_ context.Context, _ string, _ int) (*entity.AudioQuery, error) {
+	mock.createQueryFunc = func(_ context.Context, _ string, _ entity.SpeakerID) (*entity.AudioQuery, error) {
 		return nil, &mockNetError{msg: "connection refused"}
 	}
 
@@ -429,7 +429,7 @@ func TestRetryableVoicevoxClient_ContextCancelled(t *testing.T) {
 	}
 	client := infra.NewRetryableVoicevoxClient(mock, infra.WithSleepFunc(cancelledSleep))
 
-	_, err := client.CreateQuery(context.Background(), "test", 1)
+	_, err := client.CreateQuery(context.Background(), "test", entity.MustNewSpeakerID(1))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/infra/voicevox_client.go
+++ b/internal/infra/voicevox_client.go
@@ -76,7 +76,7 @@ func (c *VoicevoxClient) HealthCheck(ctx context.Context) error {
 }
 
 // CreateQuery はテキストから音声合成用クエリを生成する。
-func (c *VoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID int) (*entity.AudioQuery, error) {
+func (c *VoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID entity.SpeakerID) (*entity.AudioQuery, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/audio_query", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -84,7 +84,7 @@ func (c *VoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID
 
 	q := req.URL.Query()
 	q.Set("text", text)
-	q.Set("speaker", strconv.Itoa(speakerID))
+	q.Set("speaker", strconv.Itoa(speakerID.Value()))
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := c.httpClient.Do(req)
@@ -111,7 +111,7 @@ func (c *VoicevoxClient) CreateQuery(ctx context.Context, text string, speakerID
 }
 
 // Synthesize は音声合成を実行し、WAV形式のバイト列を返す。
-func (c *VoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID int) ([]byte, error) {
+func (c *VoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuery, speakerID entity.SpeakerID) ([]byte, error) {
 	jsonBody, err := json.Marshal(query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal audio query: %w", err)
@@ -124,7 +124,7 @@ func (c *VoicevoxClient) Synthesize(ctx context.Context, query *entity.AudioQuer
 	req.Header.Set("Content-Type", "application/json")
 
 	params := req.URL.Query()
-	params.Set("speaker", strconv.Itoa(speakerID))
+	params.Set("speaker", strconv.Itoa(speakerID.Value()))
 	req.URL.RawQuery = params.Encode()
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/infra/voicevox_client_test.go
+++ b/internal/infra/voicevox_client_test.go
@@ -100,7 +100,7 @@ func TestCreateQuery_Success(t *testing.T) {
 	defer server.Close()
 
 	client := infra.NewVoicevoxClient(server.URL)
-	query, err := client.CreateQuery(context.Background(), "こんにちは", 1)
+	query, err := client.CreateQuery(context.Background(), "こんにちは", entity.MustNewSpeakerID(1))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -142,7 +142,7 @@ func TestCreateQuery_Non200(t *testing.T) {
 	defer server.Close()
 
 	client := infra.NewVoicevoxClient(server.URL)
-	query, err := client.CreateQuery(context.Background(), "test", 1)
+	query, err := client.CreateQuery(context.Background(), "test", entity.MustNewSpeakerID(1))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -192,7 +192,7 @@ func TestSynthesize_Success(t *testing.T) {
 	}
 
 	client := infra.NewVoicevoxClient(server.URL)
-	wav, err := client.Synthesize(context.Background(), query, 1)
+	wav, err := client.Synthesize(context.Background(), query, entity.MustNewSpeakerID(1))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -238,7 +238,7 @@ func TestSynthesize_PassesThroughQueryDirectly(t *testing.T) {
 	}
 
 	client := infra.NewVoicevoxClient(server.URL)
-	_, err := client.Synthesize(context.Background(), query, 1)
+	_, err := client.Synthesize(context.Background(), query, entity.MustNewSpeakerID(1))
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -313,7 +313,7 @@ func TestSynthesize_Non200(t *testing.T) {
 	}
 
 	client := infra.NewVoicevoxClient(server.URL)
-	wav, err := client.Synthesize(context.Background(), query, 1)
+	wav, err := client.Synthesize(context.Background(), query, entity.MustNewSpeakerID(1))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/test/e2e/say_comm_test.go
+++ b/test/e2e/say_comm_test.go
@@ -324,7 +324,6 @@ func TestSayE2E_BoundaryValues_DryRun_ExitsZero(t *testing.T) {
 		name string
 		args []string
 	}{
-		{"speaker negative", []string{"say", "--dry-run", "--speaker", "-1", "テスト"}},
 		{"speed large", []string{"say", "--dry-run", "--speed", "999.0", "テスト"}},
 		{"pitch large", []string{"say", "--dry-run", "--pitch", "1.0", "テスト"}},
 		{"intonation large", []string{"say", "--dry-run", "--intonation", "999.0", "テスト"}},
@@ -337,6 +336,14 @@ func TestSayE2E_BoundaryValues_DryRun_ExitsZero(t *testing.T) {
 				t.Errorf("expected exit 0 for boundary value %q, got %d\nstderr:\n%s", tc.name, exitCode, stderr)
 			}
 		})
+	}
+}
+
+func TestSayE2E_NegativeSpeaker_ExitsNonZero(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runCLI(t, nil, "say", "--dry-run", "--speaker", "-1", "テスト")
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit for --speaker -1, got 0\nstderr:\n%s", stderr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `entity.SpeakerID` 値オブジェクトを新設し、コンストラクタで非負値を保証（`NewSpeakerID`/`MustNewSpeakerID`）
- `entity.Script.SpeakerID` を `*int` → `*entity.SpeakerID` に変更し、`ResolveSpeakerID` のシグネチャを統一
- `app.PlayMeta`・`SayParams`・`ActParams`・`WatchParams` および `VoicevoxClient` インターフェースの SpeakerID 関連引数を `entity.SpeakerID` に統一
- `cmd` 層でフラグ値 (`--speaker`) の負値バリデーションを追加、`/api/play` ハンドラでも負値を 400 で早期拒否
- `file_reader` で無効な speaker フィールド（負値）を読んだ際に WARN ログを出力

## Test plan

- [ ] `go test ./...` が通ること（`TestRunWatch_AudioProbe_*` 2件は変更前から失敗している既存テスト）
- [ ] `--speaker -1` を指定して `vox-actor say` / `vox-actor act` / `vox-actor watch` を実行するとエラー終了すること（外部サービス不要）
- [ ] `/api/play` に `speaker_id: -1` を含む JSON を POST すると 400 Bad Request が返ること（外部サービス不要）

Closes #558

---
🤖 Generated with [Claude Code](https://claude.ai/code)
