### PR TITLE
refactor(domain): HistoryRecord をドメイン層へ切り出す

### DIFF
--- a/internal/domain/entity/history_entry.go
+++ b/internal/domain/entity/history_entry.go
@@ -1,0 +1,30 @@
+package entity
+
+// HistoryEntry は再生履歴1件のドメインオブジェクト。
+// 旧形式（SpeakerID=0, Speed/Pitch/Intonation=nil）も有効な状態として受け入れる。
+// 旧形式は永続化ファイルに SpeakerID/Speed/Pitch/Intonation が欠落していた場合を指し、
+// ゼロ値・nil として扱うことで後方互換を維持する。
+type HistoryEntry struct {
+	Text        string
+	SpeakerName string
+	StyleName   string
+	Timestamp   int64
+	SpeakerID   SpeakerID
+	Speed       *float64
+	Pitch       *float64
+	Intonation  *float64
+}
+
+// NewHistoryEntry は HistoryEntry を生成する。
+func NewHistoryEntry(text, speakerName, styleName string, timestamp int64, speakerID SpeakerID, speed, pitch, intonation *float64) HistoryEntry {
+	return HistoryEntry{
+		Text:        text,
+		SpeakerName: speakerName,
+		StyleName:   styleName,
+		Timestamp:   timestamp,
+		SpeakerID:   speakerID,
+		Speed:       speed,
+		Pitch:       pitch,
+		Intonation:  intonation,
+	}
+}

--- a/internal/domain/entity/history_entry_test.go
+++ b/internal/domain/entity/history_entry_test.go
@@ -1,0 +1,62 @@
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+func TestNewHistoryEntry_StoresAllFields(t *testing.T) {
+	speakerID := entity.MustNewSpeakerID(3)
+	speed := ptr(1.2)
+	pitch := ptr(0.05)
+	intonation := ptr(1.5)
+
+	entry := entity.NewHistoryEntry("テスト", "ずんだもん", "ノーマル", 1000, speakerID, speed, pitch, intonation)
+
+	if entry.Text != "テスト" {
+		t.Errorf("Text: got %q, want %q", entry.Text, "テスト")
+	}
+	if entry.SpeakerName != "ずんだもん" {
+		t.Errorf("SpeakerName: got %q, want %q", entry.SpeakerName, "ずんだもん")
+	}
+	if entry.StyleName != "ノーマル" {
+		t.Errorf("StyleName: got %q, want %q", entry.StyleName, "ノーマル")
+	}
+	if entry.Timestamp != 1000 {
+		t.Errorf("Timestamp: got %d, want %d", entry.Timestamp, 1000)
+	}
+	if entry.SpeakerID != speakerID {
+		t.Errorf("SpeakerID: got %v, want %v", entry.SpeakerID, speakerID)
+	}
+	if entry.Speed != speed {
+		t.Errorf("Speed: got %v, want %v", entry.Speed, speed)
+	}
+	if entry.Pitch != pitch {
+		t.Errorf("Pitch: got %v, want %v", entry.Pitch, pitch)
+	}
+	if entry.Intonation != intonation {
+		t.Errorf("Intonation: got %v, want %v", entry.Intonation, intonation)
+	}
+}
+
+// TestNewHistoryEntry_LegacyFormat は旧形式（SpeakerID=0, Speed/Pitch/Intonation=nil）が
+// 有効な HistoryEntry として表現できることを確認する。
+func TestNewHistoryEntry_LegacyFormat(t *testing.T) {
+	speakerID := entity.MustNewSpeakerID(0)
+
+	entry := entity.NewHistoryEntry("旧テキスト", "話者#0", "", 500, speakerID, nil, nil, nil)
+
+	if entry.SpeakerID.Value() != 0 {
+		t.Errorf("SpeakerID.Value(): got %d, want 0", entry.SpeakerID.Value())
+	}
+	if entry.Speed != nil {
+		t.Errorf("Speed: got %v, want nil", entry.Speed)
+	}
+	if entry.Pitch != nil {
+		t.Errorf("Pitch: got %v, want nil", entry.Pitch)
+	}
+	if entry.Intonation != nil {
+		t.Errorf("Intonation: got %v, want nil", entry.Intonation)
+	}
+}

