### PR TITLE
feat(act): --save-wav フラグで全セリフを結合した単一WAVを出力する

### DIFF
--- a/cmd/act.go
+++ b/cmd/act.go
@@ -24,6 +24,8 @@ type ActDeps struct {
 	// AudioProbe はローカル再生前に音声デバイス可用性を検査する関数。
 	// nil の場合は検査をスキップする。--dry-run 時は呼ばれない。
 	AudioProbe func() error
+	WavSaver   app.WavSaver
+	WavMerger  app.WavMerger
 }
 
 func makeActCmd(deps *ActDeps) *cobra.Command {
@@ -52,6 +54,8 @@ func makeActCmd(deps *ActDeps) *cobra.Command {
 	}
 
 	registerCommonFlags(cmd)
+	registerSaveWavFlag(cmd)
+	registerGapMsFlag(cmd)
 	// --watch / --watch-delete は廃止済み。廃止フラグが渡された場合は PreRunE でエラーを返す。
 	cmd.Flags().Bool("watch", false, "")
 	cmd.Flags().Bool("watch-delete", false, "")
@@ -123,6 +127,8 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 	pitch, _ := cmd.Flags().GetFloat64("pitch")
 	intonation, _ := cmd.Flags().GetFloat64("intonation")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	saveWavPath, _ := cmd.Flags().GetString("save-wav")
+	gapMs, _ := cmd.Flags().GetInt("gap-ms")
 
 	speakerID, err := entity.NewSpeakerID(speakerIDInt)
 	if err != nil {
@@ -141,7 +147,8 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 		return fmt.Errorf("failed to create VoicevoxClient for %s", engineURL)
 	}
 
-	if !dryRun {
+	// --save-wav 指定時はローカル合成強制（viewer 経路をスキップ）
+	if !dryRun && saveWavPath == "" {
 		viewerURL, _ := cmd.Flags().GetString("viewer-url")
 
 		if viewerURL != "" {
@@ -175,14 +182,29 @@ func runAct(cmd *cobra.Command, args []string, deps *ActDeps) error {
 		return err
 	}
 
-	uc := app.NewActUsecase(deps.Reader, client, deps.Player, app.WithLogger(logger))
+	ucOpts := []app.ActOption{app.WithLogger(logger)}
+	if saveWavPath != "" {
+		wavSaver := deps.WavSaver
+		if wavSaver == nil {
+			wavSaver = infra.NewWavSaver()
+		}
+		wavMerger := deps.WavMerger
+		if wavMerger == nil {
+			wavMerger = infra.NewWavMerger()
+		}
+		ucOpts = append(ucOpts, app.WithActWavSaver(wavSaver), app.WithActWavMerger(wavMerger))
+	}
+
+	uc := app.NewActUsecase(deps.Reader, client, deps.Player, ucOpts...)
 	if err := uc.Run(ctx, app.ActParams{
-		Path:       args[0],
-		SpeakerID:  speakerID,
-		Speed:      &speed,
-		Pitch:      &pitch,
-		Intonation: &intonation,
-		DryRun:     dryRun,
+		Path:        args[0],
+		SpeakerID:   speakerID,
+		Speed:       &speed,
+		Pitch:       &pitch,
+		Intonation:  &intonation,
+		DryRun:      dryRun,
+		SaveWavPath: saveWavPath,
+		GapMs:       gapMs,
 	}); err != nil {
 		return err
 	}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -95,3 +95,8 @@ func saveWavDirDefaultFromEnv() string {
 func registerSaveWavDirFlag(cmd *cobra.Command) {
 	cmd.Flags().String("save-wav-dir", saveWavDirDefaultFromEnv(), "合成した WAV を保存するディレクトリ（ローカル合成時のみ。未作成なら自動作成）")
 }
+
+// registerGapMsFlag は --gap-ms フラグを登録する。act コマンドなど複数 WAV 結合時のセリフ間無音指定に使う。
+func registerGapMsFlag(cmd *cobra.Command) {
+	cmd.Flags().Int("gap-ms", 300, "セリフ間に挿入する無音のミリ秒数（--save-wav 指定時のみ有効）")
+}

--- a/docs/acceptance/cli/act.feature
+++ b/docs/acceptance/cli/act.feature
@@ -98,12 +98,36 @@ Feature: vox-actor act コマンド
     Then 終了コード 2 で完了する
     # test: test/e2e/act_test.go::TestActE2E_WatchDeleteFlag_ExitCode2
 
+  # ===== --save-wav / --gap-ms =====
+
+  Scenario: --save-wav を指定すると VOICEVOX 合成・結合した WAV が出力される
+    Given VOICEVOX スタブサーバーが起動している
+    And テンポラリディレクトリに2行の .jsonl ファイルを作成する
+    When "vox-actor act <path> --save-wav <out.wav>" を実行する
+    Then 終了コード 0 で完了する
+    And <out.wav> が正しい RIFF WAV ファイルとして存在する
+    # test: manual（VOICEVOX 接続が必要なためCI自動検証不可、PR test plan に手動確認要）
+
+  Scenario: --save-wav 指定時は音声を再生しない（--dry-run との組み合わせ不可、保存経路のみ）
+    Given VOICEVOX スタブサーバーが起動している
+    And テンポラリディレクトリに .jsonl ファイルを作成する
+    When "vox-actor act <path> --save-wav <out.wav>" を実行する
+    Then 音声デバイスへの再生が行われず WAV ファイルのみ出力される
+    # test: manual（VOICEVOX 接続が必要なためCI自動検証不可、PR test plan に手動確認要）
+
+  Scenario: --gap-ms 0 を指定すると無音なしで結合される
+    Given VOICEVOX スタブサーバーが起動している
+    And テンポラリディレクトリに2行の .jsonl ファイルを作成する
+    When "vox-actor act <path> --save-wav <out.wav> --gap-ms 0" を実行する
+    Then 終了コード 0 で完了する
+    # test: manual（VOICEVOX 接続が必要なためCI自動検証不可、PR test plan に手動確認要）
+
   # ===== ヘルプ =====
 
   Scenario: --help フラグで終了コード 0 かつ全フラグが表示される
     When "vox-actor act --help" を実行する
     Then 終了コード 0 で完了する
-    And stdout に "--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run" が含まれる
+    And stdout に "--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run", "--save-wav", "--gap-ms" が含まれる
     # test: test/e2e/act_test.go::TestActE2E_Help_ExitZeroWithAllFlags
 
   # ===== 空ファイル・特殊ケース =====

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -185,6 +185,26 @@ vox-actor act <path>
 | `--intonation` | — | `1.0` | 抑揚 |
 | `--verbose` | — | `false` | 詳細ログを出力 |
 | `--dry-run` | — | `false` | VOICEVOX・音声再生を行わず、読み上げ対象をログ出力（[詳細](#dry-runモード)） |
+| `--save-wav` | `VOX_SAVE_WAV` | (未指定) | 全セリフを合成・結合した WAV を保存するパス（ローカル合成時のみ。親ディレクトリは自動作成。指定時は音声を再生せず保存のみ行う） |
+| `--gap-ms` | — | `300` | `--save-wav` 指定時にセリフ間へ挿入する無音のミリ秒数（`0` で無音なし） |
+
+**使用例**
+
+```
+# JSONL 台本の全セリフを結合して1つの WAV に保存
+vox-actor act script.jsonl --save-wav out.wav
+
+# セリフ間の無音を500msにして保存
+vox-actor act script.jsonl --save-wav out.wav --gap-ms 500
+
+# 無音なしで結合
+vox-actor act script.jsonl --save-wav out.wav --gap-ms 0
+
+# ディレクトリ内の全台本を結合
+vox-actor act scripts/ --save-wav combined.wav
+```
+
+> **注意**: `--save-wav` はローカル合成時のみ有効です。指定時は viewer 経路（`--viewer-url` や lockfile auto-detect）をスキップしてローカル合成を強制します。
 
 > **注意**: `act --watch` および `act --watch-delete` は削除されました。ディレクトリ監視は [`watch` サブコマンド](#watch-サブコマンド)を使用してください。
 >

--- a/internal/app/act_usecase.go
+++ b/internal/app/act_usecase.go
@@ -18,6 +18,11 @@ type ActParams struct {
 	Intonation *float64
 	// DryRun が true の場合、VOICEVOXエンジン/音声再生を一切呼ばずログ出力のみ行う。
 	DryRun bool
+	// SaveWavPath が空でない場合、全セリフを結合した WAV をこのパスに保存する。
+	// DryRun 時・viewer 送信経路では保存しない。
+	SaveWavPath string
+	// GapMs はセリフ間に挿入する無音のミリ秒数。SaveWavPath が空でない場合のみ有効。
+	GapMs int
 }
 
 // ActOption はActUsecaseの生成時に指定するオプション。
@@ -40,10 +45,30 @@ func discardLogger() *slog.Logger {
 
 // ActUsecase はactサブコマンドのユースケース。
 type ActUsecase struct {
-	reader ScriptReader
-	client VoicevoxClient
-	player AudioPlayer
-	logger *slog.Logger
+	reader    ScriptReader
+	client    VoicevoxClient
+	player    AudioPlayer
+	logger    *slog.Logger
+	wavSaver  WavSaver
+	wavMerger WavMerger
+}
+
+// WithActWavSaver は WAV 保存先を設定するオプション。
+func WithActWavSaver(saver WavSaver) ActOption {
+	return func(u *ActUsecase) {
+		if saver != nil {
+			u.wavSaver = saver
+		}
+	}
+}
+
+// WithActWavMerger は WAV 結合器を設定するオプション。
+func WithActWavMerger(merger WavMerger) ActOption {
+	return func(u *ActUsecase) {
+		if merger != nil {
+			u.wavMerger = merger
+		}
+	}
 }
 
 // NewActUsecase は新しいActUsecaseを生成する。
@@ -102,15 +127,14 @@ func (u *ActUsecase) Run(ctx context.Context, params ActParams) error {
 	}
 	ch := startSynthPipeline(ctx, u.client, u.logger, scripts, cfg)
 
-	for result := range ch {
-		switch result.stage {
-		case synthStageQueryFailed:
-			return fmt.Errorf("create query for %s: %w", result.script.Path, result.err)
-		case synthStageSynthesizeFailed:
-			return fmt.Errorf("synthesize %s: %w", result.script.Path, result.err)
-		}
+	if params.SaveWavPath != "" && u.wavSaver != nil && u.wavMerger != nil {
+		return u.runSaveWav(ctx, ch, total, params)
+	}
 
-		u.logger.Info(fmt.Sprintf("[%d/%d] processing script", result.index, total), "path", result.script.Path)
+	for result := range ch {
+		if err := u.checkSynthResult(result, total); err != nil {
+			return err
+		}
 
 		speakerID := result.script.ResolveSpeakerID(params.SpeakerID)
 		if err := u.player.Play(ctx, result.wav, PlayMeta{Text: result.script.Text, SpeakerID: speakerID}); err != nil {
@@ -128,6 +152,47 @@ func (u *ActUsecase) Run(ctx context.Context, params ActParams) error {
 		}
 	}
 
+	u.logger.Info("all scripts processed")
+	return nil
+}
+
+// checkSynthResult は synthResult のエラーステージを検査して進捗ログを出力する。
+// エラーステージの場合はラップしたエラーを返す。
+func (u *ActUsecase) checkSynthResult(result synthResult, total int) error {
+	switch result.stage {
+	case synthStageQueryFailed:
+		return fmt.Errorf("create query for %s: %w", result.script.Path, result.err)
+	case synthStageSynthesizeFailed:
+		return fmt.Errorf("synthesize %s: %w", result.script.Path, result.err)
+	}
+	u.logger.Info(fmt.Sprintf("[%d/%d] processing script", result.index, total), "path", result.script.Path)
+	return nil
+}
+
+// runSaveWav は --save-wav 指定時の WAV 結合・保存処理。再生は行わない。
+func (u *ActUsecase) runSaveWav(ctx context.Context, ch <-chan synthResult, total int, params ActParams) error {
+	var wavClips [][]byte
+	for result := range ch {
+		if err := u.checkSynthResult(result, total); err != nil {
+			return err
+		}
+
+		wavClips = append(wavClips, result.wav)
+
+		if ctx.Err() != nil {
+			return nil
+		}
+	}
+
+	merged, err := u.wavMerger.Merge(wavClips, params.GapMs)
+	if err != nil {
+		return fmt.Errorf("merge wav: %w", err)
+	}
+
+	if err := u.wavSaver.Save(params.SaveWavPath, merged); err != nil {
+		return fmt.Errorf("save wav: %w", err)
+	}
+	u.logger.Info("wav saved", "path", params.SaveWavPath)
 	u.logger.Info("all scripts processed")
 	return nil
 }

--- a/internal/app/act_usecase_test.go
+++ b/internal/app/act_usecase_test.go
@@ -1062,3 +1062,139 @@ func TestActUsecase_Run_MultipleScriptsWithDifferentParams(t *testing.T) {
 		t.Errorf("expected third SpeedScale 1.5, got %f", client.synthesizeArgs[2].query.SpeedScale)
 	}
 }
+
+// act --save-wav テストリスト
+// DONE: 正常系: SaveWavPath 指定時に WavMerger.Merge が呼ばれ WavSaver.Save で保存される
+// DONE: 正常系: SaveWavPath 指定時は音声を再生しない
+// DONE: 正常系: SaveWavPath が空の場合は通常の再生挙動（WavSaver.Save 未呼び出し）
+
+type mockWavMerger struct {
+	result      []byte
+	err         error
+	mergeCalls  int
+	mergedClips [][]byte
+	mergedGapMs int
+}
+
+func (m *mockWavMerger) Merge(wavClips [][]byte, gapMs int) ([]byte, error) {
+	m.mergeCalls++
+	m.mergedClips = wavClips
+	m.mergedGapMs = gapMs
+	return m.result, m.err
+}
+
+func TestActUsecase_Run_SaveWav_MergesAndSavesWithoutPlay(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "セリフ1", IsEmpty: false},
+			{Path: "b.txt", Text: "セリフ2", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	merger := &mockWavMerger{result: []byte("merged-wav")}
+	saver := &mockWavSaver{}
+
+	uc := app.NewActUsecase(reader, client, player,
+		app.WithActWavMerger(merger),
+		app.WithActWavSaver(saver),
+	)
+	params := app.ActParams{
+		Path:        "scripts/",
+		SpeakerID:   entity.MustNewSpeakerID(3),
+		SaveWavPath: "out.wav",
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if player.playCalls != 0 {
+		t.Errorf("expected no Play calls when SaveWavPath is set, got %d", player.playCalls)
+	}
+	if merger.mergeCalls != 1 {
+		t.Errorf("expected 1 Merge call, got %d", merger.mergeCalls)
+	}
+	if len(merger.mergedClips) != 2 {
+		t.Errorf("expected 2 clips merged, got %d", len(merger.mergedClips))
+	}
+	if saver.saveCalls != 1 {
+		t.Errorf("expected 1 Save call, got %d", saver.saveCalls)
+	}
+	if saver.savedPath != "out.wav" {
+		t.Errorf("expected saved path 'out.wav', got %q", saver.savedPath)
+	}
+}
+
+func TestActUsecase_Run_SaveWav_GapMsPassed(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "セリフ", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	merger := &mockWavMerger{result: []byte("merged-wav")}
+	saver := &mockWavSaver{}
+
+	uc := app.NewActUsecase(reader, client, player,
+		app.WithActWavMerger(merger),
+		app.WithActWavSaver(saver),
+	)
+	params := app.ActParams{
+		Path:        "scripts/",
+		SpeakerID:   entity.MustNewSpeakerID(3),
+		SaveWavPath: "out.wav",
+		GapMs:       300,
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if merger.mergedGapMs != 300 {
+		t.Errorf("expected gapMs=300 passed to Merge, got %d", merger.mergedGapMs)
+	}
+}
+
+func TestActUsecase_Run_SaveWav_NotSet_PlaybackUnchanged(t *testing.T) {
+	reader := &mockScriptReader{
+		scripts: []entity.Script{
+			{Path: "a.txt", Text: "セリフ", IsEmpty: false},
+		},
+	}
+	client := &mockVoicevoxClient{
+		query:   &entity.AudioQuery{},
+		wavData: []byte("fake-wav"),
+	}
+	player := &mockAudioPlayer{}
+	merger := &mockWavMerger{}
+	saver := &mockWavSaver{}
+
+	uc := app.NewActUsecase(reader, client, player,
+		app.WithActWavMerger(merger),
+		app.WithActWavSaver(saver),
+	)
+	params := app.ActParams{
+		Path:      "scripts/",
+		SpeakerID: entity.MustNewSpeakerID(3),
+		// SaveWavPath 未指定 → 通常再生
+	}
+
+	if err := uc.Run(context.Background(), params); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if player.playCalls != 1 {
+		t.Errorf("expected 1 Play call when SaveWavPath is empty, got %d", player.playCalls)
+	}
+	if saver.saveCalls != 0 {
+		t.Errorf("expected no Save calls when SaveWavPath is empty, got %d", saver.saveCalls)
+	}
+}

--- a/internal/app/port.go
+++ b/internal/app/port.go
@@ -60,6 +60,16 @@ type WavSaver interface {
 	Save(path string, wavData []byte) error
 }
 
+// WavMerger は複数の WAV バイト列を1つに結合するインターフェース。
+type WavMerger interface {
+	// Merge は複数の WAV バイト列を結合して1つの WAV を返す。
+	// gapMs > 0 の場合はクリップ間に無音 PCM を挿入する。
+	// 空クリップ（PCM データなし）はスキップする。
+	// フォーマットが異なるクリップが含まれる場合はエラーを返す。
+	// 有効なクリップが0件の場合はエラーを返す。
+	Merge(wavClips [][]byte, gapMs int) ([]byte, error)
+}
+
 // VoicevoxClient はVOICEVOXエンジンとの通信を抽象化するインターフェース。
 type VoicevoxClient interface {
 	// HealthCheck はエンジンの疎通確認を行う。

--- a/internal/infra/wav_merger.go
+++ b/internal/infra/wav_merger.go
@@ -1,0 +1,193 @@
+package infra
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/canpok1/vox-actor/internal/app"
+)
+
+// wavFormat は WAV の fmt チャンクから読み取ったフォーマット情報。
+type wavFormat struct {
+	audioFormat   uint16
+	numChannels   uint16
+	sampleRate    uint32
+	byteRate      uint32
+	blockAlign    uint16
+	bitsPerSample uint16
+}
+
+// WavMerger は複数の WAV バイト列を1つに結合する。
+// app.WavMerger インターフェースを実装する。
+type WavMerger struct{}
+
+var _ app.WavMerger = (*WavMerger)(nil)
+
+// NewWavMerger は WavMerger を生成する。
+func NewWavMerger() *WavMerger {
+	return &WavMerger{}
+}
+
+// Merge は複数の WAV バイト列を結合して1つの WAV を返す。
+// gapMs > 0 の場合はクリップ間に無音 PCM を挿入する。
+// 空クリップ（PCM データなし）はスキップする。
+// フォーマットが異なるクリップが含まれる場合はエラーを返す。
+// 有効なクリップが0件の場合はエラーを返す。
+func (m *WavMerger) Merge(wavClips [][]byte, gapMs int) ([]byte, error) {
+	type parsedClip struct {
+		format  wavFormat
+		pcmData []byte
+	}
+
+	var clips []parsedClip
+	for i, wav := range wavClips {
+		format, pcmData, err := parseWavChunks(wav)
+		if err != nil {
+			return nil, fmt.Errorf("clip[%d]: %w", i, err)
+		}
+		if len(pcmData) == 0 {
+			continue
+		}
+		clips = append(clips, parsedClip{format: format, pcmData: pcmData})
+	}
+
+	if len(clips) == 0 {
+		return nil, fmt.Errorf("no valid (non-empty) WAV clips to merge")
+	}
+
+	base := clips[0].format
+	for i, c := range clips[1:] {
+		if err := assertSameFormat(base, c.format, i+1); err != nil {
+			return nil, err
+		}
+	}
+
+	var gapPCM []byte
+	if gapMs > 0 {
+		gapBytes := int(base.byteRate) * gapMs / 1000
+		gapPCM = make([]byte, gapBytes)
+	}
+
+	totalSize := 0
+	for _, c := range clips {
+		totalSize += len(c.pcmData)
+	}
+	if len(clips) > 1 {
+		totalSize += len(gapPCM) * (len(clips) - 1)
+	}
+
+	pcmBuf := make([]byte, 0, totalSize)
+	for i, c := range clips {
+		if i > 0 {
+			pcmBuf = append(pcmBuf, gapPCM...)
+		}
+		pcmBuf = append(pcmBuf, c.pcmData...)
+	}
+
+	return assembleWAV(base, pcmBuf), nil
+}
+
+// parseWavChunks は WAV バイト列を解析して fmt フォーマットと data PCM を返す。
+func parseWavChunks(wav []byte) (wavFormat, []byte, error) {
+	const riffHeaderSize = 12
+	if len(wav) < riffHeaderSize {
+		return wavFormat{}, nil, fmt.Errorf("WAV data too short: %d bytes", len(wav))
+	}
+	if string(wav[0:4]) != "RIFF" {
+		return wavFormat{}, nil, fmt.Errorf("not a RIFF file")
+	}
+	if string(wav[8:12]) != "WAVE" {
+		return wavFormat{}, nil, fmt.Errorf("not a WAVE file")
+	}
+
+	var fmt_ wavFormat
+	var pcmData []byte
+	var foundFmt, foundData bool
+
+	offset := riffHeaderSize
+	for offset+8 <= len(wav) {
+		chunkID := string(wav[offset : offset+4])
+		chunkSize := binary.LittleEndian.Uint32(wav[offset+4 : offset+8])
+		bodyStart := offset + 8
+		bodyEnd := min(bodyStart+int(chunkSize), len(wav))
+
+		switch chunkID {
+		case "fmt ":
+			if bodyEnd-bodyStart < 16 {
+				return wavFormat{}, nil, fmt.Errorf("fmt chunk too small")
+			}
+			fmt_.audioFormat = binary.LittleEndian.Uint16(wav[bodyStart : bodyStart+2])
+			fmt_.numChannels = binary.LittleEndian.Uint16(wav[bodyStart+2 : bodyStart+4])
+			fmt_.sampleRate = binary.LittleEndian.Uint32(wav[bodyStart+4 : bodyStart+8])
+			fmt_.byteRate = binary.LittleEndian.Uint32(wav[bodyStart+8 : bodyStart+12])
+			fmt_.blockAlign = binary.LittleEndian.Uint16(wav[bodyStart+12 : bodyStart+14])
+			fmt_.bitsPerSample = binary.LittleEndian.Uint16(wav[bodyStart+14 : bodyStart+16])
+			foundFmt = true
+		case "data":
+			pcmData = wav[bodyStart:bodyEnd]
+			foundData = true
+		}
+
+		if foundFmt && foundData {
+			break
+		}
+		next := bodyStart + int(chunkSize)
+		if chunkSize%2 == 1 {
+			next++
+		}
+		offset = next
+	}
+
+	if !foundFmt {
+		return wavFormat{}, nil, fmt.Errorf("fmt chunk not found")
+	}
+	if !foundData {
+		return wavFormat{}, nil, fmt.Errorf("data chunk not found")
+	}
+	return fmt_, pcmData, nil
+}
+
+// assertSameFormat は2つのフォーマットが同一であることを確認する。
+func assertSameFormat(base, other wavFormat, index int) error {
+	if base.numChannels != other.numChannels {
+		return fmt.Errorf("clip[%d] numChannels mismatch: want %d, got %d", index, base.numChannels, other.numChannels)
+	}
+	if base.sampleRate != other.sampleRate {
+		return fmt.Errorf("clip[%d] sampleRate mismatch: want %d, got %d", index, base.sampleRate, other.sampleRate)
+	}
+	if base.bitsPerSample != other.bitsPerSample {
+		return fmt.Errorf("clip[%d] bitsPerSample mismatch: want %d, got %d", index, base.bitsPerSample, other.bitsPerSample)
+	}
+	if base.audioFormat != other.audioFormat {
+		return fmt.Errorf("clip[%d] audioFormat mismatch: want %d, got %d", index, base.audioFormat, other.audioFormat)
+	}
+	return nil
+}
+
+// assembleWAV は fmt フォーマットと PCM データから WAV バイト列を構築する。
+func assembleWAV(fmt_ wavFormat, pcmData []byte) []byte {
+	const fmtChunkSize = 16
+	dataSize := uint32(len(pcmData))
+	riffSize := 4 + 8 + fmtChunkSize + 8 + dataSize
+
+	buf := make([]byte, 12+8+fmtChunkSize+8+dataSize)
+
+	copy(buf[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(buf[4:8], riffSize)
+	copy(buf[8:12], "WAVE")
+
+	copy(buf[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:20], fmtChunkSize)
+	binary.LittleEndian.PutUint16(buf[20:22], fmt_.audioFormat)
+	binary.LittleEndian.PutUint16(buf[22:24], fmt_.numChannels)
+	binary.LittleEndian.PutUint32(buf[24:28], fmt_.sampleRate)
+	binary.LittleEndian.PutUint32(buf[28:32], fmt_.byteRate)
+	binary.LittleEndian.PutUint16(buf[32:34], fmt_.blockAlign)
+	binary.LittleEndian.PutUint16(buf[34:36], fmt_.bitsPerSample)
+
+	copy(buf[36:40], "data")
+	binary.LittleEndian.PutUint32(buf[40:44], dataSize)
+	copy(buf[44:], pcmData)
+
+	return buf
+}

--- a/internal/infra/wav_merger_test.go
+++ b/internal/infra/wav_merger_test.go
@@ -1,0 +1,192 @@
+package infra_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/canpok1/vox-actor/internal/infra"
+)
+
+// WavMerger テストリスト
+// DONE: 正常系: 複数クリップを結合して1つのWAVを出力できる
+// DONE: 正常系: gap=0 指定時は無音なしで連結される
+// DONE: 正常系: gap>0 指定時はクリップ間に無音PCMが挿入される
+// DONE: 正常系: 空クリップ（PCMデータなし）はスキップされる
+// DONE: 正常系: クリップが1件だけの場合は結合できる
+// DONE: 異常系: フォーマット不一致のクリップが含まれる場合はエラーを返す
+// DONE: 異常系: 有効なクリップが0件の場合はエラーを返す
+
+// makeTestWAV は指定フォーマットで指定バイト数のPCMデータを持つWAVバイト列を生成する。
+func makeTestWAV(numChannels uint16, sampleRate uint32, bitsPerSample uint16, pcmData []byte) []byte {
+	byteRate := sampleRate * uint32(numChannels) * uint32(bitsPerSample) / 8
+	blockAlign := numChannels * bitsPerSample / 8
+
+	fmtSize := uint32(16)
+	dataSize := uint32(len(pcmData))
+	riffSize := 4 + 8 + fmtSize + 8 + dataSize
+
+	wav := make([]byte, 12+8+fmtSize+8+dataSize)
+	copy(wav[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(wav[4:8], riffSize)
+	copy(wav[8:12], "WAVE")
+
+	// fmt chunk
+	copy(wav[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(wav[16:20], fmtSize)
+	binary.LittleEndian.PutUint16(wav[20:22], 1) // PCM
+	binary.LittleEndian.PutUint16(wav[22:24], numChannels)
+	binary.LittleEndian.PutUint32(wav[24:28], sampleRate)
+	binary.LittleEndian.PutUint32(wav[28:32], byteRate)
+	binary.LittleEndian.PutUint16(wav[32:34], blockAlign)
+	binary.LittleEndian.PutUint16(wav[34:36], bitsPerSample)
+
+	// data chunk
+	copy(wav[36:40], "data")
+	binary.LittleEndian.PutUint32(wav[40:44], dataSize)
+	copy(wav[44:], pcmData)
+
+	return wav
+}
+
+// extractPCMData は WAV バイト列から data チャンクの PCM データを取り出す。
+func extractPCMData(t *testing.T, wav []byte) []byte {
+	t.Helper()
+	if len(wav) < 44 {
+		t.Fatalf("wav too short: %d bytes", len(wav))
+	}
+	dataSize := binary.LittleEndian.Uint32(wav[40:44])
+	if int(44+dataSize) > len(wav) {
+		t.Fatalf("data chunk claims %d bytes but wav is only %d bytes", dataSize, len(wav))
+	}
+	return wav[44 : 44+dataSize]
+}
+
+func TestWavMerger_Merge_MultipleClips(t *testing.T) {
+	pcm1 := []byte{0x01, 0x02, 0x03, 0x04}
+	pcm2 := []byte{0x05, 0x06, 0x07, 0x08}
+	clip1 := makeTestWAV(1, 24000, 16, pcm1)
+	clip2 := makeTestWAV(1, 24000, 16, pcm2)
+
+	merger := infra.NewWavMerger()
+	result, err := merger.Merge([][]byte{clip1, clip2}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := extractPCMData(t, result)
+	expected := append(pcm1, pcm2...)
+	if string(got) != string(expected) {
+		t.Errorf("expected PCM %v, got %v", expected, got)
+	}
+}
+
+func TestWavMerger_Merge_GapZero_NoSilenceInserted(t *testing.T) {
+	pcm1 := []byte{0x01, 0x02}
+	pcm2 := []byte{0x03, 0x04}
+	clip1 := makeTestWAV(1, 24000, 16, pcm1)
+	clip2 := makeTestWAV(1, 24000, 16, pcm2)
+
+	merger := infra.NewWavMerger()
+	result, err := merger.Merge([][]byte{clip1, clip2}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := extractPCMData(t, result)
+	// gap=0: pcm1 + pcm2 のみ（無音なし）
+	if len(got) != len(pcm1)+len(pcm2) {
+		t.Errorf("expected PCM length %d, got %d", len(pcm1)+len(pcm2), len(got))
+	}
+}
+
+func TestWavMerger_Merge_GapPositive_SilenceInserted(t *testing.T) {
+	// 24000 Hz, 16bit, 1ch → 1ms = 24000/1000 * 2 = 48 bytes
+	pcm1 := make([]byte, 48)
+	pcm2 := make([]byte, 48)
+	for i := range pcm1 {
+		pcm1[i] = 0x01
+		pcm2[i] = 0x02
+	}
+	clip1 := makeTestWAV(1, 24000, 16, pcm1)
+	clip2 := makeTestWAV(1, 24000, 16, pcm2)
+
+	gapMs := 10
+	merger := infra.NewWavMerger()
+	result, err := merger.Merge([][]byte{clip1, clip2}, gapMs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := extractPCMData(t, result)
+	// gap PCM bytes = 24000 * 1 * 2 / 1000 * 10 = 480 bytes
+	gapBytes := 24000 * 1 * 2 / 1000 * gapMs
+	expectedLen := len(pcm1) + gapBytes + len(pcm2)
+	if len(got) != expectedLen {
+		t.Errorf("expected PCM length %d (gap=%d bytes), got %d", expectedLen, gapBytes, len(got))
+	}
+
+	// gap 部分はゼロバイトであることを確認
+	gapStart := len(pcm1)
+	for i := gapStart; i < gapStart+gapBytes; i++ {
+		if got[i] != 0x00 {
+			t.Errorf("expected silence (0x00) at byte %d, got 0x%02x", i, got[i])
+			break
+		}
+	}
+}
+
+func TestWavMerger_Merge_EmptyClipsSkipped(t *testing.T) {
+	pcm1 := []byte{0x01, 0x02, 0x03, 0x04}
+	emptyPCM := []byte{}
+	pcm2 := []byte{0x05, 0x06, 0x07, 0x08}
+	clip1 := makeTestWAV(1, 24000, 16, pcm1)
+	emptyClip := makeTestWAV(1, 24000, 16, emptyPCM)
+	clip2 := makeTestWAV(1, 24000, 16, pcm2)
+
+	merger := infra.NewWavMerger()
+	result, err := merger.Merge([][]byte{clip1, emptyClip, clip2}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := extractPCMData(t, result)
+	expected := append(pcm1, pcm2...)
+	if string(got) != string(expected) {
+		t.Errorf("expected PCM %v (empty clip skipped), got %v", expected, got)
+	}
+}
+
+func TestWavMerger_Merge_SingleClip(t *testing.T) {
+	pcm := []byte{0x01, 0x02, 0x03, 0x04}
+	clip := makeTestWAV(2, 44100, 16, pcm)
+
+	merger := infra.NewWavMerger()
+	result, err := merger.Merge([][]byte{clip}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := extractPCMData(t, result)
+	if string(got) != string(pcm) {
+		t.Errorf("expected PCM %v, got %v", pcm, got)
+	}
+}
+
+func TestWavMerger_Merge_FormatMismatch_ReturnsError(t *testing.T) {
+	clip1 := makeTestWAV(1, 24000, 16, []byte{0x01, 0x02})
+	clip2 := makeTestWAV(2, 44100, 16, []byte{0x03, 0x04}) // 異なるチャンネル数・サンプルレート
+
+	merger := infra.NewWavMerger()
+	_, err := merger.Merge([][]byte{clip1, clip2}, 0)
+	if err == nil {
+		t.Fatal("expected error for format mismatch, got nil")
+	}
+}
+
+func TestWavMerger_Merge_NoValidClips_ReturnsError(t *testing.T) {
+	merger := infra.NewWavMerger()
+	_, err := merger.Merge([][]byte{}, 0)
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}

--- a/test/e2e/act_test.go
+++ b/test/e2e/act_test.go
@@ -231,7 +231,7 @@ func TestActE2E_Help_ExitZeroWithAllFlags(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("expected exit 0 for act --help, got %d", exitCode)
 	}
-	for _, flag := range []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run"} {
+	for _, flag := range []string{"--engine-url", "--speaker", "--speed", "--pitch", "--intonation", "--verbose", "--dry-run", "--save-wav", "--gap-ms"} {
 		if !strings.Contains(stdout, flag) {
 			t.Errorf("expected act --help to contain %q\nstdout:\n%s", flag, stdout)
 		}


### PR DESCRIPTION
## Summary

- `act` コマンドに `--save-wav <path>` / `--gap-ms <ms>` フラグを追加
- `--save-wav` 指定時は全セリフを合成し WAV を結合して1ファイルに保存する（再生はしない）
- `--save-wav` 指定時は viewer 検出をスキップしてローカル合成を強制する
- `--gap-ms`（デフォルト 300ms）でセリフ間の無音長を制御できる
- `internal/infra/WavMerger` に WAV 結合ロジックを実装（TDD）
- `docs/reference/cli.md` に新フラグの説明と使用例を追記
- `act.feature` / `act_test.go` に新フラグのシナリオを追加

## Test plan

- [x] `go test ./internal/infra/...` — WavMerger 単体テスト（複数クリップ結合・gap挿入・空クリップスキップ・フォーマット不一致検出）
- [x] `go test ./internal/app/...` — ActUsecase SaveWav 経路テスト（マージ呼び出し確認・再生なし確認・gapMs 伝搬確認）
- [x] `go test ./test/e2e/...` — ヘルプ出力に `--save-wav` / `--gap-ms` が含まれること
- [ ] (手動・VOICEVOX必要) `vox-actor act script.jsonl --save-wav out.wav` で WAV が正常に出力されること
- [ ] (手動・VOICEVOX必要) `--gap-ms 0` で無音なし連結、`--gap-ms 500` で 500ms 無音挿入されること
- [ ] (手動・VOICEVOX必要) `--save-wav` 未指定時に従来の逐次再生が変わらないこと

Closes #576

---

🤖 Generated with [Claude Code](https://claude.ai/code)
