### PR TITLE
fix(frontend-e2e): stream.spec.ts リングバッファ flaky テストを根本修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -228,7 +228,8 @@ export function App() {
           pitch: e.pitch,
           intonation: e.intonation,
         }));
-        setEntries(historyEntries);
+        // SSE クリップが先に届いていた場合は上書きしない。
+        setEntries((prev) => (prev.length === 0 ? historyEntries : prev));
       } catch (err) {
         console.error("failed to load api history", err);
       }

--- a/frontend/test/e2e/stream.spec.ts
+++ b/frontend/test/e2e/stream.spec.ts
@@ -76,13 +76,13 @@ test.describe("配信タブ: SSE と Timeline", () => {
       });
     }
 
-    // 最初の clip（baseTs）は破棄されているはず
-    const firstItem = page.locator(`[data-clip-timestamp="${baseTs}"]`);
-    await expect(firstItem).not.toBeVisible();
-
-    // 最後の clip（baseTs+20）は表示されているはず
+    // 最後の clip（baseTs+20）が表示されるまで待つ（21 件全受信・リングバッファ適用済みを確認）
     const lastItem = page.locator(`[data-clip-timestamp="${baseTs + 20}"]`);
     await expect(lastItem).toBeVisible();
+
+    // 最初の clip（baseTs）はリングバッファで破棄されているはず
+    const firstItem = page.locator(`[data-clip-timestamp="${baseTs}"]`);
+    await expect(firstItem).not.toBeVisible();
   });
 
   test("複数ブラウザへの同時 SSE 配信", async ({ browser, request }) => {


### PR DESCRIPTION
## Summary

- `frontend/src/App.tsx`: `/api/history` の fetch で使用していた直接 `setEntries(historyEntries)` を関数型更新に変更し、SSE クリップが先に届いていた場合に上書きされる race condition を修正
- `frontend/test/e2e/stream.spec.ts`: リングバッファテストのアサーション順序を `lastItem → firstItem` に変更し、21件全受信・リングバッファ適用済みを確認してから eviction をアサートするよう修正

## 根本原因

**Race condition 1: history fetch が SSE エントリを上書き**

`setEntries(historyEntries)` は非関数型更新のため、SSE クリップが先にタイムラインへ追加されていても、その後 history fetch が完了すると `setEntries([])` で全エントリが消えてしまう。

**Race condition 2: アサーション順序**

`firstItem.not.toBeVisible()` を先にチェックすると、SSE イベントがまだ DOM に反映されていない時点で「要素が存在しないため false」として即 pass してしまう。その後 `lastItem.toBeVisible()` が history wipe 等でタイムアウトする可能性があった。

## 修正内容

```tsx
// Before
setEntries(historyEntries);

// After
setEntries((prev) => (prev.length === 0 ? historyEntries : prev));
```

関数型更新により、SSE エントリが既に存在する場合は history で上書きしない。

```ts
// Before: 先に firstItem が存在しないことを確認 → 早期 pass のリスク
await expect(firstItem).not.toBeVisible();
await expect(lastItem).toBeVisible();

// After: 先に lastItem を待つ → 全イベント受信確認後に eviction チェック
await expect(lastItem).toBeVisible();
await expect(firstItem).not.toBeVisible();
```

## Test plan

- [ ] CI (Playwright e2e) が `stream.spec.ts` のリングバッファテストを安定してパスすることを確認

Closes #564

---
🤖 Generated with [Claude Code](https://claude.ai/code)