--- a/internal/infra/history_record_mapper_test.go
+++ b/internal/infra/history_record_mapper_test.go
@@ -1,0 +1,157 @@
+package infra
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/domain/entity"
+)
+
+func TestHistoryRecord_ToDomain_FullFields(t *testing.T) {
+	speed := 1.2
+	pitch := 0.05
+	intonation := 1.5
+	rec := historyRecord{
+		Text:        "テスト",
+		SpeakerName: "ずんだもん",
+		StyleName:   "ノーマル",
+		Timestamp:   1000,
+		SpeakerID:   3,
+		Speed:       &speed,
+		Pitch:       &pitch,
+		Intonation:  &intonation,
+	}
+
+	entry := rec.toDomain()
+
+	if entry.Text != "テスト" {
+		t.Errorf("Text: got %q, want %q", entry.Text, "テスト")
+	}
+	if entry.SpeakerName != "ずんだもん" {
+		t.Errorf("SpeakerName: got %q, want %q", entry.SpeakerName, "ずんだもん")
+	}
+	if entry.StyleName != "ノーマル" {
+		t.Errorf("StyleName: got %q, want %q", entry.StyleName, "ノーマル")
+	}
+	if entry.Timestamp != 1000 {
+		t.Errorf("Timestamp: got %d, want 1000", entry.Timestamp)
+	}
+	if entry.SpeakerID.Value() != 3 {
+		t.Errorf("SpeakerID: got %d, want 3", entry.SpeakerID.Value())
+	}
+	if entry.Speed == nil || *entry.Speed != speed {
+		t.Errorf("Speed: got %v, want %v", entry.Speed, &speed)
+	}
+	if entry.Pitch == nil || *entry.Pitch != pitch {
+		t.Errorf("Pitch: got %v, want %v", entry.Pitch, &pitch)
+	}
+	if entry.Intonation == nil || *entry.Intonation != intonation {
+		t.Errorf("Intonation: got %v, want %v", entry.Intonation, &intonation)
+	}
+}
+
+// TestHistoryRecord_ToDomain_LegacyFormat は旧形式（SpeakerID=0, Speed/Pitch/Intonation=nil）の
+// 変換を検証する。旧形式ファイルは json.Unmarshal でゼロ値・nil として読み込まれる。
+func TestHistoryRecord_ToDomain_LegacyFormat(t *testing.T) {
+	rec := historyRecord{
+		Text:        "旧テキスト",
+		SpeakerName: "話者#0",
+		StyleName:   "",
+		Timestamp:   500,
+		SpeakerID:   0,
+		Speed:       nil,
+		Pitch:       nil,
+		Intonation:  nil,
+	}
+
+	entry := rec.toDomain()
+
+	if entry.SpeakerID.Value() != 0 {
+		t.Errorf("SpeakerID: got %d, want 0", entry.SpeakerID.Value())
+	}
+	if entry.Speed != nil {
+		t.Errorf("Speed: got %v, want nil", entry.Speed)
+	}
+	if entry.Pitch != nil {
+		t.Errorf("Pitch: got %v, want nil", entry.Pitch)
+	}
+	if entry.Intonation != nil {
+		t.Errorf("Intonation: got %v, want nil", entry.Intonation)
+	}
+}
+
+func TestHistoryRecordFromDomain_FullFields(t *testing.T) {
+	speed := 1.2
+	pitch := 0.05
+	intonation := 1.5
+	entry := entity.NewHistoryEntry("テスト", "ずんだもん", "ノーマル", 1000, entity.MustNewSpeakerID(3), &speed, &pitch, &intonation)
+
+	rec := historyRecordFromDomain(entry)
+
+	if rec.Text != "テスト" {
+		t.Errorf("Text: got %q, want %q", rec.Text, "テスト")
+	}
+	if rec.SpeakerName != "ずんだもん" {
+		t.Errorf("SpeakerName: got %q, want %q", rec.SpeakerName, "ずんだもん")
+	}
+	if rec.StyleName != "ノーマル" {
+		t.Errorf("StyleName: got %q, want %q", rec.StyleName, "ノーマル")
+	}
+	if rec.Timestamp != 1000 {
+		t.Errorf("Timestamp: got %d, want 1000", rec.Timestamp)
+	}
+	if rec.SpeakerID != 3 {
+		t.Errorf("SpeakerID: got %d, want 3", rec.SpeakerID)
+	}
+	if rec.Speed == nil || *rec.Speed != speed {
+		t.Errorf("Speed: got %v, want %v", rec.Speed, &speed)
+	}
+	if rec.Pitch == nil || *rec.Pitch != pitch {
+		t.Errorf("Pitch: got %v, want %v", rec.Pitch, &pitch)
+	}
+	if rec.Intonation == nil || *rec.Intonation != intonation {
+		t.Errorf("Intonation: got %v, want %v", rec.Intonation, &intonation)
+	}
+}
+
+func TestHistoryEntryFromClipEvent_ConvertsAllFields(t *testing.T) {
+	speed := 1.2
+	pitch := 0.05
+	intonation := 1.5
+	ev := clipEvent{
+		Text:        "テスト",
+		SpeakerName: "ずんだもん",
+		StyleName:   "ノーマル",
+		Timestamp:   1000,
+		SpeakerID:   3,
+		Speed:       &speed,
+		Pitch:       &pitch,
+		Intonation:  &intonation,
+	}
+
+	entry := historyEntryFromClipEvent(ev)
+
+	if entry.Text != "テスト" {
+		t.Errorf("Text: got %q, want %q", entry.Text, "テスト")
+	}
+	if entry.SpeakerName != "ずんだもん" {
+		t.Errorf("SpeakerName: got %q, want %q", entry.SpeakerName, "ずんだもん")
+	}
+	if entry.StyleName != "ノーマル" {
+		t.Errorf("StyleName: got %q, want %q", entry.StyleName, "ノーマル")
+	}
+	if entry.Timestamp != 1000 {
+		t.Errorf("Timestamp: got %d, want 1000", entry.Timestamp)
+	}
+	if entry.SpeakerID.Value() != 3 {
+		t.Errorf("SpeakerID: got %d, want 3", entry.SpeakerID.Value())
+	}
+	if entry.Speed == nil || *entry.Speed != speed {
+		t.Errorf("Speed: got %v, want %v", entry.Speed, &speed)
+	}
+	if entry.Pitch == nil || *entry.Pitch != pitch {
+		t.Errorf("Pitch: got %v, want %v", entry.Pitch, &pitch)
+	}
+	if entry.Intonation == nil || *entry.Intonation != intonation {
+		t.Errorf("Intonation: got %v, want %v", entry.Intonation, &intonation)
+	}
+}

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -161,6 +161,36 @@ type historyRecord struct {
 	Intonation  *float64 `json:"intonation,omitempty"`
 }
 
