### PR TITLE
feat(viewer): /api/play で未知の speaker_id を 400 で拒否し CLI にエラー伝播する

### DIFF
--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -1003,6 +1003,12 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 			http.Error(w, fmt.Sprintf("clips[%d].speaker_id: %v", i, err), http.StatusBadRequest)
 			return
 		}
+		if len(p.speakerLookup) > 0 {
+			if _, ok := p.speakerLookup[speakerID.Value()]; !ok {
+				http.Error(w, fmt.Sprintf("clips[%d].speaker_id: unknown speaker id %d", i, c.SpeakerID), http.StatusBadRequest)
+				return
+			}
+		}
 		clips[i] = entity.NewClip(c.Text, speakerID, c.Speed, c.Pitch, c.Intonation)
 	}
 

--- a/internal/infra/http_stream_player.go
+++ b/internal/infra/http_stream_player.go
@@ -993,6 +993,7 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	clips := make([]entity.Clip, len(req.Clips))
+	validateSpeaker := len(p.speakerLookup) > 0
 	for i, c := range req.Clips {
 		if c.Text == "" {
 			http.Error(w, fmt.Sprintf("clips[%d].text must not be empty", i), http.StatusBadRequest)
@@ -1003,7 +1004,7 @@ func (p *HTTPStreamPlayer) handleAPIPlay(w http.ResponseWriter, r *http.Request)
 			http.Error(w, fmt.Sprintf("clips[%d].speaker_id: %v", i, err), http.StatusBadRequest)
 			return
 		}
-		if len(p.speakerLookup) > 0 {
+		if validateSpeaker {
 			if _, ok := p.speakerLookup[speakerID.Value()]; !ok {
 				http.Error(w, fmt.Sprintf("clips[%d].speaker_id: unknown speaker id %d", i, c.SpeakerID), http.StatusBadRequest)
 				return

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -3022,7 +3022,6 @@ func TestHTTPStreamPlayer_APIPlay_BatchWithUnknownSpeakerIDRejected(t *testing.T
 		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
 	}
 	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub), WithSpeakerLookup(lookup))
-	// 1件目は既知ID、2件目は未知ID
 	body := bytes.NewBufferString(`{"clips":[{"text":"first","speaker_id":3},{"text":"second","speaker_id":9999}]}`)
 	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
 	if err != nil {
@@ -3041,7 +3040,6 @@ func TestHTTPStreamPlayer_APIPlay_BatchWithUnknownSpeakerIDRejected(t *testing.T
 func TestHTTPStreamPlayer_APIPlay_EmptyLookupSkipsValidation(t *testing.T) {
 	t.Parallel()
 	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
-	// speakerLookup を設定しない（空）
 	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
 	p.SetSilent("VOICEVOX接続失敗")
 	body := bytes.NewBufferString(`{"clips":[{"text":"hello","speaker_id":9999}]}`)

--- a/internal/infra/http_stream_player_test.go
+++ b/internal/infra/http_stream_player_test.go
@@ -2986,6 +2986,107 @@ func TestHTTPStreamPlayer_APIPlay_SilentModeSkipsBroadcast(t *testing.T) {
 	}
 }
 
+// --- #571 /api/play での未知 speaker_id バリデーション ---
+//
+// DONE: 未知 speaker_id を含む単一クリップで 400 + unknown speaker id  → TestHTTPStreamPlayer_APIPlay_UnknownSpeakerIDRejected
+// DONE: バッチ内 1 件のみ未知 ID で 400（playbackID 発行なし）          → TestHTTPStreamPlayer_APIPlay_BatchWithUnknownSpeakerIDRejected
+// DONE: speakerLookup 空では未知 ID でも 400 にならず silent レスポンス → TestHTTPStreamPlayer_APIPlay_EmptyLookupSkipsValidation
+// DONE: 既知 speaker_id では従来どおり 200 + playbackID               → TestHTTPStreamPlayer_APIPlay_KnownSpeakerIDAccepted
+
+func TestHTTPStreamPlayer_APIPlay_UnknownSpeakerIDRejected(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	lookup := map[int]entity.SpeakerStyleInfo{
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub), WithSpeakerLookup(lookup))
+	body := bytes.NewBufferString(`{"clips":[{"text":"hello","speaker_id":9999}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for unknown speaker_id, got %d", resp.StatusCode)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(respBody), "unknown speaker id") {
+		t.Errorf("expected body to contain 'unknown speaker id', got: %s", respBody)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_BatchWithUnknownSpeakerIDRejected(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	lookup := map[int]entity.SpeakerStyleInfo{
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub), WithSpeakerLookup(lookup))
+	// 1件目は既知ID、2件目は未知ID
+	body := bytes.NewBufferString(`{"clips":[{"text":"first","speaker_id":3},{"text":"second","speaker_id":9999}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for batch with unknown speaker_id, got %d", resp.StatusCode)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(respBody), "unknown speaker id") {
+		t.Errorf("expected body to contain 'unknown speaker id', got: %s", respBody)
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_EmptyLookupSkipsValidation(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	// speakerLookup を設定しない（空）
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub))
+	p.SetSilent("VOICEVOX接続失敗")
+	body := bytes.NewBufferString(`{"clips":[{"text":"hello","speaker_id":9999}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 (silent response), got %d", resp.StatusCode)
+	}
+	var result ViewerPlayResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !result.Silent {
+		t.Errorf("expected silent=true")
+	}
+}
+
+func TestHTTPStreamPlayer_APIPlay_KnownSpeakerIDAccepted(t *testing.T) {
+	t.Parallel()
+	stub := &testVoicevoxClient{wav: []byte("RIFFx")}
+	lookup := map[int]entity.SpeakerStyleInfo{
+		3: {SpeakerName: "ずんだもん", StyleName: "ノーマル"},
+	}
+	p := newStartedPlayerWithOpts(t, WithVoicevoxClient(stub), WithSpeakerLookup(lookup))
+	body := bytes.NewBufferString(`{"clips":[{"text":"hello","speaker_id":3}]}`)
+	resp, err := http.Post("http://"+p.Addr()+"/api/play", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for known speaker_id, got %d", resp.StatusCode)
+	}
+	var result ViewerPlayResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.PlaybackID == "" {
+		t.Errorf("expected non-empty playback_id")
+	}
+}
+
 // --- #488 GET /api/playback/{id} エンドポイント ---
 //
 // TODO: 未知 ID で unknown を返す                         → TestHTTPStreamPlayer_APIPlayback_UnknownID


### PR DESCRIPTION
## Summary

- `handleAPIPlay` に `speakerLookup` を使った speaker_id バリデーションを追加
- `speakerLookup` に存在しない speaker_id を含むリクエストを `400 Bad Request` で拒否し、`clips[i].speaker_id: unknown speaker id <ID>` を返す
- `speakerLookup` が空（VOICEVOX `/speakers` 取得失敗による silent モード）の場合はバリデーションをスキップし後方互換を維持
- これにより `vox-actor say --speaker <未知ID>` が exit 非0 でエラーを返すようになる

## Test plan

- [x] `go test ./internal/infra/...` がすべて PASS
- [ ] `vox-actor say --speaker 9999 "test"` が exit 非0 で `unknown speaker id` を含むエラーを返す（viewer 起動中・手動確認要）

Closes #571

---
🤖 Generated with [Claude Code](https://claude.ai/code)
