### PR TITLE
fix(viewer): say コマンドで viewer から返る 400 エラーの詳細を CLI に表示する

### DIFF
--- a/internal/infra/viewer_client.go
+++ b/internal/infra/viewer_client.go
@@ -15,6 +15,11 @@ const maxErrorBodySize = 1024
 
 const viewerDetectTimeout = 500 * time.Millisecond
 
+func readErrorBody(r io.Reader) string {
+	b, _ := io.ReadAll(io.LimitReader(r, maxErrorBodySize))
+	return strings.TrimSpace(string(b))
+}
+
 // DetectViewer checks if a viewer is running by reading the lock file and probing /api/status.
 // Returns (addr, true) if the viewer is reachable, ("", false) otherwise.
 func DetectViewer(lockPath string) (string, bool) {
@@ -114,9 +119,7 @@ func (c *ViewerAPIClient) GetPlayback(ctx context.Context, id string) (*ViewerPl
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
-		msg := strings.TrimSpace(string(body))
-		if msg != "" {
+		if msg := readErrorBody(resp.Body); msg != "" {
 			return nil, fmt.Errorf("GET /api/playback/%s returned %d: %s", id, resp.StatusCode, msg)
 		}
 		return nil, fmt.Errorf("GET /api/playback/%s returned %d", id, resp.StatusCode)
@@ -149,9 +152,7 @@ func (c *ViewerAPIClient) Play(ctx context.Context, req ViewerPlayRequest) (*Vie
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
-		msg := strings.TrimSpace(string(body))
-		if msg != "" {
+		if msg := readErrorBody(resp.Body); msg != "" {
 			return nil, fmt.Errorf("POST /api/play returned %d: %s", resp.StatusCode, msg)
 		}
 		return nil, fmt.Errorf("POST /api/play returned %d", resp.StatusCode)

--- a/internal/infra/viewer_client.go
+++ b/internal/infra/viewer_client.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 )
+
+const maxErrorBodySize = 1024
 
 const viewerDetectTimeout = 500 * time.Millisecond
 
@@ -111,6 +114,11 @@ func (c *ViewerAPIClient) GetPlayback(ctx context.Context, id string) (*ViewerPl
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+		msg := strings.TrimSpace(string(body))
+		if msg != "" {
+			return nil, fmt.Errorf("GET /api/playback/%s returned %d: %s", id, resp.StatusCode, msg)
+		}
 		return nil, fmt.Errorf("GET /api/playback/%s returned %d", id, resp.StatusCode)
 	}
 
@@ -141,6 +149,11 @@ func (c *ViewerAPIClient) Play(ctx context.Context, req ViewerPlayRequest) (*Vie
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+		msg := strings.TrimSpace(string(body))
+		if msg != "" {
+			return nil, fmt.Errorf("POST /api/play returned %d: %s", resp.StatusCode, msg)
+		}
 		return nil, fmt.Errorf("POST /api/play returned %d", resp.StatusCode)
 	}
 

--- a/internal/infra/viewer_client_test.go
+++ b/internal/infra/viewer_client_test.go
@@ -10,15 +10,18 @@ package infra_test
 // - POST /api/play 成功 → ViewerAPIClient.Play が PlayResponse を返す      → TestViewerAPIClient_Play_Success
 // - POST /api/play 無音モード応答 → ViewerAPIClient.Play が silent=true    → TestViewerAPIClient_Play_Silent
 // - POST /api/play で非 200 応答 → ViewerAPIClient.Play がエラーを返す     → TestViewerAPIClient_Play_Error
+// - POST /api/play で 400 + body → エラーメッセージに body を含む         → TestViewerAPIClient_Play_ErrorWithBody
 // #481 --viewer-url:
 // - NewViewerAPIClientFromURL でフル URL 指定 → POST /api/play が成功する  → TestViewerAPIClientFromURL_Play_Success
 // - NewViewerAPIClientFromURL でフル URL に trailing slash → POST が成功   → TestViewerAPIClientFromURL_Play_TrailingSlash
+// - GET /api/playback/{id} で非 200 + body → エラーメッセージに body を含む → TestViewerAPIClient_GetPlayback_ErrorWithBody
 
 import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-actor/internal/infra"
@@ -195,6 +198,24 @@ func TestViewerAPIClient_Play_Error(t *testing.T) {
 	}
 }
 
+func TestViewerAPIClient_Play_ErrorWithBody(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("clips[0].speaker_id: unknown speaker id 9999"))
+	}))
+	defer srv.Close()
+
+	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
+	_, err := client.Play(t.Context(), infra.ViewerPlayRequest{Clips: []infra.ViewerClip{{Text: "test", SpeakerID: 9999}}})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown speaker id 9999") {
+		t.Errorf("expected error to contain body, got: %v", err)
+	}
+}
+
 func TestViewerAPIClientFromURL_Play_Success(t *testing.T) {
 	t.Parallel()
 	var capturedReq infra.ViewerPlayRequest
@@ -291,5 +312,24 @@ func TestViewerAPIClient_GetPlayback_Error(t *testing.T) {
 	_, err := client.GetPlayback(t.Context(), "00000000-0000-4000-8000-000000000001")
 	if err == nil {
 		t.Fatal("expected error for non-200 response")
+	}
+}
+
+func TestViewerAPIClient_GetPlayback_ErrorWithBody(t *testing.T) {
+	t.Parallel()
+	id := "00000000-0000-4000-8000-000000000002"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("playback not found"))
+	}))
+	defer srv.Close()
+
+	client := infra.NewViewerAPIClient(srv.Listener.Addr().String())
+	_, err := client.GetPlayback(t.Context(), id)
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+	if !strings.Contains(err.Error(), "playback not found") {
+		t.Errorf("expected error to contain body, got: %v", err)
 	}
 }

