### PR TITLE
refactor(domain): Playbackの状態遷移とClipをドメイン層へ切り出す

### DIFF
--- a/internal/domain/entity/clip.go
+++ b/internal/domain/entity/clip.go
@@ -1,0 +1,22 @@
+package entity
+
+// Clip はドメイン層の再生1単位を表す値オブジェクト。
+// HTTP 境界では infra パッケージの ViewerClip が JSON 変換を担う。
+type Clip struct {
+	Text       string
+	SpeakerID  SpeakerID
+	Speed      *float64
+	Pitch      *float64
+	Intonation *float64
+}
+
+// NewClip は Clip を生成する。
+func NewClip(text string, speakerID SpeakerID, speed, pitch, intonation *float64) Clip {
+	return Clip{
+		Text:       text,
+		SpeakerID:  speakerID,
+		Speed:      speed,
+		Pitch:      pitch,
+		Intonation: intonation,
+	}
+}

--- a/internal/domain/entity/clip_test.go
+++ b/internal/domain/entity/clip_test.go
@@ -1,0 +1,30 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+func TestNewClip(t *testing.T) {
+	speed := 1.2
+	speakerID := entity.MustNewSpeakerID(3)
+
+	clip := entity.NewClip("こんにちは", speakerID, &speed, nil, nil)
+
+	if clip.Text != "こんにちは" {
+		t.Errorf("expected text='こんにちは', got %q", clip.Text)
+	}
+	if clip.SpeakerID != speakerID {
+		t.Errorf("expected speakerID=%v, got %v", speakerID, clip.SpeakerID)
+	}
+	if clip.Speed == nil || *clip.Speed != speed {
+		t.Errorf("expected speed=1.2, got %v", clip.Speed)
+	}
+	if clip.Pitch != nil {
+		t.Errorf("expected pitch=nil, got %v", clip.Pitch)
+	}
+	if clip.Intonation != nil {
+		t.Errorf("expected intonation=nil, got %v", clip.Intonation)
+	}
+}

--- a/internal/domain/entity/playback.go
+++ b/internal/domain/entity/playback.go
@@ -46,7 +46,6 @@ func (p *Playback) MarkPlaying(nowMs int64) error {
 }
 
 // MarkCompleted は pending または playing → completed へ遷移する。