+// historyEntryFromClipEvent は clipEvent を entity.HistoryEntry に変換する。
+// clipEvent.SpeakerID は entity.SpeakerID.Value() から派生するため常に非負であり、
+// NewSpeakerID のエラーは無視して安全に使用できる。
+func historyEntryFromClipEvent(ev clipEvent) entity.HistoryEntry {
+	speakerID, _ := entity.NewSpeakerID(ev.SpeakerID)
+	return entity.NewHistoryEntry(ev.Text, ev.SpeakerName, ev.StyleName, ev.Timestamp, speakerID, ev.Speed, ev.Pitch, ev.Intonation)
+}
+
+// toDomain は historyRecord を entity.HistoryEntry に変換する。
+// 旧形式（SpeakerID=0, Speed/Pitch/Intonation=nil）は json.Unmarshal で
+// ゼロ値・nil として読み込まれた値をそのまま entity.HistoryEntry に格納する。
+func (r historyRecord) toDomain() entity.HistoryEntry {
+	speakerID, _ := entity.NewSpeakerID(r.SpeakerID)
+	return entity.NewHistoryEntry(r.Text, r.SpeakerName, r.StyleName, r.Timestamp, speakerID, r.Speed, r.Pitch, r.Intonation)
+}
+
+// historyRecordFromDomain は entity.HistoryEntry を historyRecord に変換する。
+func historyRecordFromDomain(e entity.HistoryEntry) historyRecord {
+	return historyRecord{
+		Text:        e.Text,
+		SpeakerName: e.SpeakerName,
+		StyleName:   e.StyleName,
+		Timestamp:   e.Timestamp,
+		SpeakerID:   e.SpeakerID.Value(),
+		Speed:       e.Speed,
+		Pitch:       e.Pitch,
+		Intonation:  e.Intonation,
+	}
+}
+
 // apiHistoryResponse は GET /api/history のレスポンスペイロード。
 type apiHistoryResponse struct {
 	Entries []historyRecord `json:"entries"`
@@ -516,7 +546,7 @@ func (p *HTTPStreamPlayer) PlayText(ctx context.Context, meta app.PlayMeta) erro
 		p.logger.Warn("stream clip dropped for slow subscribers", "clipTimestamp", ts, "dropped", dropped)
 	}
 	p.logger.Info("stream clip delivered (silent)", "clipTimestamp", ts, "subscribers", n)
-	p.appendHistory(ev)
+	p.appendHistory(historyEntryFromClipEvent(ev))
 
 	if p.silentInterval <= 0 {
 		return nil
@@ -577,7 +607,7 @@ func (p *HTTPStreamPlayer) Play(ctx context.Context, wavData []byte, meta app.Pl
 		p.logger.Warn("stream clip dropped for slow subscribers", "clipTimestamp", ts, "dropped", dropped)
 	}
 	p.logger.Info("stream clip delivered", "clipTimestamp", ts, "subscribers", n)
-	p.appendHistory(ev)
+	p.appendHistory(historyEntryFromClipEvent(ev))
 	return nil
 }
 