--- a/test/e2e/say_comm_test.go
+++ b/test/e2e/say_comm_test.go
@@ -361,6 +361,36 @@ func TestSayE2E_Verbose_ShowsSpecificDebugLogs(t *testing.T) {
 	}
 }
 
+// TestSayE2E_Viewer_UnknownSpeaker_ShowsBodyError は viewer が 400 + body を返したとき、
+// CLI の標準エラーにそのボディ内容が表示されることを検証する。
+func TestSayE2E_Viewer_UnknownSpeaker_ShowsBodyError(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/api/play", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("clips[0].speaker_id: unknown speaker id 9999"))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	homeDir := t.TempDir()
+	writeViewerLockFile(t, homeDir, srv.Listener.Addr().String())
+
+	_, stderr, exitCode := runCLI(t, map[string]string{"HOME": homeDir},
+		"say", "--speaker", "9999", "テスト")
+
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit for unknown speaker, got 0\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "unknown speaker id 9999") {
+		t.Errorf("expected stderr to contain 'unknown speaker id 9999'\nstderr:\n%s", stderr)
+	}
+}
+
 // TestSayE2E_ViewerURL_ConnFailed_NoFallback は --viewer-url で到達不能な URL を指定した場合に
 // ローカル再生へのフォールバックなしでエラー終了することを検証する。
 func TestSayE2E_ViewerURL_ConnFailed_NoFallback(t *testing.T) {


### PR DESCRIPTION
## Summary

- `ViewerAPIClient.Play` / `GetPlayback` が非 200 応答時にレスポンス本文 (上限 1KB) を読み取り、エラーメッセージに付与するよう修正
- `vox-actor say --speaker 9999 "test"` を viewer 起動中に実行すると `unknown speaker id 9999` を含むエラーが CLI の標準エラー出力に表示される
- 単体テスト (`TestViewerAPIClient_Play_ErrorWithBody` / `TestViewerAPIClient_GetPlayback_ErrorWithBody`) と e2e テスト (`TestSayE2E_Viewer_UnknownSpeaker_ShowsBodyError`) を追加

## Test plan

- [ ] `go test ./internal/infra/` — 既存テストを含む全テスト PASS を確認
- [ ] e2e: `TestSayE2E_Viewer_UnknownSpeaker_ShowsBodyError` が PASS することを確認
- [ ] 手動確認: viewer 起動中に `vox-actor say --speaker 9999 "test"` を実行し、stderr に `unknown speaker id 9999` が表示されることを確認 (VOICEVOX 接続必要)

Closes #574

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