-// pending からの遷移は無音モード（silent）での即時完了を想定する。
 func (p *Playback) MarkCompleted(nowMs int64) error {
 	switch p.status {
 	case PlaybackStatusPending, PlaybackStatusPlaying:

--- a/internal/domain/entity/playback.go
+++ b/internal/domain/entity/playback.go
@@ -1,0 +1,85 @@
+package entity
+
+import (
+	"fmt"
+	"time"
+)
+
+// PlaybackStatus は再生バッチの状態を表す。
+type PlaybackStatus string
+
+const (
+	PlaybackStatusPending   PlaybackStatus = "pending"
+	PlaybackStatusPlaying   PlaybackStatus = "playing"
+	PlaybackStatusCompleted PlaybackStatus = "completed"
+	PlaybackStatusFailed    PlaybackStatus = "failed"
+)
+
+// Playback は1再生バッチの状態遷移を管理するエンティティ。
+type Playback struct {
+	status         PlaybackStatus
+	reason         string
+	createdAt      time.Time
+	clipCount      int
+	completedClips int
+	startedAt      *int64 // Unix milliseconds
+	finishedAt     *int64 // Unix milliseconds
+}
+
+// NewPlayback は pending 状態の Playback を生成する。
+func NewPlayback(clipCount int, now time.Time) *Playback {
+	return &Playback{
+		status:    PlaybackStatusPending,
+		clipCount: clipCount,
+		createdAt: now,
+	}
+}
+
+// MarkPlaying は pending → playing へ遷移する。他の状態からはエラーを返す。
+func (p *Playback) MarkPlaying(nowMs int64) error {
+	if p.status != PlaybackStatusPending {
+		return fmt.Errorf("cannot transition from %s to playing", p.status)
+	}
+	p.status = PlaybackStatusPlaying
+	p.startedAt = &nowMs
+	return nil
+}
+
+// MarkCompleted は pending または playing → completed へ遷移する。
+// pending からの遷移は無音モード（silent）での即時完了を想定する。
+func (p *Playback) MarkCompleted(nowMs int64) error {
+	switch p.status {
+	case PlaybackStatusPending, PlaybackStatusPlaying:
+		p.status = PlaybackStatusCompleted
+		p.finishedAt = &nowMs
+		return nil
+	default:
+		return fmt.Errorf("cannot transition from %s to completed", p.status)
+	}
+}
+
+// MarkFailed は pending または playing → failed へ遷移する。
+func (p *Playback) MarkFailed(reason string, nowMs int64) error {
+	switch p.status {
+	case PlaybackStatusCompleted, PlaybackStatusFailed:
+		return fmt.Errorf("cannot transition from %s to failed", p.status)
+	default:
+		p.status = PlaybackStatusFailed
+		p.reason = reason
+		p.finishedAt = &nowMs
+		return nil
+	}
+}
+
+// IncrementCompletedClips は完了クリップ数を 1 加算する。
+func (p *Playback) IncrementCompletedClips() {
+	p.completedClips++
+}
+
+func (p *Playback) Status() PlaybackStatus { return p.status }
+func (p *Playback) Reason() string         { return p.reason }
+func (p *Playback) CreatedAt() time.Time   { return p.createdAt }
+func (p *Playback) ClipCount() int         { return p.clipCount }
+func (p *Playback) CompletedClips() int    { return p.completedClips }
+func (p *Playback) StartedAt() *int64      { return p.startedAt }
+func (p *Playback) FinishedAt() *int64     { return p.finishedAt }

--- a/internal/domain/entity/playback_test.go
+++ b/internal/domain/entity/playback_test.go
@@ -1,0 +1,248 @@
+package entity_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+func TestNewPlayback(t *testing.T) {
+	now := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	p := entity.NewPlayback(3, now)
+
+	if p.Status() != entity.PlaybackStatusPending {
+		t.Errorf("expected status=pending, got %s", p.Status())
+	}
+	if p.ClipCount() != 3 {
+		t.Errorf("expected clipCount=3, got %d", p.ClipCount())
+	}
+	if p.CompletedClips() != 0 {
+		t.Errorf("expected completedClips=0, got %d", p.CompletedClips())
+	}
+	if !p.CreatedAt().Equal(now) {
+		t.Errorf("expected createdAt=%v, got %v", now, p.CreatedAt())
+	}
+	if p.StartedAt() != nil {
+		t.Errorf("expected startedAt=nil, got %v", p.StartedAt())
+	}
+	if p.FinishedAt() != nil {
+		t.Errorf("expected finishedAt=nil, got %v", p.FinishedAt())
+	}
+}
+
+func TestPlayback_MarkPlaying(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(*entity.Playback)
+		wantErr    bool
+		wantStatus entity.PlaybackStatus
+	}{
+		{
+			name:       "pending→playing は成功する",
+			setup:      func(_ *entity.Playback) {},
+			wantErr:    false,
+			wantStatus: entity.PlaybackStatusPlaying,
+		},
+		{
+			name: "playing→playing はエラー",
+			setup: func(p *entity.Playback) {
+				_ = p.MarkPlaying(1000)
+			},
+			wantErr:    true,
+			wantStatus: entity.PlaybackStatusPlaying,
+		},
+		{
+			name: "completed→playing はエラー",
+			setup: func(p *entity.Playback) {
+				_ = p.MarkCompleted(1000)
+			},
+			wantErr:    true,
+			wantStatus: entity.PlaybackStatusCompleted,
+		},
+		{
+			name: "failed→playing はエラー",
+			setup: func(p *entity.Playback) {
+				_ = p.MarkFailed("reason", 1000)
+			},
+			wantErr:    true,
+			wantStatus: entity.PlaybackStatusFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := entity.NewPlayback(1, time.Now())
+			tt.setup(p)
+
+			err := p.MarkPlaying(2000)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if p.StartedAt() == nil {
+					t.Error("expected startedAt to be set")
+				} else if *p.StartedAt() != 2000 {
+					t.Errorf("expected startedAt=2000, got %d", *p.StartedAt())
+				}
+			}
+			if p.Status() != tt.wantStatus {
+				t.Errorf("expected status=%s, got %s", tt.wantStatus, p.Status())
+			}
+		})
+	}
+}
+
+func TestPlayback_MarkCompleted(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(*entity.Playback)
+		wantErr    bool
+		wantStatus entity.PlaybackStatus
+	}{
+		{
+			name:       "pending→completed は成功する（無音モード）",
+			setup:      func(_ *entity.Playback) {},
+			wantErr:    false,
+			wantStatus: entity.PlaybackStatusCompleted,
+		},
+		{
+			name: "playing→completed は成功する",
+			setup: func(p *entity.Playback) {
+				_ = p.MarkPlaying(1000)
+			},
+			wantErr:    false,
+			wantStatus: entity.PlaybackStatusCompleted,
+		},
+		{
+			name: "completed→completed はエラー",
+			setup: func(p *entity.Playback) {
+				_ = p.MarkCompleted(1000)
+			},
+			wantErr:    true,
+			wantStatus: entity.PlaybackStatusCompleted,
+		},
+		{
+			name: "failed→completed はエラー",
+			setup: func(p *entity.Playback) {
+				_ = p.MarkFailed("reason", 1000)
+			},
+			wantErr:    true,
+			wantStatus: entity.PlaybackStatusFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := entity.NewPlayback(1, time.Now())
+			tt.setup(p)
+
+			err := p.MarkCompleted(2000)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if p.FinishedAt() == nil {
+					t.Error("expected finishedAt to be set")
+				} else if *p.FinishedAt() != 2000 {
+					t.Errorf("expected finishedAt=2000, got %d", *p.FinishedAt())
+				}
+			}
+			if p.Status() != tt.wantStatus {
+				t.Errorf("expected status=%s, got %s", tt.wantStatus, p.Status())
+			}
+		})
+	}
+}
+
+func TestPlayback_MarkFailed(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(*entity.Playback)
+		wantErr    bool
+		wantStatus entity.PlaybackStatus
+	}{
+		{
+			name:       "pending→failed は成功する",
+			setup:      func(_ *entity.Playback) {},
+			wantErr:    false,
+			wantStatus: entity.PlaybackStatusFailed,
+		},
+		{
+			name: "playing→failed は成功する",
+			setup: func(p *entity.Playback) {
+				_ = p.MarkPlaying(1000)
+			},
+			wantErr:    false,
+			wantStatus: entity.PlaybackStatusFailed,
+		},
+		{
+			name: "completed→failed はエラー",
+			setup: func(p *entity.Playback) {
+				_ = p.MarkCompleted(1000)
+			},
+			wantErr:    true,
+			wantStatus: entity.PlaybackStatusCompleted,
+		},
+		{
+			name: "failed→failed はエラー",
+			setup: func(p *entity.Playback) {
+				_ = p.MarkFailed("first", 1000)
+			},
+			wantErr:    true,
+			wantStatus: entity.PlaybackStatusFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := entity.NewPlayback(1, time.Now())
+			tt.setup(p)
+
+			err := p.MarkFailed("test reason", 2000)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if p.FinishedAt() == nil {
+					t.Error("expected finishedAt to be set")
+				} else if *p.FinishedAt() != 2000 {
+					t.Errorf("expected finishedAt=2000, got %d", *p.FinishedAt())
+				}
+				if p.Reason() != "test reason" {
+					t.Errorf("expected reason='test reason', got %q", p.Reason())
+				}
+			}
+			if p.Status() != tt.wantStatus {
+				t.Errorf("expected status=%s, got %s", tt.wantStatus, p.Status())
+			}
+		})
+	}
+}
+
+func TestPlayback_IncrementCompletedClips(t *testing.T) {
+	p := entity.NewPlayback(3, time.Now())
+	_ = p.MarkPlaying(1000)
+
+	p.IncrementCompletedClips()
+	p.IncrementCompletedClips()
+
+	if p.CompletedClips() != 2 {
+		t.Errorf("expected completedClips=2, got %d", p.CompletedClips())
+	}
+}