@@ -922,11 +952,12 @@ func (p *HTTPStreamPlayer) handleAPICharacters(w http.ResponseWriter, _ *http.Re
 }
 
 func (p *HTTPStreamPlayer) handleAPIHistory(w http.ResponseWriter, _ *http.Request) {
-	entries := p.loadHistory(historyLoadSize)
-	if entries == nil {
-		entries = []historyRecord{}
+	domainEntries := p.loadHistory(historyLoadSize)
+	records := make([]historyRecord, 0, len(domainEntries))
+	for _, e := range domainEntries {
+		records = append(records, historyRecordFromDomain(e))
 	}
-	payload, err := json.Marshal(apiHistoryResponse{Entries: entries})
+	payload, err := json.Marshal(apiHistoryResponse{Entries: records})
 	if err != nil {
 		p.logger.Warn("failed to marshal api history", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -1370,7 +1401,7 @@ func newUUIDv4() (string, error) {
 }
 
 // loadHistory は今日の履歴ファイルから末尾 n 件を読み込む。
-func (p *HTTPStreamPlayer) loadHistory(n int) []historyRecord {
+func (p *HTTPStreamPlayer) loadHistory(n int) []entity.HistoryEntry {
 	if p.historyDir == "" {
 		return nil
 	}
@@ -1387,7 +1418,7 @@ func (p *HTTPStreamPlayer) loadHistory(n int) []historyRecord {
 	if len(lines) > n {
 		start = len(lines) - n
 	}
-	records := make([]historyRecord, 0, len(lines)-start)
+	entries := make([]entity.HistoryEntry, 0, len(lines)-start)
 	for _, line := range lines[start:] {
 		if line == "" {
 			continue
@@ -1397,9 +1428,9 @@ func (p *HTTPStreamPlayer) loadHistory(n int) []historyRecord {
 			p.logger.Warn("failed to parse history line", "error", err)
 			continue
 		}
-		records = append(records, r)
+		entries = append(entries, r.toDomain())
 	}
-	return records
+	return entries
 }
 
 // pruneOldHistory は historyDir 配下の 30日より古い *.jsonl を削除する（ベストエフォート）。
@@ -1437,21 +1468,12 @@ func (p *HTTPStreamPlayer) pruneOldHistory() {
 	}
 }
 
-// appendHistory は clip イベントを今日の履歴ファイルに追記する（ベストエフォート）。
-func (p *HTTPStreamPlayer) appendHistory(ev clipEvent) {
+// appendHistory は履歴エントリを今日の履歴ファイルに追記する（ベストエフォート）。
+func (p *HTTPStreamPlayer) appendHistory(entry entity.HistoryEntry) {
 	if p.historyDir == "" {
 		return
 	}
-	record := historyRecord{
-		Text:        ev.Text,
-		SpeakerName: ev.SpeakerName,
-		StyleName:   ev.StyleName,
-		Timestamp:   ev.Timestamp,
-		SpeakerID:   ev.SpeakerID,
-		Speed:       ev.Speed,
-		Pitch:       ev.Pitch,
-		Intonation:  ev.Intonation,
-	}
+	record := historyRecordFromDomain(entry)
 	data, err := json.Marshal(record)
 	if err != nil {
 		p.logger.Warn("failed to marshal history record", "error", err)


### PR DESCRIPTION
## Summary

- `entity.HistoryEntry` を新設し、再生履歴1件の値オブジェクトとしてドメイン層に表現する
- `infra` 側の `historyRecord` に `toDomain()` / `historyRecordFromDomain()` マッパーを追加し、永続化フォーマットとドメインオブジェクトの役割を明確に分離する
- 旧形式（SpeakerID=0, Speed/Pitch/Intonation=nil）の後方互換ルールをドメインレベルでドキュメント化する
- `loadHistory` の戻り型を `[]entity.HistoryEntry` に変更し、`appendHistory` の引数を `entity.HistoryEntry` に変更する

## Changes

| ファイル | 変更内容 |
|---|---|
| `entity/history_entry.go` | `HistoryEntry` 値オブジェクトと `NewHistoryEntry` コンストラクタを新設 |
| `entity/history_entry_test.go` | 通常形式・旧形式の2ケースをテスト |
| `infra/http_stream_player.go` | `toDomain()`, `historyRecordFromDomain()`, `historyEntryFromClipEvent()` 追加、`loadHistory`/`appendHistory` シグネチャ変更 |
| `infra/history_record_mapper_test.go` | マッパー関数の単体テストを追加 |

## Test plan

- [x] `go test ./internal/...` で全テスト GREEN を確認
- [x] `gofmt -l .` で差分なし
- [x] `golangci-lint run` で 0 issues

Closes #560

---
🤖 Generated with [Claude Code](https://claude.ai/code)