--- a/internal/infra/export_test.go
+++ b/internal/infra/export_test.go
@@ -15,7 +15,7 @@ func (p *HTTPStreamPlayer) PlaybackStatus(id string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return string(state.status), true
+	return string(state.Status()), true
 }
 
 // PrunePlaybacks はテスト用に TTL 切れの playback state を削除する。

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -961,15 +961,18 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 		http.Error(w, fmt.Sprintf("clips count exceeds limit %d", maxClipsPerBatch), http.StatusBadRequest)
 		return
 	}
-	for i, clip := range req.Clips {
-		if clip.Text == "" {
+	clips := make([]entity.Clip, len(req.Clips))
+	for i, c := range req.Clips {
+		if c.Text == "" {
 			http.Error(w, fmt.Sprintf("clips[%d].text must not be empty", i), http.StatusBadRequest)
 			return
 		}
-		if _, err := entity.NewSpeakerID(clip.SpeakerID); err != nil {
+		speakerID, err := entity.NewSpeakerID(c.SpeakerID)
+		if err != nil {
 			http.Error(w, fmt.Sprintf("clips[%d].speaker_id: %v", i, err), http.StatusBadRequest)
 			return
 		}
+		clips[i] = entity.NewClip(c.Text, speakerID, c.Speed, c.Pitch, c.Intonation)
 	}
 
 	playbackID, err := newUUIDv4()
@@ -999,10 +1002,6 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_, _ = w.Write(payload)
 		return
-	}
-	clips := make([]entity.Clip, len(req.Clips))
-	for i, c := range req.Clips {
-		clips[i] = entity.NewClip(c.Text, entity.MustNewSpeakerID(c.SpeakerID), c.Speed, c.Pitch, c.Intonation)
 	}
 	batch := playBatch{playbackID: playbackID, clips: clips}
 	select {
@@ -1073,6 +1072,9 @@ func (p *HTTPStreamPlayer) initPlayback(id string, clipCount int) {
 	defer p.playbackMu.Unlock()
 	p.playbacks[id] = entity.NewPlayback(clipCount, p.nowFunc())
 }
+
+// startPlayback/completePlayback/failPlayback は TTL GC で pruned されたエントリへの
+// 遅延更新を無視するため、遷移エラーを破棄している。
 
 func (p *HTTPStreamPlayer) startPlayback(id string) {
 	p.playbackMu.Lock()

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -94,8 +94,8 @@ type HTTPStreamPlayer struct {
 
 	// playbackMu は playbacks マップの排他制御。
 	playbackMu sync.Mutex
-	// playbacks は playback_id → state の in-memory store。TTL 1 時間で GC される。
-	playbacks map[string]*playbackStateRecord
+	// playbacks は playback_id → Playback エンティティの in-memory store。TTL 1 時間で GC される。
+	playbacks map[string]*entity.Playback
 }
 
 var (
@@ -134,31 +134,10 @@ const (
 	playbackGCInterval = 5 * time.Minute
 )
 
-// playbackStatus は playback の処理状態。
-type playbackStatus string
-
-const (
-	playbackStatusPending   playbackStatus = "pending"
-	playbackStatusPlaying   playbackStatus = "playing"
-	playbackStatusCompleted playbackStatus = "completed"
-	playbackStatusFailed    playbackStatus = "failed"
-)
-
-// playbackStateRecord は 1 バッチの処理状態を保持する。
-type playbackStateRecord struct {
-	status         playbackStatus
-	reason         string
-	createdAt      time.Time
-	clipCount      int
-	completedClips int
-	startedAt      *int64 // Unix milliseconds
-	finishedAt     *int64 // Unix milliseconds
-}
-
 // playBatch は worker への投入単位。
 type playBatch struct {
 	playbackID string
-	clips      []ViewerClip
+	clips      []entity.Clip
 }
 
 var (
@@ -340,7 +319,7 @@ func NewHTTPStreamPlayer(addr string, staticFS fs.FS, opts ...HTTPStreamOption) 
 		nowFunc:          time.Now,
 		silentInterval:   defaultSilentInterval,
 		batchQueue:       make(chan playBatch, batchQueueCapacity),
-		playbacks:        make(map[string]*playbackStateRecord),
+		playbacks:        make(map[string]*entity.Playback),
 		prefetchLeadTime: defaultPrefetchLeadTime,
 	}
 	for _, opt := range opts {
@@ -481,11 +460,11 @@ func (p *HTTPStreamPlayer) SetSilent(reason string) {
 	p.silentReason = reason
 }
 
-// clipToPlayMeta は ViewerClip を app.PlayMeta に変換する。
-func clipToPlayMeta(clip ViewerClip) app.PlayMeta {
+// clipToPlayMeta は entity.Clip を app.PlayMeta に変換する。
+func clipToPlayMeta(clip entity.Clip) app.PlayMeta {
 	return app.PlayMeta{
 		Text:       clip.Text,
-		SpeakerID:  entity.MustNewSpeakerID(clip.SpeakerID),
+		SpeakerID:  clip.SpeakerID,
 		Speed:      clip.Speed,
 		Pitch:      clip.Pitch,
 		Intonation: clip.Intonation,
@@ -1009,7 +988,7 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 	p.initPlayback(playbackID, clipCount)
 
 	if silent {
-		p.setPlaybackStatus(playbackID, playbackStatusCompleted, "")
+		p.completePlayback(playbackID)
 		resp := ViewerPlayResponse{
 			PlaybackID:   playbackID,
 			ClipCount:    clipCount,
@@ -1021,7 +1000,11 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 		_, _ = w.Write(payload)
 		return
 	}
-	batch := playBatch{playbackID: playbackID, clips: req.Clips}
+	clips := make([]entity.Clip, len(req.Clips))
+	for i, c := range req.Clips {
+		clips[i] = entity.NewClip(c.Text, entity.MustNewSpeakerID(c.SpeakerID), c.Speed, c.Pitch, c.Intonation)
+	}
+	batch := playBatch{playbackID: playbackID, clips: clips}
 	select {
 	case p.batchQueue <- batch:
 	default:
@@ -1088,37 +1071,44 @@ func (p *HTTPStreamPlayer) handleAPIPreviewClip(w http.ResponseWriter, r *http.R
 func (p *HTTPStreamPlayer) initPlayback(id string, clipCount int) {
 	p.playbackMu.Lock()
 	defer p.playbackMu.Unlock()
-	p.playbacks[id] = &playbackStateRecord{
-		createdAt: p.nowFunc(),
-		clipCount: clipCount,
-		status:    playbackStatusPending,
-	}
+	p.playbacks[id] = entity.NewPlayback(clipCount, p.nowFunc())
 }
 
-func (p *HTTPStreamPlayer) setPlaybackStatus(id string, status playbackStatus, reason string) {
+func (p *HTTPStreamPlayer) startPlayback(id string) {
 	p.playbackMu.Lock()
 	defer p.playbackMu.Unlock()
-	state, ok := p.playbacks[id]
+	pb, ok := p.playbacks[id]
 	if !ok {
-		// pruned or unregistered; ignore late updates from workers.
 		return
 	}
-	state.status = status
-	state.reason = reason
-	now := p.nowFunc().UnixMilli()
-	if status == playbackStatusPlaying && state.startedAt == nil {
-		state.startedAt = &now
+	_ = pb.MarkPlaying(p.nowFunc().UnixMilli())
+}
+
+func (p *HTTPStreamPlayer) completePlayback(id string) {
+	p.playbackMu.Lock()
+	defer p.playbackMu.Unlock()
+	pb, ok := p.playbacks[id]
+	if !ok {
+		return
 	}
-	if (status == playbackStatusCompleted || status == playbackStatusFailed) && state.finishedAt == nil {
-		state.finishedAt = &now
+	_ = pb.MarkCompleted(p.nowFunc().UnixMilli())
+}
+
+func (p *HTTPStreamPlayer) failPlayback(id string, reason string) {
+	p.playbackMu.Lock()
+	defer p.playbackMu.Unlock()
+	pb, ok := p.playbacks[id]
+	if !ok {
+		return
 	}
+	_ = pb.MarkFailed(reason, p.nowFunc().UnixMilli())
 }
 
 func (p *HTTPStreamPlayer) incrementCompletedClips(id string) {
 	p.playbackMu.Lock()
 	defer p.playbackMu.Unlock()
-	if state, ok := p.playbacks[id]; ok {
-		state.completedClips++
+	if pb, ok := p.playbacks[id]; ok {
+		pb.IncrementCompletedClips()
 	}
 }
 
@@ -1145,12 +1135,12 @@ func (p *HTTPStreamPlayer) handleAPIPlayback(w http.ResponseWriter, r *http.Requ
 	} else {
 		resp = ViewerPlaybackResponse{
 			ID:             id,
-			Status:         string(state.status),
-			ClipCount:      state.clipCount,
-			CompletedClips: state.completedClips,
-			StartedAt:      state.startedAt,
-			FinishedAt:     state.finishedAt,
-			FailedReason:   state.reason,
+			Status:         string(state.Status()),
+			ClipCount:      state.ClipCount(),
+			CompletedClips: state.CompletedClips(),
+			StartedAt:      state.StartedAt(),
+			FinishedAt:     state.FinishedAt(),
+			FailedReason:   state.Reason(),
 		}
 	}
 	p.playbackMu.Unlock()
@@ -1185,7 +1175,7 @@ type synthResult struct {
 // タイミングで前倒し broadcast する。
 // メモリ増加: 最大 1 本分の追加 WAV バッファを保持する（VOICEVOX 負荷も +1 並列）。
 func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
-	p.setPlaybackStatus(batch.playbackID, playbackStatusPlaying, "")
+	p.startPlayback(batch.playbackID)
 
 	// 前のイテレーションで前倒し broadcast 済みの WAV（nil なら通常合成）。
 	var prefetchedWAV []byte
@@ -1216,14 +1206,13 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 			nextClip := batch.clips[i+1]
 			nextSynthCh = make(chan synthResult, 1)
 			go func() {
-				nextSpeakerID := entity.MustNewSpeakerID(nextClip.SpeakerID)
-				q2, err := p.voicevoxClient.CreateQuery(ctx, nextClip.Text, nextSpeakerID)
+				q2, err := p.voicevoxClient.CreateQuery(ctx, nextClip.Text, nextClip.SpeakerID)
 				if err != nil {
 					nextSynthCh <- synthResult{err: err}
 					return
 				}
 				q2o := q2.WithOverrides(entity.SynthOverrides{Speed: nextClip.Speed, Pitch: nextClip.Pitch, Intonation: nextClip.Intonation})
-				w, err := p.voicevoxClient.Synthesize(ctx, &q2o, nextSpeakerID)
+				w, err := p.voicevoxClient.Synthesize(ctx, &q2o, nextClip.SpeakerID)
 				nextSynthCh <- synthResult{wav: w, err: err}
 			}()
 		}
@@ -1251,25 +1240,24 @@ func (p *HTTPStreamPlayer) processBatch(ctx context.Context, batch playBatch) {
 		p.incrementCompletedClips(batch.playbackID)
 	}
 
-	p.setPlaybackStatus(batch.playbackID, playbackStatusCompleted, "")
+	p.completePlayback(batch.playbackID)
 }
 
 // synthesizeAndPlay は clip を合成して Play() でブロードキャストする。
 // エラー時は playback を failed に遷移させて error を返す。
-func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID string, clip ViewerClip) ([]byte, error) {
-	clipSpeakerID := entity.MustNewSpeakerID(clip.SpeakerID)
-	query, err := p.voicevoxClient.CreateQuery(ctx, clip.Text, clipSpeakerID)
+func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID string, clip entity.Clip) ([]byte, error) {
+	query, err := p.voicevoxClient.CreateQuery(ctx, clip.Text, clip.SpeakerID)
 	if err != nil {
-		p.logger.Error("worker CreateQuery failed", "playbackID", playbackID, "speakerID", clip.SpeakerID, "error", err)
-		p.setPlaybackStatus(playbackID, playbackStatusFailed, err.Error())
+		p.logger.Error("worker CreateQuery failed", "playbackID", playbackID, "speakerID", clip.SpeakerID.Value(), "error", err)
+		p.failPlayback(playbackID, err.Error())
 		return nil, err
 	}
 
 	q := query.WithOverrides(entity.SynthOverrides{Speed: clip.Speed, Pitch: clip.Pitch, Intonation: clip.Intonation})
-	wav, err := p.voicevoxClient.Synthesize(ctx, &q, clipSpeakerID)
+	wav, err := p.voicevoxClient.Synthesize(ctx, &q, clip.SpeakerID)
 	if err != nil {
-		p.logger.Error("worker Synthesize failed", "playbackID", playbackID, "speakerID", clip.SpeakerID, "error", err)
-		p.setPlaybackStatus(playbackID, playbackStatusFailed, err.Error())
+		p.logger.Error("worker Synthesize failed", "playbackID", playbackID, "speakerID", clip.SpeakerID.Value(), "error", err)
+		p.failPlayback(playbackID, err.Error())
 		return nil, err
 	}
 
@@ -1277,8 +1265,8 @@ func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID str
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		p.logger.Error("worker Play failed", "playbackID", playbackID, "speakerID", clip.SpeakerID, "error", pErr)
-		p.setPlaybackStatus(playbackID, playbackStatusFailed, pErr.Error())
+		p.logger.Error("worker Play failed", "playbackID", playbackID, "speakerID", clip.SpeakerID.Value(), "error", pErr)
+		p.failPlayback(playbackID, pErr.Error())
 		return nil, pErr
 	}
 	return wav, nil
@@ -1288,7 +1276,7 @@ func (p *HTTPStreamPlayer) synthesizeAndPlay(ctx context.Context, playbackID str
 // nextClip を前倒し broadcast する。broadcast に成功した場合は nextClip の WAV を返す（nil なら
 // タイムアウトで broadcast スキップ）。エラー時は playback を failed に遷移させて error を返す。
 // goroutine leak を防ぐため nextSynthCh は buffered channel (cap=1) であること。
-func (p *HTTPStreamPlayer) prefetchSleep(ctx context.Context, playbackID string, duration time.Duration, nextSynthCh chan synthResult, nextClip ViewerClip) ([]byte, error) {
+func (p *HTTPStreamPlayer) prefetchSleep(ctx context.Context, playbackID string, duration time.Duration, nextSynthCh chan synthResult, nextClip entity.Clip) ([]byte, error) {
 	timer1 := time.NewTimer(duration - p.prefetchLeadTime)
 	select {
 	case <-timer1.C:
@@ -1310,7 +1298,7 @@ func (p *HTTPStreamPlayer) prefetchSleep(ctx context.Context, playbackID string,
 				<-remainTimer.C
 			}
 			p.logger.Error("worker prefetch Synthesize failed", "playbackID", playbackID, "error", result.err)
-			p.setPlaybackStatus(playbackID, playbackStatusFailed, result.err.Error())
+			p.failPlayback(playbackID, result.err.Error())
 			return nil, result.err
 		}
 		if pErr := p.Play(ctx, result.wav, clipToPlayMeta(nextClip)); pErr != nil {
@@ -1321,7 +1309,7 @@ func (p *HTTPStreamPlayer) prefetchSleep(ctx context.Context, playbackID string,
 				return nil, ctx.Err()
 			}
 			p.logger.Error("worker prefetch Play failed", "playbackID", playbackID, "error", pErr)
-			p.setPlaybackStatus(playbackID, playbackStatusFailed, pErr.Error())
+			p.failPlayback(playbackID, pErr.Error())
 			return nil, pErr
 		}
 		select {
@@ -1362,7 +1350,7 @@ func (p *HTTPStreamPlayer) prunePlaybacks() {
 	p.playbackMu.Lock()
 	defer p.playbackMu.Unlock()
 	for id, state := range p.playbacks {
-		if state.createdAt.Before(cutoff) {
+		if state.CreatedAt().Before(cutoff) {
 			delete(p.playbacks, id)
 		}
 	}


### PR DESCRIPTION
## Summary

- `entity.Playback` エンティティを新設し、状態遷移（pending/playing/completed/failed）とメソッド（`MarkPlaying` / `MarkCompleted` / `MarkFailed`）をドメイン層で管理するようにした
- 不正な状態遷移（completed/failed からの再遷移など）はエラーを返して防止する
- `entity.Clip` 値オブジェクトを新設し、infra 内部処理での `ViewerClip` 利用を置き換えた（HTTP 境界の JSON 変換は引き続き infra の `ViewerClip` が担当）
- `internal/infra/http_stream_player.go` から `playbackStatus` 型・`playbackStateRecord` 構造体を削除し、ドメインエンティティを保持する薄い層に変更した
- API 境界（`handleAPIPlay`）でバリデーションと `entity.Clip` 変換を単一ループに統合し `SpeakerID` の二重構築を解消した

## Test plan

- [x] `entity.Playback` の全状態遷移パターンをテーブル駆動テストでカバー（`playback_test.go`）
- [x] `entity.Clip` の生成テストを追加（`clip_test.go`）
- [x] `go test ./...` で既存テストが全てパス（`cmd` パッケージの 2 件は変更前から失敗している既存の flaky テスト）
- [x] `gofmt` / `golangci-lint` 問題なし

Closes #559

---
🤖 Generated with [Claude Code](https://claude.ai/code)
